### PR TITLE
Disable inner scrolling on the onboarding pages even if it overflows

### DIFF
--- a/services/agora/src/layouts/OnboardingLayout.vue
+++ b/services/agora/src/layouts/OnboardingLayout.vue
@@ -51,6 +51,7 @@ const welcomeBackgroundImagePath =
   background-color: white;
   border-top: 1px solid $secondary;
   overflow: auto;
+  scrollbar-width: none;
 }
 
 .containerPaddings {


### PR DESCRIPTION
Due to the special layout requirement we have for onboarding, the inner scrolling had been completely disabled.

https://github.com/zkorum/agora/issues/165