### PR TITLE
Fix the Safari scrolling bug which is triggered by the Quasar dialog

### DIFF
--- a/services/agora/src/App.vue
+++ b/services/agora/src/App.vue
@@ -6,10 +6,13 @@
 import * as swiperElement from "swiper/element/bundle";
 import { onMounted } from "vue";
 import { useBackendAuthApi } from "./utils/api/auth";
+import { useHtmlNodeCssPatch } from "./utils/css/htmlNodeCssPatch";
 
 swiperElement.register();
 
 const authenticationStore = useBackendAuthApi();
+
+useHtmlNodeCssPatch();
 
 onMounted(async () => {
   try {

--- a/services/agora/src/utils/css/htmlNodeCssPatch.ts
+++ b/services/agora/src/utils/css/htmlNodeCssPatch.ts
@@ -1,0 +1,16 @@
+import { useQuasar } from "quasar";
+import { onMounted } from "vue";
+
+export const useHtmlNodeCssPatch = () => {
+  const quasar = useQuasar();
+
+  onMounted(() => {
+    if (
+      quasar.platform.is.desktop &&
+      quasar.platform.is.safari &&
+      quasar.platform.is.mac
+    ) {
+      document.documentElement.style.overscrollBehavior = "auto";
+    }
+  });
+};

--- a/services/agora/src/utils/css/htmlNodeCssPatch.ts
+++ b/services/agora/src/utils/css/htmlNodeCssPatch.ts
@@ -5,11 +5,7 @@ export const useHtmlNodeCssPatch = () => {
   const quasar = useQuasar();
 
   onMounted(() => {
-    if (
-      quasar.platform.is.desktop &&
-      quasar.platform.is.safari &&
-      quasar.platform.is.mac
-    ) {
+    if (quasar.platform.is.desktop && quasar.platform.is.webkit) {
       document.documentElement.style.overscrollBehavior = "auto";
     }
   });


### PR DESCRIPTION
Safari scrolling bug (freezing after closing a dialog on desktop Safari) is caused by "overscroll-behavior: none;". This PR removes that CSS for webkit based desktop browser as a workaround through JavaScript.