### PR TITLE
Fix the iOS web share functionality on Safari where it will copy duplicate links

### DIFF
--- a/services/agora/src/utils/share/WebShare.ts
+++ b/services/agora/src/utils/share/WebShare.ts
@@ -22,11 +22,19 @@ export function useWebShare() {
 
   async function share(title: string, url: string) {
     if (isSupportedSharePlatform()) {
-      await webShare.share({
-        title: title,
-        text: url,
-        url: url,
-      });
+      if (Platform.is.ios) {
+        await webShare.share({
+          title: title,
+          text: "",
+          url: url,
+        });
+      } else {
+        await webShare.share({
+          title: title,
+          text: url,
+          url: url,
+        });
+      }
     } else {
       if (clipBoard.isSupported) {
         await clipBoard.copy(url);


### PR DESCRIPTION
Added a specialized rule for the iOS platform for browser web share.

Tested browsers:
- Firefox
- Safari
- Chrome