### PR TITLE
QoL and bug fixes on the frontend

### DIFF
--- a/services/agora/src/components/feed/CompactPostList.vue
+++ b/services/agora/src/components/feed/CompactPostList.vue
@@ -127,7 +127,7 @@ useInfiniteScroll(
 );
 
 watch(pageIsVisible, async () => {
-  if (pageIsVisible.value && !endOfFeed.value) {
+  if (pageIsVisible.value == "visible") {
     await newPostCheck();
   }
 });

--- a/services/agora/src/components/feed/CompactPostList.vue
+++ b/services/agora/src/components/feed/CompactPostList.vue
@@ -88,7 +88,7 @@
 import PostDetails from "../post/PostDetails.vue";
 import { usePostStore } from "src/stores/post";
 import ZKButton from "../ui-library/ZKButton.vue";
-import { ref, useTemplateRef, watch } from "vue";
+import { onMounted, ref, useTemplateRef, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { useDocumentVisibility, useInfiniteScroll } from "@vueuse/core";
 import { useRouter } from "vue-router";
@@ -125,6 +125,10 @@ useInfiniteScroll(
     },
   }
 );
+
+onMounted(async () => {
+  await newPostCheck();
+});
 
 watch(pageIsVisible, async () => {
   if (pageIsVisible.value == "visible") {

--- a/services/agora/src/components/feed/CompactPostList.vue
+++ b/services/agora/src/components/feed/CompactPostList.vue
@@ -137,7 +137,7 @@ watch(pageIsVisible, async () => {
 });
 
 async function pullDownTriggered() {
-  await loadPostData(true);
+  await loadPostData(false);
 }
 
 async function newPostCheck() {

--- a/services/agora/src/components/feed/CompactPostList.vue
+++ b/services/agora/src/components/feed/CompactPostList.vue
@@ -138,6 +138,7 @@ watch(pageIsVisible, async () => {
 
 async function pullDownTriggered() {
   await loadPostData(false);
+  hasPendingNewPosts.value = false;
 }
 
 async function newPostCheck() {
@@ -226,5 +227,6 @@ async function refreshPage(done: () => void) {
   margin: auto;
   height: calc(100dvh - 7rem);
   overflow-y: scroll;
+  overscroll-behavior: none;
 }
 </style>

--- a/services/agora/src/components/post/PostDetails.vue
+++ b/services/agora/src/components/post/PostDetails.vue
@@ -380,5 +380,6 @@ async function shareClicked() {
 .fixedHeightContainer {
   height: calc(100dvh - 3.5rem);
   overflow-y: scroll;
+  overscroll-behavior: none;
 }
 </style>

--- a/services/agora/src/components/post/views/CommentSingle.vue
+++ b/services/agora/src/components/post/views/CommentSingle.vue
@@ -2,11 +2,15 @@
 <template>
   <div>
     <div class="container">
-      <div
-        v-if="reasonLabel !== undefined"
-        class="pushReasonPosition pushReasonStyle pushReasonFlex"
-      >
-        {{ reasonLabel }}
+      <div class="pushReasonPosition">
+        <ZKCard padding="0rem" class="labelBackground">
+          <div
+            v-if="reasonLabel !== undefined"
+            class="pushReasonStyle pushReasonFlex"
+          >
+            {{ reasonLabel }}
+          </div>
+        </ZKCard>
       </div>
 
       <div class="topBar">
@@ -58,6 +62,7 @@ import CommentActionOptions from "./CommentActionOptions.vue";
 import { formatClusterLabel } from "src/utils/component/opinion";
 import { calculatePercentage } from "src/utils/common";
 import UserIdentity from "./UserIdentity.vue";
+import ZKCard from "src/components/ui-library/ZKCard.vue";
 
 const emit = defineEmits(["deleted", "mutedComment"]);
 
@@ -186,17 +191,16 @@ function mutedComment() {
   align-items: center;
 }
 
+.labelBackground {
+  background-color: #f6f5f8;
+}
+
 .pushReasonStyle {
   padding-top: 0.2rem;
   padding-bottom: 0.2rem;
   padding-left: 1rem;
   padding-right: 1rem;
-  border-radius: 0.5rem;
-  color: $primary;
-  background-color: white;
-  border-style: solid;
-  border-width: 1px;
-  border-color: $primary;
+  color: #5c6c74;
 }
 
 .pushReasonPosition {

--- a/services/agora/src/components/post/views/cluster/ClusterTabs.vue
+++ b/services/agora/src/components/post/views/cluster/ClusterTabs.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="container">
+    <div v-if="clusterMetadataList.length > 1" class="container">
       <div
         class="tabStyle"
         :class="{ highlightTab: model === 'all' }"

--- a/services/agora/src/pages/notification/index.vue
+++ b/services/agora/src/pages/notification/index.vue
@@ -171,6 +171,7 @@ async function redirectPage(routeTarget: RouteTarget) {
   margin: auto;
   height: calc(100dvh - 7rem);
   overflow-y: scroll;
+  overscroll-behavior: none;
 }
 
 .widthConstraint {

--- a/services/agora/src/pages/user-profile/conversations/index.vue
+++ b/services/agora/src/pages/user-profile/conversations/index.vue
@@ -51,7 +51,6 @@ onMounted(async () => {
 });
 
 watch(targetIsVisible, async () => {
-  console.log(endOfFeed.value);
   if (
     targetIsVisible.value &&
     !isExpandingPosts &&

--- a/services/agora/src/stores/opinionScrollable.ts
+++ b/services/agora/src/stores/opinionScrollable.ts
@@ -1,6 +1,9 @@
-import { defineStore } from "pinia";
+import { defineStore, storeToRefs } from "pinia";
 import { OpinionItem } from "src/shared/types/zod";
+import { CommentFilterOptions } from "src/utils/component/opinion";
 import { ref } from "vue";
+import { useAuthenticationStore } from "./authentication";
+import { useNotify } from "src/utils/ui/notify";
 
 export const useOpinionScrollableStore = defineStore(
   "opinionScrollable",
@@ -9,6 +12,9 @@ export const useOpinionScrollableStore = defineStore(
     const opinionItemListPartial = ref<OpinionItem[]>([]);
 
     const hasMore = ref(true);
+
+    const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+    const { showNotifyMessage } = useNotify();
 
     function loadMore() {
       const endSliceIndex = Math.min(
@@ -29,16 +35,76 @@ export const useOpinionScrollableStore = defineStore(
         opinionItemListPartial.value.concat(slicedList);
     }
 
-    function setupOpinionlist(opinionListFull: OpinionItem[]) {
+    function setupOpinionlist(
+      opinionListFull: OpinionItem[],
+      opinionSlugId: string
+    ) {
       opinionItemListPartial.value = [];
       opinionItemListFull.value = opinionListFull;
       hasMore.value = true;
+
+      if (opinionSlugId.length > 0) {
+        // Search for the specific opinion and move it to the front of list
+        let moveIndex = 0;
+        for (const [index, val] of opinionItemListFull.value.entries()) {
+          if (val.opinionSlugId == opinionSlugId) {
+            moveIndex = index;
+            break;
+          }
+        }
+
+        if (moveIndex > 0) {
+          opinionItemListFull.value.unshift(
+            opinionItemListFull.value.splice(moveIndex, 1)[0]
+          );
+        }
+      }
+
       loadMore();
+    }
+
+    function detectOpinionFilterBySlugId(
+      commentSlugId: string,
+      commentItemsNew: OpinionItem[],
+      commentItemsDiscover: OpinionItem[],
+      commentItemsModerated: OpinionItem[],
+      commentItemsHidden: OpinionItem[]
+    ): CommentFilterOptions | "not_found" {
+      for (const commentItem of commentItemsDiscover) {
+        if (commentItem.opinionSlugId == commentSlugId) {
+          return "discover";
+        }
+      }
+      for (const commentItem of commentItemsNew) {
+        if (commentItem.opinionSlugId == commentSlugId) {
+          return "new";
+        }
+      }
+
+      for (const commentItem of commentItemsModerated) {
+        if (commentItem.opinionSlugId == commentSlugId) {
+          return "moderated";
+        }
+      }
+
+      if (!isAuthenticated.value) {
+        showNotifyMessage("This opinion has been removed by the moderators");
+        return "discover";
+      } else {
+        for (const commentItem of commentItemsHidden) {
+          if (commentItem.opinionSlugId == commentSlugId) {
+            return "hidden";
+          }
+        }
+      }
+
+      return "not_found";
     }
 
     return {
       setupOpinionlist,
       loadMore,
+      detectOpinionFilterBySlugId,
       opinionItemListPartial,
       hasMore,
     };


### PR DESCRIPTION
- Adjusted the opinion's push label style
- Fixed bug where cluster tabs were being displayed when cluster size is < 2
- Disabled browser's default scroll behavior for infinite scrolling containers
- Fixed a bug where scroll down to refresh will cause font page to show duplicate conversations
- Fixed a bug where a requested opinion might get buried in the infinite scrolling list. We now move the requested opinion to the top of the display list
- Added a check for new conversations whenever the font page is loaded