### PR TITLE
Update the username field to use CSS word break if it is an organization

### DIFF
--- a/services/agora/src/components/post/views/UserIdentity.vue
+++ b/services/agora/src/components/post/views/UserIdentity.vue
@@ -22,6 +22,7 @@
           :author-verified="authorVerified"
           :user-identity="userIdentity"
           :show-verified-text="showVerifiedText"
+          :user-type="organizationImageUrl != '' ? 'organization' : 'normal'"
         />
       </div>
 

--- a/services/agora/src/components/post/views/UserMetadata.vue
+++ b/services/agora/src/components/post/views/UserMetadata.vue
@@ -2,6 +2,10 @@
   <div class="authorContainer">
     <Username
       class="usernameStyle"
+      :class="{
+        wordBreakNormal: userType == 'normal',
+        wordBreakOrganization: userType == 'organization',
+      }"
       :username="userIdentity"
       :show-is-guest="showIsGuest"
     />
@@ -20,6 +24,7 @@ defineProps<{
   userIdentity: string;
   authorVerified: boolean;
   showVerifiedText: boolean;
+  userType: "organization" | "normal";
 }>();
 </script>
 
@@ -28,7 +33,14 @@ defineProps<{
   font-size: 0.875rem;
   font-weight: 500;
   color: #0a0714;
+}
+
+.wordBreakNormal {
   word-break: break-all;
+}
+
+.wordBreakOrganization {
+  word-break: break-word;
 }
 
 .verifiedMessage {

--- a/services/agora/src/pages/user-profile.vue
+++ b/services/agora/src/pages/user-profile.vue
@@ -32,6 +32,7 @@
               :user-identity="profileData.userName"
               :show-is-guest="isGuest"
               :show-verified-text="true"
+              :user-type="'normal'"
             />
           </div>
         </div>

--- a/services/agora/src/utils/api/administrator/organization.ts
+++ b/services/agora/src/utils/api/administrator/organization.ts
@@ -197,15 +197,15 @@ export function useBackendAdministratorOrganizationApi() {
       });
 
       if (response.status == 200) {
-        showNotifyMessage("Updated user organization");
+        showNotifyMessage("Created user organization");
         return true;
       } else {
-        showNotifyMessage("Failed to set user organization");
+        showNotifyMessage("Failed to create user organization");
         return false;
       }
     } catch (e) {
       console.error(e);
-      showNotifyMessage("Failed to set user organization");
+      showNotifyMessage("Failed to create user organization");
       return false;
     }
   }


### PR DESCRIPTION
Previously usernames are continuous so we had to use break-all for the names. Since organization names are spaced properly we will use break-word.

Example 1: Org with enough space so breaks down on a word level 
Example 2: Org without enough space so `awerawer` gets force breakdown on character level
Example 3: Standard username so always force breakdown

<img width="240" alt="Screenshot 2025-05-11 at 3 45 52 AM" src="https://github.com/user-attachments/assets/1f69ddd4-2619-457e-8cee-356724901bb0" />
