### PR TITLE
Fix the Safari scrolling bug which is triggered by the Quasar dialog

### DIFF
--- a/services/agora/src/css/app.scss
+++ b/services/agora/src/css/app.scss
@@ -43,6 +43,12 @@ a {
 }
 
 html {
-  overscroll-behavior: none;
   overflow-y: scroll;
+  overscroll-behavior: none;
+}
+
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  html {
+    overscroll-behavior: auto;
+  }
 }

--- a/services/agora/src/layouts/DrawerLayout.vue
+++ b/services/agora/src/layouts/DrawerLayout.vue
@@ -32,7 +32,7 @@
         show-if-above
         :behavior="drawerBehavior"
         :width="300"
-        :breakpoint="700"
+        :breakpoint="800"
         :overlay="drawerBehavior == 'mobile'"
         :no-swipe-open="noSwipeOpen"
         bordered


### PR DESCRIPTION
Safari scrolling bug (freezing after closing a dialog on desktop Safari) is caused by "overscroll-behavior: none;". This PR disables that CSS for Webkit browsers as a workaround. That CSS was used to remove browser's bouncing effect to make the page more "app like" but it is incompatible with Quasar's dialog component.

I tested two other dialog component (PrimeVue and another custom one) and they did not trigger the bug in Safari. So this is a Quasar specific bug.