### PR TITLE
Fix the scroll position bug by removing the reset of query params in the conversation page

### DIFF
--- a/services/agora/src/components/post/views/CommentSection.vue
+++ b/services/agora/src/components/post/views/CommentSection.vue
@@ -146,7 +146,6 @@ import {
 import { storeToRefs } from "pinia";
 import CommentGroup from "./CommentGroup.vue";
 import { useNotify } from "src/utils/ui/notify";
-import { useRouter } from "vue-router";
 import { useRouteQuery } from "@vueuse/router";
 import CommentSortingSelector from "./CommentSortingSelector.vue";
 import { CommentFilterOptions } from "src/utils/component/opinion";
@@ -190,7 +189,6 @@ const commentFilterQuery = useRouteQuery("filter", "", {
 });
 
 const { showNotifyMessage } = useNotify();
-const router = useRouter();
 
 const { fetchCommentsForPost, fetchHiddenCommentsForPost } =
   useBackendCommentApi();
@@ -220,7 +218,6 @@ loadCommentFilterQuery();
 onMounted(async () => {
   await Promise.all([initializeData(), fetchPersonalLikes()]);
   updateInfiniteScrollingList(sortAlgorithm.value);
-  await resetRouteParams();
   isMounted = true;
 });
 
@@ -319,12 +316,6 @@ async function deletedComment() {
   emit("deleted");
   await initializeData();
   updateInfiniteScrollingList(sortAlgorithm.value);
-}
-
-async function resetRouteParams() {
-  await router.replace({
-    query: {},
-  });
 }
 
 async function fetchPersonalLikes() {


### PR DESCRIPTION
This patch removes the query reset to avoid triggering the router which means your browser history will always reset to the way you first landed on a conversation page (e.g., if you have query params for the filter or opinion ID).