### PR TITLE
Make the mobile's '+' button (adds a conversation) hide on scroll 

### DIFF
--- a/services/agora/src/components/post/NewPostButtonWrapper.vue
+++ b/services/agora/src/components/post/NewPostButtonWrapper.vue
@@ -1,22 +1,24 @@
 <template>
   <div>
-    <q-page-sticky
-      v-if="drawerBehavior == 'mobile'"
-      position="bottom-right"
-      :offset="[15, 15]"
-    >
-      <RouterLink :to="{ name: '/conversation/create/' }">
-        <div class="stickyButton">
-          <img :src="newConversationButton" />
-        </div>
-      </RouterLink>
-    </q-page-sticky>
+    <div v-if="drawerBehavior == 'mobile' && revealHeader">
+      <q-page-sticky position="bottom-right" :offset="[15, 15]">
+        <RouterLink :to="{ name: '/conversation/create/' }">
+          <div class="stickyButton">
+            <img :src="newConversationButton" />
+          </div>
+        </RouterLink>
+      </q-page-sticky>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import { useLayoutHeaderStore } from "src/stores/layout/header";
 import { useNavigationStore } from "src/stores/navigation";
+
+const { reveal: revealHeader } = storeToRefs(useLayoutHeaderStore());
+revealHeader.value = true;
 
 const newConversationButton =
   process.env.VITE_PUBLIC_DIR + "/images/conversation/newConversationShort.svg";

--- a/services/agora/src/components/post/NewPostButtonWrapper.vue
+++ b/services/agora/src/components/post/NewPostButtonWrapper.vue
@@ -1,14 +1,16 @@
 <template>
   <div>
-    <div v-if="drawerBehavior == 'mobile' && revealHeader">
-      <q-page-sticky position="bottom-right" :offset="[15, 15]">
-        <RouterLink :to="{ name: '/conversation/create/' }">
-          <div class="stickyButton">
-            <img :src="newConversationButton" />
-          </div>
-        </RouterLink>
-      </q-page-sticky>
-    </div>
+    <q-page-sticky
+      v-if="drawerBehavior == 'mobile' && revealHeader"
+      position="bottom-right"
+      :offset="[15, 15]"
+    >
+      <RouterLink :to="{ name: '/conversation/create/' }">
+        <div class="stickyButton">
+          <img :src="newConversationButton" />
+        </div>
+      </RouterLink>
+    </q-page-sticky>
   </div>
 </template>
 

--- a/services/agora/src/layouts/DrawerLayout.vue
+++ b/services/agora/src/layouts/DrawerLayout.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <q-layout :key="drawerBehavior" :view="'lHh LpR lFf'">
-      <q-header reveal :model-value="props.generalProps.enableHeader">
+      <q-header
+        reveal
+        :model-value="props.generalProps.enableHeader"
+        @reveal="captureHeaderReval"
+      >
         <slot name="header"></slot>
       </q-header>
 
@@ -50,6 +54,7 @@ import { storeToRefs } from "pinia";
 import FooterBar from "src/components/navigation/footer/FooterBar.vue";
 import SideDrawer from "src/components/navigation/SideDrawer.vue";
 import WidthWrapper from "src/components/navigation/WidthWrapper.vue";
+import { useLayoutHeaderStore } from "src/stores/layout/header";
 import { useNavigationStore } from "src/stores/navigation";
 import { useNotificationRefresher } from "src/utils/component/notification/menuRefresher";
 import { type MainLayoutProps } from "src/utils/model/props";
@@ -57,9 +62,17 @@ import { type MainLayoutProps } from "src/utils/model/props";
 const props = defineProps<MainLayoutProps>();
 
 const { showMobileDrawer, drawerBehavior } = storeToRefs(useNavigationStore());
+const { reveal: revealHeader } = storeToRefs(useLayoutHeaderStore());
+
 useNotificationRefresher();
 
 const noSwipeOpen = process.env.MODE != "capacitor";
+
+function captureHeaderReval(reveal: boolean) {
+  if (drawerBehavior.value == "mobile") {
+    revealHeader.value = reveal;
+  }
+}
 </script>
 
 <style scoped lang="scss">

--- a/services/agora/src/stores/layout/header.ts
+++ b/services/agora/src/stores/layout/header.ts
@@ -1,0 +1,8 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export const useLayoutHeaderStore = defineStore("layoutHeader", () => {
+  const reveal = ref(true);
+
+  return { reveal };
+});


### PR DESCRIPTION
Changes:
- Mirrors the + button against the q-header and hide it on scroll