### PR TITLE
feat(fullstack): guest mode

### DIFF
--- a/services/agora/src/App.vue
+++ b/services/agora/src/App.vue
@@ -16,6 +16,7 @@ useHtmlNodeCssPatch();
 
 onMounted(async () => {
   try {
+    console.log("Initializing authentication state");
     await authenticationStore.initializeAuthState();
   } catch (e) {
     console.error("Error while trying to get logged-in status", e);

--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -335,21 +335,61 @@ export type ApiV1AuthAuthenticatePostRequestDefaultCallingCodeEnum = typeof ApiV
 export interface ApiV1AuthCheckLoginStatusPost200Response {
     /**
      * 
-     * @type {string}
+     * @type {ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatus}
      * @memberof ApiV1AuthCheckLoginStatusPost200Response
      */
-    'loggedInStatus': ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusEnum;
+    'loggedInStatus': ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatus;
 }
-
-export const ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusEnum = {
-    LoggedIn: 'logged_in',
-    Unknown: 'unknown',
-    Unverified: 'unverified',
-    LoggedOut: 'logged_out'
-} as const;
-
-export type ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusEnum = typeof ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusEnum[keyof typeof ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusEnum];
-
+/**
+ * 
+ * @export
+ * @interface ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatus
+ */
+export interface ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatus {
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatus
+     */
+    'isKnown': boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatus
+     */
+    'isRegistered': boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatus
+     */
+    'isLoggedIn': boolean;
+}
+/**
+ * 
+ * @export
+ * @interface ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusAnyOf
+ */
+export interface ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusAnyOf {
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusAnyOf
+     */
+    'isKnown': boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusAnyOf
+     */
+    'isRegistered': boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1AuthCheckLoginStatusPost200ResponseLoggedInStatusAnyOf
+     */
+    'isLoggedIn': boolean;
+}
 /**
  * 
  * @export

--- a/services/agora/src/components/navigation/SideDrawer.vue
+++ b/services/agora/src/components/navigation/SideDrawer.vue
@@ -172,7 +172,7 @@ function initializeMenu() {
 }
 
 async function enterRoute(routeName: keyof RouteMap, requireAuth: boolean) {
-  if (requireAuth && !isGuestOrLoggedIn) {
+  if (requireAuth && isGuestOrLoggedIn.value === false) {
     showLoginDialog.value = true;
   } else {
     if (drawerBehavior.value == "mobile") {

--- a/services/agora/src/components/navigation/SideDrawer.vue
+++ b/services/agora/src/components/navigation/SideDrawer.vue
@@ -7,15 +7,13 @@
           <img :src="drawerIconLogo2" class="logoStyle2" />
         </div>
 
-        <div v-if="isAuthenticated" class="usernameBar">
+        <div v-if="isGuestOrLoggedIn" class="usernameBar">
           <UserAvatar
             :key="profileData.userName"
             :user-identity="profileData.userName"
             :size="35"
           />
-          <div>
-            {{ profileData.userName }}
-          </div>
+          <Username :username="profileData.userName" :show-is-guest="isGuest" />
         </div>
 
         <div class="menuListFlex">
@@ -73,22 +71,23 @@
 </template>
 
 <script setup lang="ts">
-import { RouteMap, useRoute, useRouter } from "vue-router";
-import ZKHoverEffect from "../ui-library/ZKHoverEffect.vue";
 import { storeToRefs } from "pinia";
 import { useAuthenticationStore } from "src/stores/authentication";
-import UserAvatar from "../account/UserAvatar.vue";
-import { useUserStore } from "src/stores/user";
 import { useNavigationStore } from "src/stores/navigation";
+import { useUserStore } from "src/stores/user";
 import { ref, watch } from "vue";
-import ZKStyledIcon from "../ui-library/ZKStyledIcon.vue";
-import NewNotificationIndicator from "../notification/NewNotificationIndicator.vue";
+import { RouteMap, useRoute, useRouter } from "vue-router";
+import UserAvatar from "../account/UserAvatar.vue";
 import PreLoginIntentionDialog from "../authentication/intention/PreLoginIntentionDialog.vue";
+import NewNotificationIndicator from "../notification/NewNotificationIndicator.vue";
+import Username from "../post/views/Username.vue";
+import ZKHoverEffect from "../ui-library/ZKHoverEffect.vue";
+import ZKStyledIcon from "../ui-library/ZKStyledIcon.vue";
 
 const newConversationButton =
   process.env.VITE_PUBLIC_DIR + "/images/conversation/newConversationLong.svg";
 
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isGuestOrLoggedIn, isGuest } = storeToRefs(useAuthenticationStore());
 const { profileData } = storeToRefs(useUserStore());
 const { drawerBehavior, showMobileDrawer } = storeToRefs(useNavigationStore());
 
@@ -173,7 +172,7 @@ function initializeMenu() {
 }
 
 async function enterRoute(routeName: keyof RouteMap, requireAuth: boolean) {
-  if (requireAuth && isAuthenticated.value == false) {
+  if (requireAuth && !isGuestOrLoggedIn) {
     showLoginDialog.value = true;
   } else {
     if (drawerBehavior.value == "mobile") {

--- a/services/agora/src/components/navigation/footer/FooterBar.vue
+++ b/services/agora/src/components/navigation/footer/FooterBar.vue
@@ -55,7 +55,7 @@ import { useAuthenticationStore } from "src/stores/authentication";
 import { ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isGuestOrLoggedIn } = storeToRefs(useAuthenticationStore());
 
 const route = useRoute();
 const router = useRouter();
@@ -71,7 +71,7 @@ async function accessHomeFeed() {
 }
 
 async function accessNotifications() {
-  if (!isAuthenticated.value) {
+  if (!isGuestOrLoggedIn) {
     showLoginDialog.value = true;
   } else {
     await router.push({ name: "/notification/" });

--- a/services/agora/src/components/navigation/footer/FooterBar.vue
+++ b/services/agora/src/components/navigation/footer/FooterBar.vue
@@ -71,7 +71,7 @@ async function accessHomeFeed() {
 }
 
 async function accessNotifications() {
-  if (!isGuestOrLoggedIn) {
+  if (isGuestOrLoggedIn.value === false) {
     showLoginDialog.value = true;
   } else {
     await router.push({ name: "/notification/" });

--- a/services/agora/src/components/navigation/header/DefaultMenuBar.vue
+++ b/services/agora/src/components/navigation/header/DefaultMenuBar.vue
@@ -11,7 +11,7 @@
               <div>
                 <UserAvatar
                   v-if="
-                    isAuthenticated &&
+                    isGuestOrLoggedIn &&
                     !isCapacitor &&
                     drawerBehavior == 'mobile'
                   "
@@ -24,7 +24,9 @@
 
               <ZKButton
                 v-if="
-                  !isAuthenticated && !isCapacitor && drawerBehavior == 'mobile'
+                  !isGuestOrLoggedIn &&
+                  !isCapacitor &&
+                  drawerBehavior == 'mobile'
                 "
                 button-type="standardButton"
                 icon="mdi-menu"
@@ -50,7 +52,7 @@
           >
             <div>
               <RouterLink
-                v-if="hasLoginButton && !isAuthenticated && showAuthButton"
+                v-if="hasLoginButton && !isLoggedIn && showAuthButton"
                 :to="{ name: '/welcome/' }"
               >
                 <ZKButton
@@ -91,7 +93,7 @@ const { profileData } = storeToRefs(useUserStore());
 
 const { showMobileDrawer, drawerBehavior } = storeToRefs(useNavigationStore());
 
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isLoggedIn, isGuestOrLoggedIn } = storeToRefs(useAuthenticationStore());
 
 const showAuthButton = ref(false);
 

--- a/services/agora/src/components/poll/PollWrapper.vue
+++ b/services/agora/src/components/poll/PollWrapper.vue
@@ -193,32 +193,28 @@ function showVoteInterface() {
 
 async function clickedVotingOption(selectedIndex: number, event: MouseEvent) {
   if (currentDisplayMode.value === DisplayModes.Results) {
-    return
+    return;
   }
-    event.stopPropagation();
+  event.stopPropagation();
 
-    if (props.loginRequiredToParticipate && !isLoggedIn.value) {
+  if (props.loginRequiredToParticipate && !isLoggedIn.value) {
     showLoginDialog.value = true;
     return;
   }
-    const response = await backendPollApi.submitPollResponse(
-      selectedIndex,
-      props.postSlugId
-    );
+  const response = await backendPollApi.submitPollResponse(
+    selectedIndex,
+    props.postSlugId
+  );
   // TODO: refactor backend to send error and reason if any, and react appropriately
   // and eventual change in state (isGuest etc)
-    if (response == true) {
+  if (response == true) {
     // TODO: refactor because there arep potentially redundant requests (loadPostData inside updateAuthState)
     await updateAuthState({ partialLoginStatus: { isKnown: true } });
-      await Promise.all([
-          loadPostData(false),
-          fetchUserPollResponseData(true),
-        ]);
-      incrementLocalPollIndex(selectedIndex);
-      totalVoteCount.value += 1;
-      } else {
-      showLoginDialog.value = true;
-    }
+    await Promise.all([loadPostData(false), fetchUserPollResponseData(true)]);
+    incrementLocalPollIndex(selectedIndex);
+    totalVoteCount.value += 1;
+  } else {
+    showLoginDialog.value = true;
   }
 }
 

--- a/services/agora/src/components/post/PostDetails.vue
+++ b/services/agora/src/components/post/PostDetails.vue
@@ -80,6 +80,10 @@
                 class="pollContainer"
               >
                 <PollWrapper
+                  :login-required-to-participate="
+                    extendedPostData.metadata.isIndexed ||
+                    extendedPostData.metadata.isLoginRequired
+                  "
                   :poll-options="extendedPostData.payload.poll"
                   :post-slug-id="extendedPostData.metadata.conversationSlugId"
                   :user-response="extendedPostData.interaction"

--- a/services/agora/src/components/post/views/CommentActionOptions.vue
+++ b/services/agora/src/components/post/views/CommentActionOptions.vue
@@ -52,7 +52,7 @@ const props = defineProps<{
   commentItem: OpinionItem;
 }>();
 
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 
 const webShare = useWebShare();
 
@@ -79,7 +79,7 @@ function onLoginConfirmationOk() {
 }
 
 function reportContentCallback() {
-  if (isAuthenticated.value) {
+  if (isLoggedIn.value) {
     showReportDialog.value = true;
   } else {
     showLoginDialog.value = true;

--- a/services/agora/src/components/post/views/CommentComposer.vue
+++ b/services/agora/src/components/post/views/CommentComposer.vue
@@ -86,7 +86,7 @@ const dummyInput = ref<HTMLInputElement>();
 
 const { saveOpinionDraft, getOpinionDraft, deleteOpinionDraft } =
   useNewOpinionDraftsStore();
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 
 const { createNewOpinionIntention, clearNewOpinionIntention } =
   useLoginIntentionStore();
@@ -174,7 +174,7 @@ function routeLeaveCallback() {
 function onBeforeRouteLeaveCallback(to: RouteLocationNormalized): boolean {
   if (characterCount.value > 0 && isLockedRoute()) {
     showExitDialog.value = true;
-    if (isAuthenticated.value) {
+    if (props.loginRequiredToParticipate ? isLoggedIn.value : true) {
       savedToRoute.value = to;
     }
     return false;
@@ -202,7 +202,7 @@ function checkWordCount() {
 }
 
 async function submitPostClicked() {
-  if (!isAuthenticated.value && props.loginRequiredToParticipate) {
+  if (!isLoggedIn.value && props.loginRequiredToParticipate) {
     showLoginDialog.value = true;
   } else {
     isSubmissionLoading.value = true;

--- a/services/agora/src/components/post/views/CommentSection.vue
+++ b/services/agora/src/components/post/views/CommentSection.vue
@@ -192,7 +192,7 @@ const { fetchCommentsForPost, fetchHiddenCommentsForPost } =
   useBackendCommentApi();
 const { fetchUserVotesForPostSlugIds } = useBackendVoteApi();
 
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isGuestOrLoggedIn } = storeToRefs(useAuthenticationStore());
 
 const isLoadingCommentItemsNew = ref<boolean>(true);
 const isLoadingCommentItemsDiscover = ref<boolean>(true);
@@ -326,7 +326,7 @@ async function resetRouteParams() {
 }
 
 async function fetchPersonalLikes() {
-  if (isAuthenticated.value) {
+  if (isGuestOrLoggedIn.value) {
     commentSlugIdLikedMap.value = new Map();
     const response = await fetchUserVotesForPostSlugIds([props.postSlugId]);
     if (response) {

--- a/services/agora/src/components/post/views/PostMetadata.vue
+++ b/services/agora/src/components/post/views/PostMetadata.vue
@@ -89,7 +89,7 @@ const route = useRoute();
 
 const { showPostOptionSelector } = useBottomSheet();
 
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 
 const { muteUser } = useBackendUserMuteApi();
 const { loadPostData } = usePostStore();
@@ -105,7 +105,7 @@ function onLoginConfirmationOk() {
 }
 
 function reportContentCallback() {
-  if (isAuthenticated.value) {
+  if (isLoggedIn.value) {
     showReportDialog.value = true;
   } else {
     showLoginDialog.value = true;

--- a/services/agora/src/components/post/views/UserIdentity.vue
+++ b/services/agora/src/components/post/views/UserIdentity.vue
@@ -18,6 +18,7 @@
     <div class="userNameTimeContainer">
       <div>
         <UserMetadata
+          :show-is-guest="false"
           :author-verified="authorVerified"
           :user-identity="userIdentity"
           :show-verified-text="showVerifiedText"

--- a/services/agora/src/components/post/views/UserMetadata.vue
+++ b/services/agora/src/components/post/views/UserMetadata.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="authorContainer">
-    <div class="usernameStyle">
-      {{ userIdentity }}
-    </div>
+    <Username
+      class="usernameStyle"
+      :username="userIdentity"
+      :show-is-guest="showIsGuest"
+    />
     <div v-if="authorVerified" class="verifiedMessage">
       <q-icon name="mdi-check-decagram" class="verifiedIconStyle" />
       <div v-if="showVerifiedText">ID verified</div>
@@ -11,7 +13,10 @@
 </template>
 
 <script setup lang="ts">
+import Username from "./Username.vue";
+
 defineProps<{
+  showIsGuest: boolean;
   userIdentity: string;
   authorVerified: boolean;
   showVerifiedText: boolean;

--- a/services/agora/src/components/post/views/Username.vue
+++ b/services/agora/src/components/post/views/Username.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    {{ username }}
+    <q-badge v-if="showIsGuest" align="middle">Guest</q-badge>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  showIsGuest: boolean;
+  username: string;
+}>();
+</script>
+
+<style lang="scss" scoped></style>

--- a/services/agora/src/pages/conversation/[postSlugId].vue
+++ b/services/agora/src/pages/conversation/[postSlugId].vue
@@ -45,7 +45,7 @@ import { onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 
 const { fetchPostBySlugId } = useBackendPostApi();
-const { isAuthenticated, isAuthInitialized } = storeToRefs(
+const { isGuestOrLoggedIn, isAuthInitialized } = storeToRefs(
   useAuthenticationStore()
 );
 const { emptyPost } = usePostStore();
@@ -85,7 +85,7 @@ async function loadData() {
   if (route.name == "/conversation/[postSlugId]") {
     const response = await fetchPostBySlugId(
       route.params.postSlugId,
-      isAuthenticated.value
+      isGuestOrLoggedIn.value
     );
     if (response != null) {
       postData.value = response;

--- a/services/agora/src/pages/conversation/create/index.vue
+++ b/services/agora/src/pages/conversation/create/index.vue
@@ -333,10 +333,7 @@ function onLoginCallback() {
 function onBeforeRouteLeaveCallback(to: RouteLocationNormalized): boolean {
   if (isPostEdited() && isLockedRoute()) {
     showExitDialog.value = true;
-    // TODO: not sure for this below if condition
-    if (isLoggedIn.value) {
-      savedToRoute.value = to;
-    }
+    savedToRoute.value = to;
     return false;
   } else {
     return true;

--- a/services/agora/src/pages/conversation/create/index.vue
+++ b/services/agora/src/pages/conversation/create/index.vue
@@ -264,7 +264,7 @@ import CloseButton from "src/components/navigation/buttons/CloseButton.vue";
 import DatePicker from "primevue/datepicker";
 import { useUserStore } from "src/stores/user";
 
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 
 const bodyWordCount = ref(0);
 const exceededBodyWordCount = ref(false);
@@ -333,7 +333,8 @@ function onLoginCallback() {
 function onBeforeRouteLeaveCallback(to: RouteLocationNormalized): boolean {
   if (isPostEdited() && isLockedRoute()) {
     showExitDialog.value = true;
-    if (isAuthenticated.value) {
+    // TODO: not sure for this below if condition
+    if (isLoggedIn.value) {
       savedToRoute.value = to;
     }
     return false;
@@ -395,7 +396,7 @@ function removePollOption(index: number) {
 }
 
 async function onSubmit() {
-  if (!isAuthenticated.value) {
+  if (!isLoggedIn.value) {
     showLoginDialog.value = true;
   } else {
     quasar.loading.show();

--- a/services/agora/src/pages/onboarding/step3-passport/index.vue
+++ b/services/agora/src/pages/onboarding/step3-passport/index.vue
@@ -160,7 +160,6 @@ import { useQRCode } from "@vueuse/integrations/useQRCode";
 import { useRouter } from "vue-router";
 import { onMounted, ref } from "vue";
 import ZKCard from "src/components/ui-library/ZKCard.vue";
-import { useAuthSetup } from "src/utils/auth/setup";
 import { DefaultApiAxiosParamCreator, DefaultApiFactory } from "src/api/api";
 import { useCommonApi, type KeyAction } from "src/utils/api/common";
 import { api } from "src/boot/axios";
@@ -173,6 +172,7 @@ import OnboardingLayout from "src/layouts/OnboardingLayout.vue";
 import RarimoImageExample from "src/components/onboarding/backgrounds/RarimoImageExample.vue";
 import WidthWrapper from "src/components/navigation/WidthWrapper.vue";
 import { useLoginIntentionStore } from "src/stores/loginIntention";
+import { useBackendAuthApi } from "src/utils/api/auth";
 
 const description =
   "RariMe is a ZK-powered identity wallet that converts your passport into an anonymous digital ID, stored on your device, so you can prove that you’re a unique human without sharing any personal data with anyone.";
@@ -191,7 +191,7 @@ const verificationLink = ref("");
 
 const qrcode = useQRCode(verificationLink);
 
-const { userLogin } = useAuthSetup();
+const { updateAuthState } = useBackendAuthApi();
 
 const rarimeStoreLink = ref("");
 
@@ -327,7 +327,10 @@ async function clickedVerifyButton() {
 async function completeVerification() {
   window.clearInterval(isDeviceLoggedInIntervalId);
   showNotifyMessage("Verification successful 🎉");
-  await userLogin();
+  await updateAuthState({
+    partialLoginStatus: { isLoggedIn: true },
+    forceRefresh: true,
+  });
 
   if (onboardingMode == "LOGIN") {
     await routeUserAfterLogin();

--- a/services/agora/src/pages/onboarding/step3-phone-2/index.vue
+++ b/services/agora/src/pages/onboarding/step3-phone-2/index.vue
@@ -86,7 +86,6 @@ import ZKButton from "src/components/ui-library/ZKButton.vue";
 import { useRouter } from "vue-router";
 import { useBackendPhoneVerification } from "src/utils/api/phoneVerification";
 import { type ApiV1AuthAuthenticatePost200Response } from "src/api";
-import { useAuthSetup } from "src/utils/auth/setup";
 import { onboardingFlowStore } from "src/stores/onboarding/flow";
 import type { KeyAction } from "src/utils/api/common";
 import { useNotify } from "src/utils/ui/notify";
@@ -96,6 +95,7 @@ import { getPlatform } from "src/utils/common";
 import DefaultImageExample from "src/components/onboarding/backgrounds/DefaultImageExample.vue";
 import OnboardingLayout from "src/layouts/OnboardingLayout.vue";
 import { useLoginIntentionStore } from "src/stores/loginIntention";
+import { useBackendAuthApi } from "src/utils/api/auth";
 
 const $q = useQuasar();
 let platform: "mobile" | "web" = "web";
@@ -110,7 +110,7 @@ const verificationCodeExpirySeconds = ref(0);
 
 const router = useRouter();
 
-const { userLogin } = useAuthSetup();
+const { updateAuthState } = useBackendAuthApi();
 
 const { requestCode, submitCode } = useBackendPhoneVerification();
 
@@ -142,7 +142,10 @@ async function nextButtonClicked() {
     });
     if (response.success) {
       showNotifyMessage("Verification successful 🎉");
-      await userLogin();
+      await updateAuthState({
+        partialLoginStatus: { isLoggedIn: true },
+        forceRefresh: true,
+      });
       if (onboardingMode == "LOGIN") {
         await routeUserAfterLogin();
       } else {
@@ -163,7 +166,10 @@ async function nextButtonClicked() {
           break;
         case "already_logged_in":
           showNotifyMessage("Verification successful 🎉");
-          await userLogin();
+          await updateAuthState({
+            partialLoginStatus: { isLoggedIn: true },
+            forceRefresh: true,
+          });
           if (onboardingMode == "LOGIN") {
             await routeUserAfterLogin();
           } else {
@@ -200,7 +206,10 @@ async function requestCodeClicked(
       switch (response.reason) {
         case "already_logged_in":
           showNotifyMessage("Verification successful 🎉");
-          await userLogin();
+          await updateAuthState({
+            partialLoginStatus: { isLoggedIn: true },
+            forceRefresh: true,
+          });
           if (onboardingMode == "LOGIN") {
             await routeUserAfterLogin();
           } else {

--- a/services/agora/src/pages/settings/index.vue
+++ b/services/agora/src/pages/settings/index.vue
@@ -21,21 +21,21 @@
     </template>
 
     <div class="container">
-      <div v-if="isAuthenticated">
+      <div v-if="isGuestOrLoggedIn">
         <SettingsSection :settings-item-list="accountSettings" />
       </div>
 
       <SettingsSection :settings-item-list="aboutSettings" />
 
-      <div v-if="isAuthenticated">
+      <div v-if="isGuestOrLoggedIn">
         <SettingsSection :settings-item-list="deleteAccountSettings" />
       </div>
 
-      <div v-if="isAuthenticated">
+      <div v-if="isLoggedIn">
         <SettingsSection :settings-item-list="logoutSettings" />
       </div>
 
-      <div v-if="isAuthenticated && profileData.isModerator">
+      <div v-if="isLoggedIn && profileData.isModerator">
         <SettingsSection :settings-item-list="moderatorSettings" />
       </div>
     </div>
@@ -53,9 +53,10 @@ import { useBackendAuthApi } from "src/utils/api/auth";
 import { SettingsInterface } from "src/utils/component/settings/settings";
 import { useDialog } from "src/utils/ui/dialog";
 import { useNotify } from "src/utils/ui/notify";
+import { computed } from "vue";
 import { useRouter } from "vue-router";
 
-const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+const { isGuestOrLoggedIn, isLoggedIn } = storeToRefs(useAuthenticationStore());
 const { profileData } = storeToRefs(useUserStore());
 
 const { showDeleteAccountDialog } = useDialog();
@@ -64,6 +65,10 @@ const { logoutFromServer, logoutDataCleanup, showLogoutMessageAndRedirect } =
   useBackendAuthApi();
 const router = useRouter();
 const { showNotifyMessage } = useNotify();
+
+const deleteAccountLabel = computed(() =>
+  isLoggedIn.value ? "Delete Account" : "Delete Guest Account"
+);
 
 async function logoutRequested() {
   try {
@@ -132,7 +137,7 @@ const moderatorSettings: SettingsInterface[] = [
 
 const deleteAccountSettings: SettingsInterface[] = [
   {
-    label: "Delete Account",
+    label: deleteAccountLabel.value,
     action: processDeleteAccount,
     style: "negative",
   },

--- a/services/agora/src/pages/user-profile.vue
+++ b/services/agora/src/pages/user-profile.vue
@@ -30,6 +30,7 @@
             <UserMetadata
               :author-verified="false"
               :user-identity="profileData.userName"
+              :show-is-guest="isGuest"
               :show-verified-text="true"
             />
           </div>
@@ -76,6 +77,7 @@ import { useAuthenticationStore } from "src/stores/authentication";
 const router = useRouter();
 
 const { loadUserProfile } = useUserStore();
+const { isGuest } = storeToRefs(useAuthenticationStore());
 
 interface CustomTab {
   route: keyof RouteNamedMap;

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -100,14 +100,6 @@ export class Dto {
             })
             .strict(),
     ]);
-    static getDeviceStatusResp = z
-        .object({
-            userId: zodUserId,
-            isLoggedIn: z.boolean(),
-            sessionExpiry: z.date(),
-        })
-        .strict()
-        .optional();
     static fetchFeedRequest = z
         .object({
             lastSlugId: zodSlugId.optional(),
@@ -453,7 +445,6 @@ export type AuthenticateResponse = z.infer<typeof Dto.authenticate200>;
 export type VerifyOtp200 = z.infer<typeof Dto.verifyOtp200>;
 export type VerifyOtpReqBody = z.infer<typeof Dto.verifyOtpReqBody>;
 export type IsLoggedInResponse = z.infer<typeof Dto.isLoggedInResponse>;
-export type GetDeviceStatusResp = z.infer<typeof Dto.getDeviceStatusResp>;
 export type PostFetch200 = z.infer<typeof Dto.postFetch200>;
 export type CreateNewConversationRequest = z.infer<
     typeof Dto.createNewConversationRequest

--- a/services/agora/src/shared/types/zod.ts
+++ b/services/agora/src/shared/types/zod.ts
@@ -745,28 +745,34 @@ export const zodGenLabelSummaryOutputLoose = z.object({
     clusters: zodGenLabelSummaryOutputClusterLoose,
 });
 
-export const zodGetDeviceStatusResponse = z.discriminatedUnion("isRegistered", [
-    z.object({
-        isRegistered: z.literal(false),
-    }),
-    z.object({
-        isRegistered: z.literal(true),
+const zodIsKnownTrueLoginStatus = z
+    .object({
+        isKnown: z.literal(true),
+        isRegistered: z.boolean(),
         isLoggedIn: z.boolean(),
-        isVerified: z.boolean(),
-        userId: z.string(),
-    }),
+    })
+    .strict();
+
+const zodIsKnownTrueLoginStatusExtended = zodIsKnownTrueLoginStatus.extend({
+    userId: z.string(),
+});
+
+const zodIsKnownFalseLoginStatus = z.object({
+    isKnown: z.literal(false),
+    isRegistered: z.literal(false),
+    isLoggedIn: z.literal(false),
+});
+
+export const zodGetDeviceStatusResponse = z.discriminatedUnion("isKnown", [
+    zodIsKnownFalseLoginStatus,
+    zodIsKnownTrueLoginStatusExtended,
 ]);
 
-export const zodDeviceLoginStatus = z.enum([
-    "logged_in",
-    "unknown",
-    "unverified",
-    "logged_out",
+export const zodDeviceLoginStatus = z.discriminatedUnion("isKnown", [
+    zodIsKnownFalseLoginStatus,
+    zodIsKnownTrueLoginStatus,
 ]);
 
-export type GetDeviceStatusResponse = z.infer<
-    typeof zodGetDeviceStatusResponse
->;
 export type Device = z.infer<typeof zodDevice>;
 export type Devices = z.infer<typeof zodDevices>;
 export type ExtendedConversation = z.infer<typeof zodExtendedConversationData>;
@@ -833,3 +839,12 @@ export type GenLabelSummaryOutputClusterLoose = z.infer<
 >;
 export type OrganizationProperties = z.infer<typeof zodOrganization>;
 export type DeviceLoginStatus = z.infer<typeof zodDeviceLoginStatus>;
+export type DeviceLoginStatusExtended = z.infer<
+    typeof zodGetDeviceStatusResponse
+>;
+export type DeviceIsKnownTrueLoginStatus = z.infer<
+    typeof zodIsKnownTrueLoginStatus
+>;
+export type DeviceIsKnownTrueLoginStatusExtended = z.infer<
+    typeof zodIsKnownTrueLoginStatusExtended
+>;

--- a/services/agora/src/stores/authentication.ts
+++ b/services/agora/src/stores/authentication.ts
@@ -1,16 +1,83 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { DeviceLoginStatus } from "src/shared/types/zod";
+import { computed, ref } from "vue";
 
 export const useAuthenticationStore = defineStore("authentication", () => {
   const verificationPhoneNumber = ref("");
   const verificationDefaultCallingCode = ref("");
-  const isAuthenticated = ref(false);
+  const _loginStatus = ref<DeviceLoginStatus>({
+    isLoggedIn: false,
+    isRegistered: false,
+    isKnown: false,
+  });
+  const isRegistered = computed(() => _loginStatus.value.isRegistered);
+  const isKnown = computed(() => _loginStatus.value.isKnown);
+  const isGuest = computed(() => !isRegistered.value && isKnown.value); // there is no such thing as "logged-in" for guests
+  const isLoggedIn = computed(
+    () =>
+      // note that backend already enforces that loggedIn users must be registered
+      isRegistered.value && _loginStatus.value.isLoggedIn
+  );
+  const isGuestOrLoggedIn = computed(() => {
+    return isGuest.value || isLoggedIn.value;
+  });
+
+  // Function to safely update loginStatus
+  function setLoginStatus(status: Partial<DeviceLoginStatus>): {
+    newLoginStatus: DeviceLoginStatus;
+    oldLoginStatus: DeviceLoginStatus;
+    newIsGuestOrLoggedIn: boolean;
+    oldIsGuestOrLoggedIn: boolean;
+  } {
+    const oldLoginStatus = _loginStatus.value;
+    const oldIsGuestOrLoggedIn = isGuestOrLoggedIn.value;
+    if (status.isKnown === false) {
+      _loginStatus.value = {
+        isKnown: false,
+        isLoggedIn: false,
+        isRegistered: false,
+      };
+    } else if (
+      status.isKnown === true ||
+      _loginStatus.value.isKnown ||
+      status.isRegistered ||
+      status.isLoggedIn
+    ) {
+      _loginStatus.value = {
+        isKnown: true,
+        isLoggedIn: status.isLoggedIn ?? _loginStatus.value.isLoggedIn,
+        isRegistered: status.isLoggedIn
+          ? true
+          : (status.isRegistered ?? _loginStatus.value.isRegistered),
+      };
+    } else {
+      _loginStatus.value = {
+        isKnown: false,
+        isLoggedIn: false,
+        isRegistered: false,
+      };
+    }
+    console.log(
+      `Login status updated from input '${JSON.stringify(status)}' to '${JSON.stringify(_loginStatus.value)}'`
+    );
+    return {
+      newLoginStatus: _loginStatus.value,
+      oldLoginStatus: oldLoginStatus,
+      oldIsGuestOrLoggedIn: oldIsGuestOrLoggedIn,
+      newIsGuestOrLoggedIn: isGuestOrLoggedIn.value,
+    };
+  }
   const isAuthInitialized = ref(false);
 
   return {
-    isAuthenticated,
     verificationPhoneNumber,
     verificationDefaultCallingCode,
+    isKnown,
+    isRegistered,
+    isLoggedIn,
+    isGuest,
+    isGuestOrLoggedIn,
+    setLoginStatus,
     isAuthInitialized,
   };
 });

--- a/services/agora/src/stores/opinionScrollable.ts
+++ b/services/agora/src/stores/opinionScrollable.ts
@@ -13,7 +13,7 @@ export const useOpinionScrollableStore = defineStore(
 
     const hasMore = ref(true);
 
-    const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+    const { isLoggedIn } = storeToRefs(useAuthenticationStore());
     const { showNotifyMessage } = useNotify();
 
     function loadMore() {
@@ -87,7 +87,8 @@ export const useOpinionScrollableStore = defineStore(
         }
       }
 
-      if (!isAuthenticated.value) {
+      // TODO: not sure about this if
+      if (!isLoggedIn.value) {
         showNotifyMessage("This opinion has been removed by the moderators");
         return "discover";
       } else {

--- a/services/agora/src/stores/post.ts
+++ b/services/agora/src/stores/post.ts
@@ -74,7 +74,7 @@ export const usePostStore = defineStore("post", () => {
 
   const { loadUserProfile } = useUserStore();
 
-  const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+  const { isGuestOrLoggedIn } = storeToRefs(useAuthenticationStore());
 
   const hasPendingNewPosts = ref(false);
 
@@ -140,7 +140,7 @@ export const usePostStore = defineStore("post", () => {
       }
     }
 
-    const response = await fetchRecentPost(lastSlugId, isAuthenticated.value);
+    const response = await fetchRecentPost(lastSlugId, isGuestOrLoggedIn.value);
 
     if (response != null) {
       const internalDataList = composeInternalPostList(response.postDataList);
@@ -176,7 +176,7 @@ export const usePostStore = defineStore("post", () => {
   }
 
   async function hasNewPosts() {
-    const response = await fetchRecentPost(undefined, isAuthenticated.value);
+    const response = await fetchRecentPost(undefined, isGuestOrLoggedIn.value);
     if (response != null) {
       if (
         response.postDataList.length > 0 &&

--- a/services/agora/src/stores/user.ts
+++ b/services/agora/src/stores/user.ts
@@ -45,13 +45,13 @@ export const useUserStore = defineStore("user", () => {
       fetchUserComments(undefined),
     ]);
 
-    if (userProfile && userPosts && userComments) {
+    if (userProfile) {
       profileData.value = {
         activePostCount: userProfile.activePostCount,
         createdAt: new Date(userProfile.createdAt),
         userName: String(userProfile.username),
-        userPostList: userPosts,
-        userCommentList: userComments,
+        userPostList: userPosts ?? [],
+        userCommentList: userComments ?? [],
         isModerator: userProfile.isModerator,
         dataLoaded: true,
         organizationList: userProfile.organizationList,

--- a/services/agora/src/utils/api/account.ts
+++ b/services/agora/src/utils/api/account.ts
@@ -54,25 +54,15 @@ export function useBackendAccountApi() {
     }
   }
 
-  async function deleteUserAccount(): Promise<boolean> {
-    try {
-      const { url, options } =
-        await DefaultApiAxiosParamCreator().apiV1UserDeletePost();
-      const encodedUcan = await buildEncodedUcan(url, options);
-      await DefaultApiFactory(undefined, undefined, api).apiV1UserDeletePost({
-        headers: {
-          ...buildAuthorizationHeader(encodedUcan),
-        },
-      });
-      showNotifyMessage("Account deleted");
-      return true;
-    } catch (e) {
-      console.error(e);
-      showNotifyMessage(
-        "Failed to delete user account. Please contact support for further assistance."
-      );
-      return false;
-    }
+  async function deleteUserAccount(): Promise<void> {
+    const { url, options } =
+      await DefaultApiAxiosParamCreator().apiV1UserDeletePost();
+    const encodedUcan = await buildEncodedUcan(url, options);
+    await DefaultApiFactory(undefined, undefined, api).apiV1UserDeletePost({
+      headers: {
+        ...buildAuthorizationHeader(encodedUcan),
+      },
+    });
   }
 
   async function isUsernameInUse(username: string): Promise<boolean | null> {

--- a/services/agora/src/utils/api/auth.ts
+++ b/services/agora/src/utils/api/auth.ts
@@ -1,29 +1,29 @@
+import { api } from "boot/axios";
+import { storeToRefs } from "pinia";
+import { useQuasar } from "quasar";
 import {
+  DefaultApiAxiosParamCreator,
+  DefaultApiFactory,
   type ApiV1AuthAuthenticatePost200Response,
   type ApiV1AuthAuthenticatePostRequest,
   type ApiV1AuthPhoneVerifyOtpPost200Response,
   type ApiV1AuthPhoneVerifyOtpPostRequest,
-  DefaultApiAxiosParamCreator,
-  DefaultApiFactory,
 } from "src/api";
-import { api } from "boot/axios";
-import { buildAuthorizationHeader, deleteDid } from "../crypto/ucan/operation";
-import { useCommonApi, type KeyAction } from "./common";
-import { useAuthenticationStore } from "src/stores/authentication";
-import { usePostStore } from "src/stores/post";
-import { useUserStore } from "src/stores/user";
-import { storeToRefs } from "pinia";
-import { useQuasar } from "quasar";
-import { getPlatform } from "../common";
-import { useNotify } from "../ui/notify";
-import { RouteMap, useRoute, useRouter } from "vue-router";
-import { useNotificationStore } from "src/stores/notification";
 import {
   DeviceLoginStatus,
   SupportedCountryCallingCode,
 } from "src/shared/types/zod";
-import { useNewPostDraftsStore } from "../../stores/newConversationDrafts";
+import { useAuthenticationStore } from "src/stores/authentication";
 import { useNewOpinionDraftsStore } from "src/stores/newOpinionDrafts";
+import { useNotificationStore } from "src/stores/notification";
+import { usePostStore } from "src/stores/post";
+import { useUserStore } from "src/stores/user";
+import { RouteMap, useRoute, useRouter } from "vue-router";
+import { useNewPostDraftsStore } from "../../stores/newConversationDrafts";
+import { getPlatform } from "../common";
+import { buildAuthorizationHeader, deleteDid } from "../crypto/ucan/operation";
+import { useNotify } from "../ui/notify";
+import { useCommonApi, type KeyAction } from "./common";
 
 interface SendSmsCodeProps {
   phoneNumber: string;
@@ -40,9 +40,8 @@ interface VerifyPhoneOtpProps {
 
 export function useBackendAuthApi() {
   const { buildEncodedUcan } = useCommonApi();
-  const { isAuthenticated, isAuthInitialized } = storeToRefs(
-    useAuthenticationStore()
-  );
+  const authStore = useAuthenticationStore();
+  const { isAuthInitialized } = storeToRefs(authStore);
   const { loadPostData } = usePostStore();
   const { loadUserProfile, clearProfileData } = useUserStore();
   const { loadNotificationData } = useNotificationStore();
@@ -106,7 +105,7 @@ export function useBackendAuthApi() {
     return response.data;
   }
 
-  async function deviceIsLoggedIn(): Promise<DeviceLoginStatus> {
+  async function getDeviceLoginStatus(): Promise<DeviceLoginStatus> {
     const { url, options } =
       await DefaultApiAxiosParamCreator().apiV1AuthCheckLoginStatusPost();
     const encodedUcan = await buildEncodedUcan(url, options);
@@ -119,7 +118,7 @@ export function useBackendAuthApi() {
         ...buildAuthorizationHeader(encodedUcan),
       },
     });
-    return resp.data.loggedInStatus;
+    return resp.data.loggedInStatus as DeviceLoginStatus;
     //NOTE: DO NOT return false on error! You would wipe out the user session at the first backend interruption.
   }
 
@@ -147,17 +146,27 @@ export function useBackendAuthApi() {
     ]);
   }
 
-  async function initializeAuthState() {
+  // update the global state according to the change in login status
+  async function updateAuthState({
+    partialLoginStatus,
+    forceRefresh = false,
+  }: {
+    partialLoginStatus: Partial<DeviceLoginStatus>;
+    forceRefresh?: boolean;
+  }) {
     try {
-      const deviceLoginStatus = await deviceIsLoggedIn();
-      if (deviceLoginStatus === "logged_in") {
-        isAuthenticated.value = true;
-        await loadAuthenticatedModules();
-      } else {
-        await logoutDataCleanup({
-          doDeleteKeypair: deviceLoginStatus === "logged_out",
-        });
-
+      const {
+        oldLoginStatus,
+        newLoginStatus,
+        oldIsGuestOrLoggedIn,
+        newIsGuestOrLoggedIn,
+      } = authStore.setLoginStatus(partialLoginStatus);
+      if (
+        (oldLoginStatus.isKnown !== newLoginStatus.isKnown || forceRefresh) &&
+        newLoginStatus.isKnown == false
+      ) {
+        console.log("Cleaning data from detecting change to unknown device");
+        await logoutDataCleanup({ doDeleteKeypair: false });
         setTimeout(async function () {
           const needRedirect = needRedirectUnauthenticatedUser();
           if (needRedirect) {
@@ -166,12 +175,40 @@ export function useBackendAuthApi() {
             await loadPostData(false);
           }
         }, 500);
+        return;
       }
-    } catch (error) {
-      console.error("Error while initializing authentication state");
+
+      if (forceRefresh || oldIsGuestOrLoggedIn !== newIsGuestOrLoggedIn)
+        if (newIsGuestOrLoggedIn) {
+          console.log(
+            "Loading authenticated modules upon detecting new login or guest user"
+          );
+          await loadAuthenticatedModules();
+        } else {
+          console.log("Cleaning data from logging out");
+          await logoutDataCleanup({ doDeleteKeypair: true });
+          setTimeout(async function () {
+            const needRedirect = needRedirectUnauthenticatedUser();
+            if (needRedirect) {
+              await showLogoutMessageAndRedirect();
+            } else {
+              await loadPostData(false);
+            }
+          }, 500);
+        }
+    } catch (e) {
+      console.error("Failed to update authentication state", e);
     } finally {
       isAuthInitialized.value = true;
     }
+  }
+
+  async function initializeAuthState() {
+    const deviceLoginStatus = await getDeviceLoginStatus();
+    await updateAuthState({
+      partialLoginStatus: deviceLoginStatus,
+      forceRefresh: true,
+    });
   }
 
   async function showLogoutMessageAndRedirect() {
@@ -222,7 +259,7 @@ export function useBackendAuthApi() {
     clearConversationDrafts();
     clearOpinionDrafts();
 
-    isAuthenticated.value = false;
+    authStore.setLoginStatus({ isKnown: false });
 
     await loadPostData(false);
     clearProfileData();
@@ -232,7 +269,8 @@ export function useBackendAuthApi() {
     sendSmsCode,
     verifyPhoneOtp,
     logoutFromServer,
-    deviceIsLoggedIn,
+    getDeviceLoginStatus,
+    updateAuthState,
     initializeAuthState,
     logoutDataCleanup,
     showLogoutMessageAndRedirect,

--- a/services/agora/src/utils/api/comment.ts
+++ b/services/agora/src/utils/api/comment.ts
@@ -19,7 +19,6 @@ import {
 import { useNotify } from "../ui/notify";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { storeToRefs } from "pinia";
-import { CreateCommentResponse } from "src/shared/types/dto";
 import { useBackendAuthApi } from "./auth";
 
 export function useBackendCommentApi() {
@@ -182,23 +181,11 @@ export function useBackendCommentApi() {
       },
     });
 
-      if (!response.data.success) {
-        if (response.data.reason == "conversation_locked") {
-          showNotifyMessage(
-            "Cannot create opinion because the conversation is locked"
-          );
-          // TODO: manage that appropriately instead of returning undefined
-          return;
-        }
-      }
-      // TODO: properly manage errors in backend and return login status
+    if (response.data.success) {
+      // TODO: properly manage errors in backend and return login status to update to
       await updateAuthState({ partialLoginStatus: { isKnown: true } });
-      return response.data;
-    } catch (e) {
-      console.error(e);
-      showNotifyMessage("Failed to add opinion to the conversation");
-      return undefined;
     }
+    return response.data;
   }
 
   async function deleteCommentBySlugId(commentSlugId: string) {

--- a/services/agora/src/utils/auth/setup.ts
+++ b/services/agora/src/utils/auth/setup.ts
@@ -1,4 +1,3 @@
-import { storeToRefs } from "pinia";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { usePostStore } from "src/stores/post";
 import { useUserStore } from "src/stores/user";
@@ -6,10 +5,12 @@ import { useUserStore } from "src/stores/user";
 export function useAuthSetup() {
   const { loadPostData } = usePostStore();
   const { loadUserProfile } = useUserStore();
-  const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+  const authStore = useAuthenticationStore();
 
   async function userLogin() {
-    isAuthenticated.value = true;
+    authStore.setLoginStatus({
+      isLoggedIn: true,
+    });
     await loadPostData(false);
     await loadUserProfile();
   }

--- a/services/agora/src/utils/component/notification/menuRefresher.ts
+++ b/services/agora/src/utils/component/notification/menuRefresher.ts
@@ -5,12 +5,12 @@ import { useNotificationStore } from "src/stores/notification";
 import { watch } from "vue";
 
 export function useNotificationRefresher() {
-  const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+  const { isGuestOrLoggedIn } = storeToRefs(useAuthenticationStore());
   const { loadNotificationData } = useNotificationStore();
   const documentVisibility = useDocumentVisibility();
 
   watch(documentVisibility, async () => {
-    if (isAuthenticated.value && documentVisibility.value == "visible") {
+    if (isGuestOrLoggedIn.value && documentVisibility.value == "visible") {
       await loadNotificationData(false);
     }
   });

--- a/services/agora/src/utils/ui/bottomSheet.ts
+++ b/services/agora/src/utils/ui/bottomSheet.ts
@@ -21,7 +21,7 @@ export const useBottomSheet = () => {
   const { profileData } = storeToRefs(useUserStore());
   const { loadUserProfile } = useUserStore();
   const { loadPostData } = usePostStore();
-  const { isAuthenticated } = storeToRefs(useAuthenticationStore());
+  const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 
   interface QuasarAction {
     label: string;
@@ -46,7 +46,7 @@ export const useBottomSheet = () => {
       id: "report",
     });
 
-    if (profileData.value.userName != posterUserName && isAuthenticated.value) {
+    if (profileData.value.userName != posterUserName && isLoggedIn.value) {
       actionList.push({
         label: "Mute User",
         icon: "mdi-account-off",
@@ -129,7 +129,7 @@ export const useBottomSheet = () => {
       id: "report",
     });
 
-    if (profileData.value.userName != posterUserName && isAuthenticated.value) {
+    if (profileData.value.userName != posterUserName && isLoggedIn.value) {
       actionList.push({
         label: "Mute User",
         icon: "mdi-account-off",

--- a/services/agora/src/utils/ui/dialog.ts
+++ b/services/agora/src/utils/ui/dialog.ts
@@ -1,10 +1,10 @@
 import { useQuasar } from "quasar";
-import { useBackendAccountApi } from "../api/account";
+import { useNotify } from "./notify";
 
 export const useDialog = () => {
   const quasar = useQuasar();
+  const { showNotifyMessage } = useNotify();
 
-  const { deleteUserAccount } = useBackendAccountApi();
   function showReportDialog(itemName: "post" | "comment") {
     quasar.dialog({
       title: "Thank you for the report",
@@ -44,12 +44,11 @@ export const useDialog = () => {
       })
       .onOk(async (data) => {
         if (data == "DELETE") {
-          const isDeleted = await deleteUserAccount();
-          if (isDeleted) {
-            callbackSuccess();
-          }
+          callbackSuccess();
         } else {
-          console.log("cancel");
+          showNotifyMessage(
+            "Account deletion request failed. Try again later."
+          );
         }
       })
       .onCancel(() => {

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -26,12 +26,59 @@
                                     "type": "object",
                                     "properties": {
                                         "loggedInStatus": {
-                                            "type": "string",
-                                            "enum": [
-                                                "logged_in",
-                                                "unknown",
-                                                "unverified",
-                                                "logged_out"
+                                            "anyOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "isKnown": {
+                                                            "type": "boolean",
+                                                            "enum": [
+                                                                false
+                                                            ]
+                                                        },
+                                                        "isRegistered": {
+                                                            "type": "boolean",
+                                                            "enum": [
+                                                                false
+                                                            ]
+                                                        },
+                                                        "isLoggedIn": {
+                                                            "type": "boolean",
+                                                            "enum": [
+                                                                false
+                                                            ]
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "isKnown",
+                                                        "isRegistered",
+                                                        "isLoggedIn"
+                                                    ],
+                                                    "additionalProperties": false
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "isKnown": {
+                                                            "type": "boolean",
+                                                            "enum": [
+                                                                true
+                                                            ]
+                                                        },
+                                                        "isRegistered": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "isLoggedIn": {
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "isKnown",
+                                                        "isRegistered",
+                                                        "isLoggedIn"
+                                                    ],
+                                                    "additionalProperties": false
+                                                }
                                             ]
                                         }
                                     },

--- a/services/api/package.json
+++ b/services/api/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "build": "NODE_ENV=production rm -rf dist && tsc --sourceMap -p tsconfig.json",
         "start": "node --loader esm-module-alias/loader --no-warnings dist/index.js",
-        "start:dev": "tsx watch src/index.ts",
+        "start:dev": "tsx watch --trace-uncaught src/index.ts",
         "start:import": "tsx src/index.ts",
         "start:dev:capacitor": "MODE=capacitor tsx watch src/index.ts",
         "db:drop": "drizzle-kit drop",

--- a/services/api/src/service/rarimo.ts
+++ b/services/api/src/service/rarimo.ts
@@ -210,15 +210,16 @@ export async function verifyUserStatusAndAuthenticate({
 }: VerifyUserStatusProps): Promise<VerifyUserStatusAndAuthenticate200> {
     const now = nowZeroMs();
     // TODO: move this check to verifyUCAN directly in the controller:
-    const deviceStatus = await isLoggedInOrExistsAndAssociatedWithNoNullifier({
-        db,
-        didWrite,
-        now,
-    });
-    if (deviceStatus !== undefined) {
+    const badStatusReason =
+        await isLoggedInOrExistsAndAssociatedWithNoNullifier({
+            db,
+            didWrite,
+            now,
+        });
+    if (badStatusReason !== undefined) {
         return {
             success: false,
-            reason: deviceStatus,
+            reason: badStatusReason,
         };
     }
     const verifyUserStatusUrl = `/integrations/verificator-svc/light/private/verification-status/${didWrite}`;

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -100,14 +100,6 @@ export class Dto {
             })
             .strict(),
     ]);
-    static getDeviceStatusResp = z
-        .object({
-            userId: zodUserId,
-            isLoggedIn: z.boolean(),
-            sessionExpiry: z.date(),
-        })
-        .strict()
-        .optional();
     static fetchFeedRequest = z
         .object({
             lastSlugId: zodSlugId.optional(),
@@ -453,7 +445,6 @@ export type AuthenticateResponse = z.infer<typeof Dto.authenticate200>;
 export type VerifyOtp200 = z.infer<typeof Dto.verifyOtp200>;
 export type VerifyOtpReqBody = z.infer<typeof Dto.verifyOtpReqBody>;
 export type IsLoggedInResponse = z.infer<typeof Dto.isLoggedInResponse>;
-export type GetDeviceStatusResp = z.infer<typeof Dto.getDeviceStatusResp>;
 export type PostFetch200 = z.infer<typeof Dto.postFetch200>;
 export type CreateNewConversationRequest = z.infer<
     typeof Dto.createNewConversationRequest

--- a/services/api/src/shared/types/zod.ts
+++ b/services/api/src/shared/types/zod.ts
@@ -745,28 +745,34 @@ export const zodGenLabelSummaryOutputLoose = z.object({
     clusters: zodGenLabelSummaryOutputClusterLoose,
 });
 
-export const zodGetDeviceStatusResponse = z.discriminatedUnion("isRegistered", [
-    z.object({
-        isRegistered: z.literal(false),
-    }),
-    z.object({
-        isRegistered: z.literal(true),
+const zodIsKnownTrueLoginStatus = z
+    .object({
+        isKnown: z.literal(true),
+        isRegistered: z.boolean(),
         isLoggedIn: z.boolean(),
-        isVerified: z.boolean(),
-        userId: z.string(),
-    }),
+    })
+    .strict();
+
+const zodIsKnownTrueLoginStatusExtended = zodIsKnownTrueLoginStatus.extend({
+    userId: z.string(),
+});
+
+const zodIsKnownFalseLoginStatus = z.object({
+    isKnown: z.literal(false),
+    isRegistered: z.literal(false),
+    isLoggedIn: z.literal(false),
+});
+
+export const zodGetDeviceStatusResponse = z.discriminatedUnion("isKnown", [
+    zodIsKnownFalseLoginStatus,
+    zodIsKnownTrueLoginStatusExtended,
 ]);
 
-export const zodDeviceLoginStatus = z.enum([
-    "logged_in",
-    "unknown",
-    "unverified",
-    "logged_out",
+export const zodDeviceLoginStatus = z.discriminatedUnion("isKnown", [
+    zodIsKnownFalseLoginStatus,
+    zodIsKnownTrueLoginStatus,
 ]);
 
-export type GetDeviceStatusResponse = z.infer<
-    typeof zodGetDeviceStatusResponse
->;
 export type Device = z.infer<typeof zodDevice>;
 export type Devices = z.infer<typeof zodDevices>;
 export type ExtendedConversation = z.infer<typeof zodExtendedConversationData>;
@@ -833,3 +839,12 @@ export type GenLabelSummaryOutputClusterLoose = z.infer<
 >;
 export type OrganizationProperties = z.infer<typeof zodOrganization>;
 export type DeviceLoginStatus = z.infer<typeof zodDeviceLoginStatus>;
+export type DeviceLoginStatusExtended = z.infer<
+    typeof zodGetDeviceStatusResponse
+>;
+export type DeviceIsKnownTrueLoginStatus = z.infer<
+    typeof zodIsKnownTrueLoginStatus
+>;
+export type DeviceIsKnownTrueLoginStatusExtended = z.infer<
+    typeof zodIsKnownTrueLoginStatusExtended
+>;

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -99,14 +99,6 @@ export class Dto {
             })
             .strict(),
     ]);
-    static getDeviceStatusResp = z
-        .object({
-            userId: zodUserId,
-            isLoggedIn: z.boolean(),
-            sessionExpiry: z.date(),
-        })
-        .strict()
-        .optional();
     static fetchFeedRequest = z
         .object({
             lastSlugId: zodSlugId.optional(),
@@ -452,7 +444,6 @@ export type AuthenticateResponse = z.infer<typeof Dto.authenticate200>;
 export type VerifyOtp200 = z.infer<typeof Dto.verifyOtp200>;
 export type VerifyOtpReqBody = z.infer<typeof Dto.verifyOtpReqBody>;
 export type IsLoggedInResponse = z.infer<typeof Dto.isLoggedInResponse>;
-export type GetDeviceStatusResp = z.infer<typeof Dto.getDeviceStatusResp>;
 export type PostFetch200 = z.infer<typeof Dto.postFetch200>;
 export type CreateNewConversationRequest = z.infer<
     typeof Dto.createNewConversationRequest

--- a/services/shared/src/types/zod.ts
+++ b/services/shared/src/types/zod.ts
@@ -744,28 +744,34 @@ export const zodGenLabelSummaryOutputLoose = z.object({
     clusters: zodGenLabelSummaryOutputClusterLoose,
 });
 
-export const zodGetDeviceStatusResponse = z.discriminatedUnion("isRegistered", [
-    z.object({
-        isRegistered: z.literal(false),
-    }),
-    z.object({
-        isRegistered: z.literal(true),
+const zodIsKnownTrueLoginStatus = z
+    .object({
+        isKnown: z.literal(true),
+        isRegistered: z.boolean(),
         isLoggedIn: z.boolean(),
-        isVerified: z.boolean(),
-        userId: z.string(),
-    }),
+    })
+    .strict();
+
+const zodIsKnownTrueLoginStatusExtended = zodIsKnownTrueLoginStatus.extend({
+    userId: z.string(),
+});
+
+const zodIsKnownFalseLoginStatus = z.object({
+    isKnown: z.literal(false),
+    isRegistered: z.literal(false),
+    isLoggedIn: z.literal(false),
+});
+
+export const zodGetDeviceStatusResponse = z.discriminatedUnion("isKnown", [
+    zodIsKnownFalseLoginStatus,
+    zodIsKnownTrueLoginStatusExtended,
 ]);
 
-export const zodDeviceLoginStatus = z.enum([
-    "logged_in",
-    "unknown",
-    "unverified",
-    "logged_out",
+export const zodDeviceLoginStatus = z.discriminatedUnion("isKnown", [
+    zodIsKnownFalseLoginStatus,
+    zodIsKnownTrueLoginStatus,
 ]);
 
-export type GetDeviceStatusResponse = z.infer<
-    typeof zodGetDeviceStatusResponse
->;
 export type Device = z.infer<typeof zodDevice>;
 export type Devices = z.infer<typeof zodDevices>;
 export type ExtendedConversation = z.infer<typeof zodExtendedConversationData>;
@@ -832,3 +838,12 @@ export type GenLabelSummaryOutputClusterLoose = z.infer<
 >;
 export type OrganizationProperties = z.infer<typeof zodOrganization>;
 export type DeviceLoginStatus = z.infer<typeof zodDeviceLoginStatus>;
+export type DeviceLoginStatusExtended = z.infer<
+    typeof zodGetDeviceStatusResponse
+>;
+export type DeviceIsKnownTrueLoginStatus = z.infer<
+    typeof zodIsKnownTrueLoginStatus
+>;
+export type DeviceIsKnownTrueLoginStatusExtended = z.infer<
+    typeof zodIsKnownTrueLoginStatusExtended
+>;


### PR DESCRIPTION
## Done in this PR

- introducing new auth mode: guest. isGuest == deviceIsKnown && !isNotRegistered
- note that isLoggedIn=true automatically assume isRegistered=true
- session expiration data in the deviceTable DB is completely unused for "guests". They are or they aren't.
- allowing guests to maintain a persistent session 
- revamping front and back auth functions to account for this new status

## Still TODO:
- [x] as a first guest user, posting multiple times fails
- "login" go to action in settings?
- "login" go to action in sidebar?
- **login/signup with guest account using existing phone number/passport nullifier should merge the guest account with the existing registered account.**

Not relevant to this PR particularly:
- profile should open on the tab where the user has data if any, else in conversation tab

