### PR TITLE
Fix bug where opinions' cluster reasoning do not rerender between cluster changes

### DIFF
--- a/services/agora/src/components/post/views/CommentGroup.vue
+++ b/services/agora/src/components/post/views/CommentGroup.vue
@@ -25,7 +25,7 @@
       <ZKCard
         v-for="commentItem in commentItemList"
         :id="commentItem.opinionSlugId"
-        :key="commentItem.opinionSlugId"
+        :key="commentItem.opinionSlugId + '-' + selectedClusterKey"
         padding="1rem"
         class="commentItemBackground"
       >


### PR DESCRIPTION
Changes:
- Forced a re-render of the v-for opinion loop whenever there is a cluster change