### PR TITLE
Add authorized phone numbers to the frontend for testing purposes

### DIFF
--- a/services/agora/env.example
+++ b/services/agora/env.example
@@ -1,3 +1,3 @@
 VITE_API_BASE_URL="https://xxx.com:8701" // backend API endpoint
 VITE_BACK_DID="did:web:xxx.com%3A8701" // update with custom URL and port
-VITE_USE_DUMMY_ACCESS="true" // can be true or false, used to skip the authentication pages
+VITE_DEV_AUTHORIZED_PHONES="+33612345678,+12223333333" // comma list of authorized phone numbers for testing

--- a/services/agora/quasar.config.ts
+++ b/services/agora/quasar.config.ts
@@ -76,9 +76,9 @@ export default defineConfig((ctx) => {
       // https://github.com/quasarframework/quasar/discussions/15303#discussioncomment-5904464
       // https://vite.dev/config/
       env: {
-        VITE_USE_DUMMY_ACCESS: process.env.VITE_USE_DUMMY_ACCESS,
         VITE_API_BASE_URL: process.env.VITE_API_BASE_URL,
         VITE_BACK_DID: process.env.VITE_BACK_DID,
+        VITE_DEV_AUTHORIZED_PHONES: process.env.VITE_DEV_AUTHORIZED_PHONES
       },
       // rawDefine: {}
       // ignorePublicFolder: true,

--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -388,10 +388,10 @@ export interface ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadata {
     'commentCount': number;
     /**
      * 
-     * @type {ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName}
+     * @type {ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername}
      * @memberof ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadata
      */
-    'authorUserName': ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName;
+    'authorUsername': ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername;
     /**
      * 
      * @type {string}
@@ -402,9 +402,9 @@ export interface ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadata {
 /**
  * 
  * @export
- * @interface ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName
+ * @interface ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername
  */
-export interface ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName {
+export interface ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername {
 }
 /**
  * 
@@ -489,10 +489,10 @@ export interface ApiV1FeedFetchRecentPostRequest {
 export interface ApiV1OnboardingIsUsernameInUsePostRequest {
     /**
      * 
-     * @type {ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName}
+     * @type {ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername}
      * @memberof ApiV1OnboardingIsUsernameInUsePostRequest
      */
-    'userName': ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName;
+    'username': ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername;
 }
 /**
  * 
@@ -714,10 +714,10 @@ export interface ApiV1UserFetchUserCommentsPost200ResponseInnerCommentItem {
     'numDislikes': number;
     /**
      * 
-     * @type {ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName}
+     * @type {ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername}
      * @memberof ApiV1UserFetchUserCommentsPost200ResponseInnerCommentItem
      */
-    'userName': ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName;
+    'username': ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername;
 }
 /**
  * 
@@ -765,10 +765,10 @@ export interface ApiV1UserFetchUserProfilePost200Response {
     'createdAt': string;
     /**
      * 
-     * @type {ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName}
+     * @type {ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername}
      * @memberof ApiV1UserFetchUserProfilePost200Response
      */
-    'userName': ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUserName;
+    'username': ApiV1FeedFetchRecentPost200ResponsePostDataListInnerMetadataAuthorUsername;
 }
 /**
  * 

--- a/services/agora/src/components/post/PostDetails.vue
+++ b/services/agora/src/components/post/PostDetails.vue
@@ -4,7 +4,7 @@
     <ZKHoverEffect :enable-hover="compactMode">
       <div class="container postPadding">
         <div class="innerContainer">
-          <PostMetadata :poster-user-name="extendedPostData.metadata.authorUserName"
+          <PostMetadata :poster-user-name="extendedPostData.metadata.authorUsername"
             :created-at="new Date(extendedPostData.metadata.createdAt)" :is-compat-size="true"
             :skeleton-mode="skeletonMode" :show-author="showAuthor" :display-absolute-time="displayAbsoluteTime"
             :post-slug-id="extendedPostData.metadata.postSlugId" />

--- a/services/agora/src/components/post/views/CommentActionBar.vue
+++ b/services/agora/src/components/post/views/CommentActionBar.vue
@@ -121,7 +121,7 @@ function optionButtonClicked() {
 
   bottomSheet.showCommentOptionSelector(
     props.commentItem.commentSlugId,
-    props.commentItem.userName,
+    props.commentItem.username,
     deleteCommentCallback);
 }
 

--- a/services/agora/src/components/post/views/CommentSingle.vue
+++ b/services/agora/src/components/post/views/CommentSingle.vue
@@ -6,11 +6,11 @@
     </div>
     <div v-if="!deleted" class="contentLayout">
       <div class="metadata">
-        <UserAvatar :user-name="commentItem.userName" :size="40" class="avatarIcon" />
+        <UserAvatar :user-name="commentItem.username" :size="40" class="avatarIcon" />
 
         <div class="userNameTime">
           <div>
-            {{ commentItem.userName }}
+            {{ commentItem.username }}
           </div>
 
           <div>

--- a/services/agora/src/components/profile/UserCommentList.vue
+++ b/services/agora/src/components/profile/UserCommentList.vue
@@ -14,7 +14,7 @@
             </div>
 
             <div class="commentMetadata">
-              <span :style="{ fontWeight: 'bold' }">{{ commentItem.commentItem.userName }}</span> commented
+              <span :style="{ fontWeight: 'bold' }">{{ commentItem.commentItem.username }}</span> commented
               {{ useTimeAgo(commentItem.commentItem.createdAt) }}
             </div>
 

--- a/services/agora/src/pages/onboarding/step3-passport/index.vue
+++ b/services/agora/src/pages/onboarding/step3-passport/index.vue
@@ -52,7 +52,7 @@
 
                 <div v-if="verificationLink.length != 0" class="verificationProcedureBlock">
                   <img :src="qrcode" alt="QR Code" />
-                  <div>or copy the below link on your mobile:</div>
+                  <div>Or copy the below link on your mobile:</div>
                   <!-- make this copyable -->
                   <div class="longUrl">{{ verificationLink }}</div>
 
@@ -60,8 +60,13 @@
                 </div>
               </div>
 
-              <ZKButton v-if="quasar.platform.is.mobile" label="Verify" color="primary"
-                @click="clickedVerifyButton()" />
+              <div v-if="quasar.platform.is.mobile" class="verificationProcedureBlock">
+                <ZKButton label="Verify" color="primary" @click="clickedVerifyButton()" />
+                <div class="waitingVerificationText">
+                  Waiting for verification...
+                </div>
+              </div>
+
             </div>
           </div>
         </ZKCard>
@@ -251,11 +256,16 @@ function goToPhoneVerification() {
 
 .longUrl {
   word-break: break-all;
+  font-size: 0.8rem;
 }
 
 .verificationProcedureBlock {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.8rem;
+}
+
+.waitingVerificationText {
+  font-size: 0.9rem;
 }
 </style>

--- a/services/agora/src/pages/onboarding/step3-passport/index.vue
+++ b/services/agora/src/pages/onboarding/step3-passport/index.vue
@@ -1,18 +1,9 @@
 <template>
   <div>
-    <StepperLayout
-      :submit-call-back="() => {}"
-      :current-step="3"
-      :total-steps="6"
-      :enable-next-button="true"
-      :show-next-button="false"
-    >
+    <StepperLayout :submit-call-back="() => { }" :current-step="3" :total-steps="6" :enable-next-button="true"
+      :show-next-button="false">
       <template #header>
-        <InfoHeader
-          title="Own Your Privacy"
-          :description="description"
-          icon-name="mdi-wallet"
-        />
+        <InfoHeader title="Own Your Privacy" :description="description" icon-name="mdi-wallet" />
       </template>
 
       <template #body>
@@ -22,12 +13,7 @@
               <q-icon name="mdi-numeric-1" size="2rem" class="numberCircle" />
               Download
               <div v-if="quasar.platform.is.mobile">
-                <a
-                  :href="rarimeStoreLink"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >RariMe</a
-                >
+                <a :href="rarimeStoreLink" target="_blank" rel="noopener noreferrer">RariMe</a>
               </div>
               <div v-else>RariMe on your phone by scanning the QR code</div>
             </div>
@@ -48,38 +34,21 @@
 
             <div class="innerInstructions">
               <div v-if="!quasar.platform.is.mobile">
-                <img
-                  v-if="qrcode !== undefined"
-                  :src="qrcode"
-                  alt="QR Code"
-                  class="qrCode"
-                />
-                <q-spinner
-                  v-if="qrcode === undefined"
-                  color="primary"
-                  size="3em"
-                  class="qrCode"
-                />
+                <img v-if="qrcode !== undefined" :src="qrcode" alt="QR Code" class="qrCode" />
+                <q-spinner v-if="qrcode === undefined" color="primary" size="3em" class="qrCode" />
                 <div>or copy the below link on your mobile:</div>
                 <!-- make this copyable -->
                 <div>{{ verificationLink }}</div>
               </div>
 
-              <ZKButton
-                v-if="quasar.platform.is.mobile"
-                label="Verify"
-                color="primary"
-                @click="clickedVerifyButton()"
-              />
+              <ZKButton v-if="quasar.platform.is.mobile" label="Verify" color="primary"
+                @click="clickedVerifyButton()" />
             </div>
           </div>
         </ZKCard>
 
-        <ZKButton
-          label="I'd rather verify with my phone number"
-          text-color="color-text-strong"
-          @click="goToPhoneVerification()"
-        />
+        <ZKButton label="I'd rather verify with my phone number" text-color="color-text-strong"
+          @click="goToPhoneVerification()" />
       </template>
     </StepperLayout>
   </div>

--- a/services/agora/src/pages/onboarding/step3-phone-2/index.vue
+++ b/services/agora/src/pages/onboarding/step3-phone-2/index.vue
@@ -12,7 +12,7 @@
 
           <div class="instructions">
             Please enter the 6-digit code that was sent to
-            <span class="phoneNumberStyle">{{ verificationPhoneNumber }}</span>.
+            <span class="phoneNumberStyle">{{ verificationPhoneNumber.phoneNumber }}</span>.
           </div>
 
           <div class="otpDiv">
@@ -92,8 +92,8 @@ async function nextButtonClicked() {
 async function requestCodeClicked(isRequestingNewCode: boolean) {
   const response = await requestCode({
     isRequestingNewCode: isRequestingNewCode,
-    phoneNumber: verificationPhoneNumber.value,
-    defaultCallingCode: "+33"
+    phoneNumber: verificationPhoneNumber.value.phoneNumber,
+    defaultCallingCode: verificationPhoneNumber.value.defaultCallingCode
   });
 
   if (response.isSuccessful) {

--- a/services/agora/src/pages/settings/index.vue
+++ b/services/agora/src/pages/settings/index.vue
@@ -50,7 +50,7 @@ const accountSettings: SettingsInterface[] = [
     icon: "mdi-logout",
     label: "Log out",
     action: logoutRequested,
-    routeName: "welcome",
+    routeName: "",
     isWarning: false
   },
 ];

--- a/services/agora/src/shared/shared.ts
+++ b/services/agora/src/shared/shared.ts
@@ -70,7 +70,7 @@ export const MIN_LENGTH_USERNAME = 3;
 
 export const PEPPER_VERSION = 0;
 
-export const POST_TAGS: Record<string, string> = {
+export const POST_TOPICS: Record<string, string> = {
     "technology": "Technology",
     "environment": "Environment",
     "politics": "Politics"

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -11,7 +11,7 @@ import {
     zodPostBody,
     zodVotingOption,
     zodVotingAction,
-    zodUserName,
+    zodUsername,
     zodPollResponse,
     zodPhoneNumber,
     zodExtendedCommentData,
@@ -172,7 +172,7 @@ export class Dto {
         .object({
             activePostCount: z.number().gte(0),
             createdAt: z.date(),
-            userName: zodUserName,
+            username: zodUsername,
         })
         .strict();
     static fetchUserPostsRequest = z
@@ -202,7 +202,7 @@ export class Dto {
     });
     static isUsernameInUseRequest = z
         .object({
-            userName: zodUserName,
+            username: zodUsername,
         })
         .strict();
     static isUsernameInUseResponse = z.boolean();

--- a/services/agora/src/shared/types/zod.ts
+++ b/services/agora/src/shared/types/zod.ts
@@ -80,10 +80,10 @@ export const zodPollResponse = z
     .strict();
 export const zodSlugId = z.string().max(10);
 export const zodCommentCount = z.number().int().nonnegative();
-export const userNameRegex = new RegExp(
+export const usernameRegex = new RegExp(
     `^[a-zA-Z0-9_]{${MIN_LENGTH_USERNAME.toString()},${MAX_LENGTH_USERNAME.toString()}}$`,
 );
-export const zodUserName = z.union([z.string().uuid(), z.string().regex(userNameRegex)]);
+export const zodUsername = z.union([z.string().uuid(), z.string().regex(usernameRegex)]);
 export const zodPostMetadata = z
     .object({
         postSlugId: zodSlugId,
@@ -92,7 +92,7 @@ export const zodPostMetadata = z
         updatedAt: z.date(),
         lastReactedAt: z.date(),
         commentCount: zodCommentCount,
-        authorUserName: zodUserName,
+        authorUsername: zodUsername,
         authorImagePath: z.string().url({ message: "Invalid url" }).optional(), // TODO: check if it accepts path segments for local dev
     })
     .strict();
@@ -105,7 +105,7 @@ export const zodCommentItem = z
         comment: zodCommentContent,
         numLikes: z.number().int().nonnegative(),
         numDislikes: z.number().int().nonnegative(),
-        userName: zodUserName,
+        username: zodUsername,
     })
     .strict();
 export const zodUserInteraction = z

--- a/services/agora/src/stores/post.ts
+++ b/services/agora/src/stores/post.ts
@@ -81,7 +81,7 @@ export const usePostStore = defineStore("post", () => {
       isHidden: false,
       createdAt: new Date(),
       commentCount: 0,
-      authorUserName: "",
+      authorUsername: "",
       lastReactedAt: new Date(),
       postSlugId: "",
       updatedAt: new Date(),

--- a/services/agora/src/stores/verification/phone.ts
+++ b/services/agora/src/stores/verification/phone.ts
@@ -2,7 +2,18 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 
 export const phoneVerificationStore = defineStore("phoneVerification", () => {
-  const verificationPhoneNumber = ref("");
+
+  interface PhoneNumberInterface {
+    phoneNumber: string;
+    defaultCallingCode: string;
+  }
+
+  const EMPTY_NUMBER: PhoneNumberInterface = {
+    phoneNumber: "",
+    defaultCallingCode: ""
+  }
+
+  const verificationPhoneNumber = ref(EMPTY_NUMBER);
 
   return { verificationPhoneNumber };
 });

--- a/services/agora/src/utils/api/auth.ts
+++ b/services/agora/src/utils/api/auth.ts
@@ -36,9 +36,6 @@ export function useBackendAuthApi() {
     defaultCallingCode,
     isRequestingNewCode,
   }: SendSmsCodeProps): Promise<AuthenticateReturn> {
-    if (process.env.VITE_USE_DUMMY_ACCESS == "true") {
-      phoneNumber = "+33612345678";
-    }
 
     const params: ApiV1AuthAuthenticatePostRequest = {
       phoneNumber: phoneNumber,

--- a/services/agora/src/utils/api/comment.ts
+++ b/services/agora/src/utils/api/comment.ts
@@ -37,7 +37,7 @@ export function useBackendCommentApi() {
           numDislikes: item.numDislikes,
           numLikes: item.numLikes,
           updatedAt: new Date(item.updatedAt),
-          userName: String(item.userName),
+          username: String(item.username),
         });
       });
 

--- a/services/agora/src/utils/api/phoneVerification.ts
+++ b/services/agora/src/utils/api/phoneVerification.ts
@@ -14,7 +14,7 @@ export function useBackendPhoneVerification() {
   const { isAuthenticated } = storeToRefs(useAuthenticationStore());
 
   async function submitCode(code: number): Promise<boolean> {
-    if (process.env.VITE_USE_DUMMY_ACCESS == "true") {
+    if (process.env.VITE_DEV_AUTHORIZED_PHONES) {
       code = 0;
     }
 

--- a/services/agora/src/utils/api/post.ts
+++ b/services/agora/src/utils/api/post.ts
@@ -179,7 +179,7 @@ export function useBackendPostApi() {
     incomingPostList.forEach((item) => {
       const newPost: ExtendedPost = {
         metadata: {
-          authorUserName: String(item.metadata.authorUserName),
+          authorUsername: String(item.metadata.authorUsername),
           commentCount: item.metadata.commentCount,
           createdAt: new Date(item.metadata.createdAt),
           lastReactedAt: new Date(item.metadata.lastReactedAt),

--- a/services/agora/src/utils/api/user.ts
+++ b/services/agora/src/utils/api/user.ts
@@ -35,7 +35,7 @@ export function useBackendUserApi() {
       return {
         activePostCount: response.data.activePostCount,
         createdAt: new Date(response.data.createdAt),
-        userName: response.data.userName,
+        userName: response.data.username,
       };
     } catch (e) {
       console.error(e);
@@ -114,7 +114,7 @@ export function useBackendUserApi() {
             numDislikes: responseItem.commentItem.numDislikes,
             numLikes: responseItem.commentItem.numLikes,
             updatedAt: new Date(responseItem.commentItem.updatedAt),
-            userName: String(responseItem.commentItem.userName),
+            username: String(responseItem.commentItem.username),
           },
         };
         extendedCommentList.push(extendedComment);

--- a/services/api/database/flyway/V0000__lean_krista_starr.sql
+++ b/services/api/database/flyway/V0000__lean_krista_starr.sql
@@ -267,8 +267,7 @@ CREATE TABLE IF NOT EXISTS "user_post_topic_preference" (
 CREATE TABLE IF NOT EXISTS "user" (
 	"id" uuid PRIMARY KEY NOT NULL,
 	"organisation_id" integer,
-	"configured_user_name" boolean DEFAULT false NOT NULL,
-	"user_name" varchar(36) NOT NULL,
+	"username" varchar(36) NOT NULL,
 	"is_anonymous" boolean DEFAULT true NOT NULL,
 	"show_flagged_content" boolean DEFAULT false NOT NULL,
 	"is_deleted" boolean DEFAULT false NOT NULL,
@@ -278,7 +277,8 @@ CREATE TABLE IF NOT EXISTS "user" (
 	"total_comment_count" integer DEFAULT 0 NOT NULL,
 	"created_at" timestamp (0) DEFAULT now() NOT NULL,
 	"updated_at" timestamp (0) DEFAULT now() NOT NULL,
-	CONSTRAINT "user_user_name_unique" UNIQUE("user_name")
+	CONSTRAINT "user_username_unique" UNIQUE("username"),
+	CONSTRAINT "user_unique_username" UNIQUE("username")
 );
 --> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "vote_content" (

--- a/services/api/drizzle/0000_lean_krista_starr.sql
+++ b/services/api/drizzle/0000_lean_krista_starr.sql
@@ -267,8 +267,7 @@ CREATE TABLE IF NOT EXISTS "user_post_topic_preference" (
 CREATE TABLE IF NOT EXISTS "user" (
 	"id" uuid PRIMARY KEY NOT NULL,
 	"organisation_id" integer,
-	"configured_user_name" boolean DEFAULT false NOT NULL,
-	"user_name" varchar(36) NOT NULL,
+	"username" varchar(36) NOT NULL,
 	"is_anonymous" boolean DEFAULT true NOT NULL,
 	"show_flagged_content" boolean DEFAULT false NOT NULL,
 	"is_deleted" boolean DEFAULT false NOT NULL,
@@ -278,7 +277,8 @@ CREATE TABLE IF NOT EXISTS "user" (
 	"total_comment_count" integer DEFAULT 0 NOT NULL,
 	"created_at" timestamp (0) DEFAULT now() NOT NULL,
 	"updated_at" timestamp (0) DEFAULT now() NOT NULL,
-	CONSTRAINT "user_user_name_unique" UNIQUE("user_name")
+	CONSTRAINT "user_username_unique" UNIQUE("username"),
+	CONSTRAINT "user_unique_username" UNIQUE("username")
 );
 --> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "vote_content" (

--- a/services/api/drizzle/meta/0000_snapshot.json
+++ b/services/api/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "fc904e2d-84bb-4465-a2ed-90c29922e6c6",
+  "id": "6bf1151d-aa5f-4670-a66d-60ee665b1313",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -2339,15 +2339,8 @@
           "primaryKey": false,
           "notNull": false
         },
-        "configured_user_name": {
-          "name": "configured_user_name",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "user_name": {
-          "name": "user_name",
+        "username": {
+          "name": "username",
           "type": "varchar(36)",
           "primaryKey": false,
           "notNull": true
@@ -2434,11 +2427,18 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
-        "user_user_name_unique": {
-          "name": "user_user_name_unique",
+        "user_username_unique": {
+          "name": "user_username_unique",
           "nullsNotDistinct": false,
           "columns": [
-            "user_name"
+            "username"
+          ]
+        },
+        "user_unique_username": {
+          "name": "user_unique_username",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
           ]
         }
       },

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1734081407874,
-      "tag": "0000_perpetual_zaran",
+      "when": 1734118685962,
+      "tag": "0000_lean_krista_starr",
       "breakpoints": true
     }
   ]

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -379,7 +379,7 @@
                                                                 "type": "integer",
                                                                 "minimum": 0
                                                             },
-                                                            "authorUserName": {
+                                                            "authorUsername": {
                                                                 "anyOf": [
                                                                     {
                                                                         "type": "string",
@@ -403,7 +403,7 @@
                                                             "updatedAt",
                                                             "lastReactedAt",
                                                             "commentCount",
-                                                            "authorUserName"
+                                                            "authorUsername"
                                                         ],
                                                         "additionalProperties": false
                                                     },
@@ -512,7 +512,7 @@
                                             "type": "string",
                                             "format": "date-time"
                                         },
-                                        "userName": {
+                                        "username": {
                                             "anyOf": [
                                                 {
                                                     "type": "string",
@@ -528,7 +528,7 @@
                                     "required": [
                                         "activePostCount",
                                         "createdAt",
-                                        "userName"
+                                        "username"
                                     ],
                                     "additionalProperties": false
                                 }
@@ -592,7 +592,7 @@
                                                         "type": "integer",
                                                         "minimum": 0
                                                     },
-                                                    "authorUserName": {
+                                                    "authorUsername": {
                                                         "anyOf": [
                                                             {
                                                                 "type": "string",
@@ -616,7 +616,7 @@
                                                     "updatedAt",
                                                     "lastReactedAt",
                                                     "commentCount",
-                                                    "authorUserName"
+                                                    "authorUsername"
                                                 ],
                                                 "additionalProperties": false
                                             },
@@ -754,7 +754,7 @@
                                                                 "type": "integer",
                                                                 "minimum": 0
                                                             },
-                                                            "authorUserName": {
+                                                            "authorUsername": {
                                                                 "anyOf": [
                                                                     {
                                                                         "type": "string",
@@ -778,7 +778,7 @@
                                                             "updatedAt",
                                                             "lastReactedAt",
                                                             "commentCount",
-                                                            "authorUserName"
+                                                            "authorUsername"
                                                         ],
                                                         "additionalProperties": false
                                                     },
@@ -879,7 +879,7 @@
                                                         "type": "integer",
                                                         "minimum": 0
                                                     },
-                                                    "userName": {
+                                                    "username": {
                                                         "anyOf": [
                                                             {
                                                                 "type": "string",
@@ -899,7 +899,7 @@
                                                     "comment",
                                                     "numLikes",
                                                     "numDislikes",
-                                                    "userName"
+                                                    "username"
                                                 ],
                                                 "additionalProperties": false
                                             }
@@ -1222,7 +1222,7 @@
                                                 "type": "integer",
                                                 "minimum": 0
                                             },
-                                            "userName": {
+                                            "username": {
                                                 "anyOf": [
                                                     {
                                                         "type": "string",
@@ -1242,7 +1242,7 @@
                                             "comment",
                                             "numLikes",
                                             "numDislikes",
-                                            "userName"
+                                            "username"
                                         ],
                                         "additionalProperties": false
                                     }
@@ -1402,7 +1402,7 @@
                                                             "type": "integer",
                                                             "minimum": 0
                                                         },
-                                                        "authorUserName": {
+                                                        "authorUsername": {
                                                             "anyOf": [
                                                                 {
                                                                     "type": "string",
@@ -1426,7 +1426,7 @@
                                                         "updatedAt",
                                                         "lastReactedAt",
                                                         "commentCount",
-                                                        "authorUserName"
+                                                        "authorUsername"
                                                     ],
                                                     "additionalProperties": false
                                                 },
@@ -1586,7 +1586,7 @@
                             "schema": {
                                 "type": "object",
                                 "properties": {
-                                    "userName": {
+                                    "username": {
                                         "anyOf": [
                                             {
                                                 "type": "string",
@@ -1600,7 +1600,7 @@
                                     }
                                 },
                                 "required": [
-                                    "userName"
+                                    "username"
                                 ],
                                 "additionalProperties": false
                             }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1061,7 +1061,7 @@ server.after(() => {
         handler: async (request) => {
             return await checkUserNameExist({
                 db: db,
-                userName: request.body.userName
+                username: request.body.username
             });
         },
     });

--- a/services/api/src/schema.ts
+++ b/services/api/src/schema.ts
@@ -560,11 +560,8 @@ export const userTable = pgTable("user", {
     organisationId: integer("organisation_id").references(
         () => organisationTable.id,
     ), // for now a user can belong to at most 1 organisation
-    configuredUsername: boolean("configured_user_name")
-        .notNull()
-        .default(false),
-    // UserName field is set to UUID length (36) because user need to setup username through onboarding
-    userName: varchar("user_name", { length: 36 })
+    // username field is set to UUID length (36) because user need to setup username through onboarding
+    username: varchar("username", { length: 36 })
         .notNull()
         .unique(),
     isAnonymous: boolean("is_anonymous").notNull().default(true),
@@ -588,6 +585,10 @@ export const userTable = pgTable("user", {
     })
         .defaultNow()
         .notNull(),
+}, (t) => {
+    return {
+        userIdx: unique("user_unique_username").on(t.username),
+    };
 });
 
 export const userLanguagePreferenceTable = pgTable("user_language_preference", {

--- a/services/api/src/service/auth.ts
+++ b/services/api/src/service/auth.ts
@@ -25,7 +25,6 @@ import parsePhoneNumberFromString, {
 } from "libphonenumber-js";
 import { log } from "@/app.js";
 import { PEPPER_VERSION, toUnionUndefined } from "@/shared/shared.js";
-import type { CountryCodeEnum } from "@/shared/types/zod.js";
 import type { HttpErrors } from "@fastify/sensible";
 import { v4 as uuidv4 } from 'uuid';
 
@@ -60,7 +59,7 @@ interface RegisterWithRarimoProps {
     userAgent: string;
     userId: string;
     sessionExpiry: Date;
-    userName: string;
+    username: string;
 }
 
 interface LoginProps {
@@ -343,7 +342,7 @@ export async function registerWithPhoneNumber({
             })
             .where(eq(authAttemptPhoneTable.didWrite, didWrite));
         await tx.insert(userTable).values({
-            userName: uuidv4(),
+            username: uuidv4(),
             id: userId,
         });
         await tx.insert(deviceTable).values({
@@ -372,11 +371,11 @@ export async function registerWithRarimo({
     userAgent,
     userId,
     sessionExpiry,
-    userName,
+    username,
 }: RegisterWithRarimoProps): Promise<void> {
     await db.transaction(async (tx) => {
         await tx.insert(userTable).values({
-            userName: userName,
+            username: username,
             id: userId,
         });
         await tx.insert(deviceTable).values({

--- a/services/api/src/service/comment.ts
+++ b/services/api/src/service/comment.ts
@@ -47,7 +47,7 @@ export async function fetchCommentsByPostSlugId(
             comment: commentContentTable.content,
             numLikes: commentTable.numLikes,
             numDislikes: commentTable.numDislikes,
-            userName: userTable.userName
+            username: userTable.username
         })
         .from(commentTable)
         .innerJoin(
@@ -76,7 +76,7 @@ export async function fetchCommentsByPostSlugId(
             numDislikes: commentResponse.numDislikes,
             numLikes: commentResponse.numLikes,
             updatedAt: commentResponse.updatedAt,
-            userName: commentResponse.userName
+            username: commentResponse.username
         };
         commentItemList.push(item);
     });

--- a/services/api/src/service/common.ts
+++ b/services/api/src/service/common.ts
@@ -45,7 +45,7 @@ export function useCommonPost() {
                 updatedAt: postTable.updatedAt,
                 lastReactedAt: postTable.lastReactedAt,
                 commentCount: postTable.commentCount,
-                authorName: userTable.userName,
+                authorName: userTable.username,
                 authorImagePath: organisationTable.imageUrl,
             })
             .from(postTable)
@@ -87,7 +87,7 @@ export function useCommonPost() {
                     updatedAt: postItem.updatedAt,
                     lastReactedAt: postItem.lastReactedAt,
                     commentCount: postItem.commentCount,
-                    authorUserName: postItem.authorName,
+                    authorUsername: postItem.authorName,
                     authorImagePath: toUnionUndefined(postItem.authorImagePath),
                 };
 

--- a/services/api/src/service/onboarding.ts
+++ b/services/api/src/service/onboarding.ts
@@ -4,17 +4,17 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 
 interface CheckUserNameExistProps {
   db: PostgresJsDatabase;
-  userName: string;
+  username: string;
 }
 
 export async function checkUserNameExist({
-  db, userName
+  db, username
 }: CheckUserNameExistProps): Promise<boolean> {
   const userTableResponse = await db
     .select({
     })
     .from(userTable)
-    .where(eq(userTable.userName, userName));
+    .where(eq(userTable.username, username));
   if (userTableResponse.length === 0) {
     return false;
   } else {

--- a/services/api/src/service/rarimo.ts
+++ b/services/api/src/service/rarimo.ts
@@ -3,7 +3,6 @@
 import { deviceTable, passportTable } from "@/schema.js";
 import type { VerifyUserStatusAndAuthenticate200 } from "@/shared/types/dto.js";
 import {
-    zodCountryCodeEnum,
     type RarimoStatusAttributes,
 } from "@/shared/types/zod.js";
 import { type AxiosInstance } from "axios";
@@ -208,7 +207,6 @@ export async function verifyUserStatusAndAuthenticate({
     didWrite,
     axiosVerificatorSvc,
     userAgent,
-    httpErrors,
 }: VerifyUserStatusProps): Promise<VerifyUserStatusAndAuthenticate200> {
     const verifyUserStatusUrl = `/integrations/verificator-svc/light/private/verification-status/${didWrite.toLowerCase()}`; // toLowerCase is a work-around because verificator-svc does it when inserting the userId in DB but not when selecting data from the DB! Missing toLowerCase() here would lead to a 404 error. This one here is not necessary as verificator-svc is doing it already, but as a safety measure I added this for now.
     const response =
@@ -271,7 +269,7 @@ export async function verifyUserStatusAndAuthenticate({
                 userAgent,
                 userId,
                 sessionExpiry: loginSessionExpiry,
-                userName: "TEST_USER", //TODO: generte random userName instead, while waiting for the user to choose another one during onboarding
+                username: "TEST_USER", //TODO: generte random username instead, while waiting for the user to choose another one during onboarding
             });
             break;
         }

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -35,7 +35,7 @@ export async function getUserComments({
         comment: commentContentTable.content,
         numLikes: commentTable.numLikes,
         numDislikes: commentTable.numDislikes,
-        userName: userTable.userName,
+        username: userTable.username,
         postSlugId: postTable.slugId
       })
       .from(commentTable)
@@ -67,7 +67,7 @@ export async function getUserComments({
         numDislikes: commentResponse.numDislikes,
         numLikes: commentResponse.numLikes,
         updatedAt: commentResponse.updatedAt,
-        userName: commentResponse.userName
+        username: commentResponse.username
       }
 
       const postItem = await fetchPostBySlugId({
@@ -150,7 +150,7 @@ export async function getUserProfile({
       .select({
         activePostCount: userTable.activePostCount,
         createdAt: userTable.createdAt,
-        userName: userTable.userName
+        username: userTable.username
       })
       .from(userTable)
       .where(eq(userTable.id, userId));
@@ -163,7 +163,7 @@ export async function getUserProfile({
       return {
         activePostCount: userTableResponse[0].activePostCount,
         createdAt: userTableResponse[0].createdAt,
-        userName: userTableResponse[0].userName,
+        username: userTableResponse[0].username,
       };
     }
 

--- a/services/api/src/shared/did/util.ts
+++ b/services/api/src/shared/did/util.ts
@@ -1,4 +1,3 @@
-/** **** WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MOFIFY THIS FILE DIRECTLY! **** **/
 import * as uint8arrays from "uint8arrays";
 
 export const BASE58_DID_PREFIX = "did:key:z";

--- a/services/api/src/shared/shared.ts
+++ b/services/api/src/shared/shared.ts
@@ -1,4 +1,3 @@
-/** **** WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MOFIFY THIS FILE DIRECTLY! **** **/
 // Copyright ts-odd team
 // Apache v2 License
 // Extracted from: https://github.com/oddsdk/ts-odd/tree/f90bde37416d9986d1c0afed406182a95ce7c1d7
@@ -70,7 +69,7 @@ export const MIN_LENGTH_USERNAME = 3;
 
 export const PEPPER_VERSION = 0;
 
-export const POST_TAGS: Record<string, string> = {
+export const POST_TOPICS: Record<string, string> = {
     "technology": "Technology",
     "environment": "Environment",
     "politics": "Politics"

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -1,4 +1,3 @@
-/** **** WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MOFIFY THIS FILE DIRECTLY! **** **/
 import { z } from "zod";
 import {
     zodExtendedPostData,
@@ -11,7 +10,7 @@ import {
     zodPostBody,
     zodVotingOption,
     zodVotingAction,
-    zodUserName,
+    zodUsername,
     zodPollResponse,
     zodPhoneNumber,
     zodExtendedCommentData,
@@ -172,7 +171,7 @@ export class Dto {
         .object({
             activePostCount: z.number().gte(0),
             createdAt: z.date(),
-            userName: zodUserName,
+            username: zodUsername,
         })
         .strict();
     static fetchUserPostsRequest = z
@@ -202,7 +201,7 @@ export class Dto {
     });
     static isUsernameInUseRequest = z
         .object({
-            userName: zodUserName,
+            username: zodUsername,
         })
         .strict();
     static isUsernameInUseResponse = z.boolean();

--- a/services/api/src/shared/types/zod.ts
+++ b/services/api/src/shared/types/zod.ts
@@ -80,10 +80,10 @@ export const zodPollResponse = z
     .strict();
 export const zodSlugId = z.string().max(10);
 export const zodCommentCount = z.number().int().nonnegative();
-export const userNameRegex = new RegExp(
+export const usernameRegex = new RegExp(
     `^[a-zA-Z0-9_]{${MIN_LENGTH_USERNAME.toString()},${MAX_LENGTH_USERNAME.toString()}}$`,
 );
-export const zodUserName = z.union([z.string().uuid(), z.string().regex(userNameRegex)]);
+export const zodUsername = z.union([z.string().uuid(), z.string().regex(usernameRegex)]);
 export const zodPostMetadata = z
     .object({
         postSlugId: zodSlugId,
@@ -92,7 +92,7 @@ export const zodPostMetadata = z
         updatedAt: z.date(),
         lastReactedAt: z.date(),
         commentCount: zodCommentCount,
-        authorUserName: zodUserName,
+        authorUsername: zodUsername,
         authorImagePath: z.string().url({ message: "Invalid url" }).optional(), // TODO: check if it accepts path segments for local dev
     })
     .strict();
@@ -105,7 +105,7 @@ export const zodCommentItem = z
         comment: zodCommentContent,
         numLikes: z.number().int().nonnegative(),
         numDislikes: z.number().int().nonnegative(),
-        userName: zodUserName,
+        username: zodUsername,
     })
     .strict();
 export const zodUserInteraction = z

--- a/services/shared/src/shared.ts
+++ b/services/shared/src/shared.ts
@@ -69,7 +69,7 @@ export const MIN_LENGTH_USERNAME = 3;
 
 export const PEPPER_VERSION = 0;
 
-export const POST_TAGS: Record<string, string> = {
+export const POST_TOPICS: Record<string, string> = {
     "technology": "Technology",
     "environment": "Environment",
     "politics": "Politics"

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -10,7 +10,7 @@ import {
     zodPostBody,
     zodVotingOption,
     zodVotingAction,
-    zodUserName,
+    zodUsername,
     zodPollResponse,
     zodPhoneNumber,
     zodExtendedCommentData,
@@ -171,7 +171,7 @@ export class Dto {
         .object({
             activePostCount: z.number().gte(0),
             createdAt: z.date(),
-            userName: zodUserName,
+            username: zodUsername,
         })
         .strict();
     static fetchUserPostsRequest = z
@@ -201,7 +201,7 @@ export class Dto {
     });
     static isUsernameInUseRequest = z
         .object({
-            userName: zodUserName,
+            username: zodUsername,
         })
         .strict();
     static isUsernameInUseResponse = z.boolean();

--- a/services/shared/src/types/zod.ts
+++ b/services/shared/src/types/zod.ts
@@ -79,10 +79,10 @@ export const zodPollResponse = z
     .strict();
 export const zodSlugId = z.string().max(10);
 export const zodCommentCount = z.number().int().nonnegative();
-export const userNameRegex = new RegExp(
+export const usernameRegex = new RegExp(
     `^[a-zA-Z0-9_]{${MIN_LENGTH_USERNAME.toString()},${MAX_LENGTH_USERNAME.toString()}}$`,
 );
-export const zodUserName = z.union([z.string().uuid(), z.string().regex(userNameRegex)]);
+export const zodUsername = z.union([z.string().uuid(), z.string().regex(usernameRegex)]);
 export const zodPostMetadata = z
     .object({
         postSlugId: zodSlugId,
@@ -91,7 +91,7 @@ export const zodPostMetadata = z
         updatedAt: z.date(),
         lastReactedAt: z.date(),
         commentCount: zodCommentCount,
-        authorUserName: zodUserName,
+        authorUsername: zodUsername,
         authorImagePath: z.string().url({ message: "Invalid url" }).optional(), // TODO: check if it accepts path segments for local dev
     })
     .strict();
@@ -104,7 +104,7 @@ export const zodCommentItem = z
         comment: zodCommentContent,
         numLikes: z.number().int().nonnegative(),
         numDislikes: z.number().int().nonnegative(),
-        userName: zodUserName,
+        username: zodUsername,
     })
     .strict();
 export const zodUserInteraction = z


### PR DESCRIPTION
Changes:
- Added `VITE_DEV_AUTHORIZED_PHONES` to the frontend for testing purposes
  - If enabled, it will automatically recommend the test phone numbers when user logins
  - Removed `VITE_USE_DUMMY_ACCESS` which was used to overwrite the submitted code, instead `VITE_DEV_AUTHORIZED_PHONES` will be used to force the submitted phone code to be `0`
- Standardized all variables to be `username` or `Username`
- Revised the passport page
  - Fixed QR code and mobile's verify button for deep linking to RariMe
  - Fixed API call sequences