### PR TITLE
Add support for a weighted home feed algorithm based on conversation's freshness and engagements

### DIFF
--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -804,10 +804,10 @@ export interface ApiV1ConversationFetchRecentPost200Response {
     'conversationDataList': Array<ApiV1ConversationFetchRecentPost200ResponseConversationDataListInner>;
     /**
      * 
-     * @type {boolean}
+     * @type {Array<string>}
      * @memberof ApiV1ConversationFetchRecentPost200Response
      */
-    'reachedEndOfFeed': boolean;
+    'topConversationSlugIdList': Array<string>;
 }
 /**
  * 
@@ -1248,8 +1248,16 @@ export interface ApiV1ConversationFetchRecentPostRequest {
      * @type {string}
      * @memberof ApiV1ConversationFetchRecentPostRequest
      */
-    'lastSlugId'?: string;
+    'sortAlgorithm': ApiV1ConversationFetchRecentPostRequestSortAlgorithmEnum;
 }
+
+export const ApiV1ConversationFetchRecentPostRequestSortAlgorithmEnum = {
+    Following: 'following',
+    New: 'new'
+} as const;
+
+export type ApiV1ConversationFetchRecentPostRequestSortAlgorithmEnum = typeof ApiV1ConversationFetchRecentPostRequestSortAlgorithmEnum[keyof typeof ApiV1ConversationFetchRecentPostRequestSortAlgorithmEnum];
+
 /**
  * 
  * @export
@@ -1778,6 +1786,19 @@ export interface ApiV1NotificationFetchPost200ResponseNotificationListInnerAnyOf
     'opinionSlugId': string;
 }
 /**
+ *
+ * @export
+ * @interface ApiV1NotificationFetchPostRequest
+ */
+export interface ApiV1NotificationFetchPostRequest {
+    /**
+     *
+     * @type {string}
+     * @memberof ApiV1NotificationFetchPostRequest
+     */
+    'lastSlugId'?: string;
+}
+/**
  * 
  * @export
  * @interface ApiV1OpinionCreatePost200Response
@@ -2093,6 +2114,38 @@ export const ApiV1ReportOpinionCreatePostRequestReportReasonEnum = {
 
 export type ApiV1ReportOpinionCreatePostRequestReportReasonEnum = typeof ApiV1ReportOpinionCreatePostRequestReportReasonEnum[keyof typeof ApiV1ReportOpinionCreatePostRequestReportReasonEnum];
 
+/**
+ *
+ * @export
+ * @interface ApiV1TopicGetAllTopicsPost200Response
+ */
+export interface ApiV1TopicGetAllTopicsPost200Response {
+    /**
+     *
+     * @type {Array<ApiV1TopicGetAllTopicsPost200ResponseTopicListInner>}
+     * @memberof ApiV1TopicGetAllTopicsPost200Response
+     */
+    'topicList': Array<ApiV1TopicGetAllTopicsPost200ResponseTopicListInner>;
+}
+/**
+ *
+ * @export
+ * @interface ApiV1TopicGetAllTopicsPost200ResponseTopicListInner
+ */
+export interface ApiV1TopicGetAllTopicsPost200ResponseTopicListInner {
+    /**
+     *
+     * @type {string}
+     * @memberof ApiV1TopicGetAllTopicsPost200ResponseTopicListInner
+     */
+    'code': string;
+    /**
+     *
+     * @type {string}
+     * @memberof ApiV1TopicGetAllTopicsPost200ResponseTopicListInner
+     */
+    'name': string;
+}
 /**
  * 
  * @export
@@ -2994,11 +3047,13 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @param {ApiV1ConversationFetchRecentPostRequest} [apiV1ConversationFetchRecentPostRequest] 
+         * @param {ApiV1ConversationFetchRecentPostRequest} apiV1ConversationFetchRecentPostRequest
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1ConversationFetchRecentPost: async (apiV1ConversationFetchRecentPostRequest?: ApiV1ConversationFetchRecentPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        apiV1ConversationFetchRecentPost: async (apiV1ConversationFetchRecentPostRequest: ApiV1ConversationFetchRecentPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'apiV1ConversationFetchRecentPostRequest' is not null or undefined
+            assertParamExists('apiV1ConversationFetchRecentPost', 'apiV1ConversationFetchRecentPostRequest', apiV1ConversationFetchRecentPostRequest)
             const localVarPath = `/api/v1/conversation/fetch-recent`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3376,11 +3431,11 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @param {ApiV1ConversationFetchRecentPostRequest} [apiV1ConversationFetchRecentPostRequest] 
+         * @param {ApiV1NotificationFetchPostRequest} [apiV1NotificationFetchPostRequest]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1NotificationFetchPost: async (apiV1ConversationFetchRecentPostRequest?: ApiV1ConversationFetchRecentPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        apiV1NotificationFetchPost: async (apiV1NotificationFetchPostRequest?: ApiV1NotificationFetchPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/api/v1/notification/fetch`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -3404,7 +3459,7 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ConversationFetchRecentPostRequest, localVarRequestOptions, configuration)
+            localVarRequestOptions.data = serializeDataIfNeeded(apiV1NotificationFetchPostRequest, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -3828,6 +3883,39 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationOpinionWithdrawPostRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiV1TopicGetAllTopicsPost: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/api/v1/topic/get-all-topics`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -4326,11 +4414,11 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @param {ApiV1ConversationFetchRecentPostRequest} [apiV1ConversationFetchRecentPostRequest] 
+         * @param {ApiV1ConversationFetchRecentPostRequest} apiV1ConversationFetchRecentPostRequest
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest?: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationFetchRecentPost200Response>> {
+        async apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationFetchRecentPost200Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1ConversationFetchRecentPost']?.[localVarOperationServerIndex]?.url;
@@ -4445,12 +4533,12 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @param {ApiV1ConversationFetchRecentPostRequest} [apiV1ConversationFetchRecentPostRequest] 
+         * @param {ApiV1NotificationFetchPostRequest} [apiV1NotificationFetchPostRequest]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiV1NotificationFetchPost(apiV1ConversationFetchRecentPostRequest?: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1NotificationFetchPost200Response>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1NotificationFetchPost(apiV1ConversationFetchRecentPostRequest, options);
+        async apiV1NotificationFetchPost(apiV1NotificationFetchPostRequest?: ApiV1NotificationFetchPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1NotificationFetchPost200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1NotificationFetchPost(apiV1NotificationFetchPostRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1NotificationFetchPost']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -4584,6 +4672,17 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ReportOpinionFetchPost(apiV1ModerationOpinionWithdrawPostRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1ReportOpinionFetchPost']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         *
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiV1TopicGetAllTopicsPost(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1TopicGetAllTopicsPost200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1TopicGetAllTopicsPost(options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1TopicGetAllTopicsPost']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -4830,11 +4929,11 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @param {ApiV1ConversationFetchRecentPostRequest} [apiV1ConversationFetchRecentPostRequest] 
+         * @param {ApiV1ConversationFetchRecentPostRequest} apiV1ConversationFetchRecentPostRequest
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest?: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationFetchRecentPost200Response> {
+        apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationFetchRecentPost200Response> {
             return localVarFp.apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest, options).then((request) => request(axios, basePath));
         },
         /**
@@ -4919,12 +5018,12 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @param {ApiV1ConversationFetchRecentPostRequest} [apiV1ConversationFetchRecentPostRequest] 
+         * @param {ApiV1NotificationFetchPostRequest} [apiV1NotificationFetchPostRequest]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1NotificationFetchPost(apiV1ConversationFetchRecentPostRequest?: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1NotificationFetchPost200Response> {
-            return localVarFp.apiV1NotificationFetchPost(apiV1ConversationFetchRecentPostRequest, options).then((request) => request(axios, basePath));
+        apiV1NotificationFetchPost(apiV1NotificationFetchPostRequest?: ApiV1NotificationFetchPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1NotificationFetchPost200Response> {
+            return localVarFp.apiV1NotificationFetchPost(apiV1NotificationFetchPostRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -5023,6 +5122,14 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          */
         apiV1ReportOpinionFetchPost(apiV1ModerationOpinionWithdrawPostRequest: ApiV1ModerationOpinionWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1ReportConversationFetchPost200ResponseInner>> {
             return localVarFp.apiV1ReportOpinionFetchPost(apiV1ModerationOpinionWithdrawPostRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         *
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiV1TopicGetAllTopicsPost(options?: RawAxiosRequestConfig): AxiosPromise<ApiV1TopicGetAllTopicsPost200Response> {
+            return localVarFp.apiV1TopicGetAllTopicsPost(options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -5276,12 +5383,12 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @param {ApiV1ConversationFetchRecentPostRequest} [apiV1ConversationFetchRecentPostRequest] 
+     * @param {ApiV1ConversationFetchRecentPostRequest} apiV1ConversationFetchRecentPostRequest
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest?: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig) {
+    public apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1ConversationFetchRecentPost(apiV1ConversationFetchRecentPostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
@@ -5385,13 +5492,13 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @param {ApiV1ConversationFetchRecentPostRequest} [apiV1ConversationFetchRecentPostRequest] 
+     * @param {ApiV1NotificationFetchPostRequest} [apiV1NotificationFetchPostRequest]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DefaultApi
      */
-    public apiV1NotificationFetchPost(apiV1ConversationFetchRecentPostRequest?: ApiV1ConversationFetchRecentPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1NotificationFetchPost(apiV1ConversationFetchRecentPostRequest, options).then((request) => request(this.axios, this.basePath));
+    public apiV1NotificationFetchPost(apiV1NotificationFetchPostRequest?: ApiV1NotificationFetchPostRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiV1NotificationFetchPost(apiV1NotificationFetchPostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**
@@ -5512,6 +5619,16 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV1ReportOpinionFetchPost(apiV1ModerationOpinionWithdrawPostRequest: ApiV1ModerationOpinionWithdrawPostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1ReportOpinionFetchPost(apiV1ModerationOpinionWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     *
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DefaultApi
+     */
+    public apiV1TopicGetAllTopicsPost(options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiV1TopicGetAllTopicsPost(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/services/agora/src/components/feed/NavigationTabs.vue
+++ b/services/agora/src/components/feed/NavigationTabs.vue
@@ -1,0 +1,44 @@
+<template>
+  <div
+    class="textStyle"
+    :class="{
+      highlightTab: isHighlighted,
+      underlineTab: showUnderline && isHighlighted,
+    }"
+  >
+    {{ text }}
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  text: string;
+  isHighlighted: boolean;
+  showUnderline: boolean;
+}>();
+</script>
+
+<style lang="scss" scoped>
+.textStyle {
+  cursor: pointer;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
+  font-weight: 500;
+  color: #7d7a85;
+  user-select: none;
+}
+
+.highlightTab {
+  color: transparent;
+  background-image: $gradient-hero;
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.underlineTab {
+  border-bottom: 3px solid;
+  border-color: $primary;
+}
+</style>

--- a/services/agora/src/components/navigation/SideDrawer.vue
+++ b/services/agora/src/components/navigation/SideDrawer.vue
@@ -133,6 +133,20 @@ function initializeMenu() {
       height: 20,
     });
 
+    /*
+    settingItemList.value.push({
+      icon: "iconamoon:home-fill",
+      name: "Topics",
+      route: "/topics/",
+      matchRouteList: ["/topics/"],
+      requireAuth: false,
+      svgPath:
+        "M11 3C11 3 9.5 1 6 1C2.5 1 1 3 1 3V17C1 17 2.5 16 6 16C9.5 16 11 17 11 17M11 3V17M11 3C11 3 12.5 1 16 1C19.5 1 21 3 21 3V17C21 17 19.5 16 16 16C12.5 16 11 17 11 17",
+      width: 21,
+      height: 20,
+    });
+    */
+
     settingItemList.value.push({
       icon: "ion:notifications",
       name: "Dings",
@@ -187,8 +201,15 @@ async function enterRoute(routeName: keyof RouteMap, requireAuth: boolean) {
       await router.push({ name: "/settings/" });
     } else if (routeName == "/") {
       await router.push({ name: "/" });
+    } else if (routeName == "/topics/") {
+      await router.push({ name: "/topics/" });
     } else {
-      console.error("Unknown route name: " + routeName);
+      console.error(
+        "Unknown route name when entering route in side bar: " + routeName
+      );
+      console.error(
+        "Unknown route name when entering route in side bar: " + routeName
+      );
     }
   }
 }

--- a/services/agora/src/components/navigation/header/DefaultMenuBar.vue
+++ b/services/agora/src/components/navigation/header/DefaultMenuBar.vue
@@ -108,7 +108,7 @@ function scrollToTop() {
 <style scoped lang="scss">
 .gridContainer {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 1fr;
   gap: 1rem 1rem;
   grid-template-areas: ". . .";
@@ -125,9 +125,7 @@ function scrollToTop() {
 }
 
 .container {
-  background-color: $app-background-color;
   padding: 0.5rem;
-  font: black;
 }
 
 .leftContainer {

--- a/services/agora/src/components/poll/PollWrapper.vue
+++ b/services/agora/src/components/poll/PollWrapper.vue
@@ -72,7 +72,10 @@
 <script setup lang="ts">
 import PollOption from "src/components/poll/PollOption.vue";
 import ZKButton from "../ui-library/ZKButton.vue";
-import { usePostStore, type DummyPollOptionFormat } from "src/stores/post";
+import {
+  useHomeFeedStore,
+  type DummyPollOptionFormat,
+} from "src/stores/homeFeed";
 import { onBeforeMount, ref, watch } from "vue";
 import { useBackendPollApi } from "src/utils/api/poll";
 import type { UserInteraction, PollList } from "src/shared/types/zod";
@@ -97,7 +100,7 @@ const dataLoaded = ref(false);
 
 const backendPollApi = useBackendPollApi();
 const { isLoggedIn } = storeToRefs(useAuthenticationStore());
-const { loadPostData } = usePostStore();
+const { loadPostData } = useHomeFeedStore();
 const { updateAuthState } = useBackendAuthApi();
 
 const { createVotingIntention } = useLoginIntentionStore();
@@ -210,7 +213,7 @@ async function clickedVotingOption(selectedIndex: number, event: MouseEvent) {
   if (response == true) {
     // TODO: refactor because there arep potentially redundant requests (loadPostData inside updateAuthState)
     await updateAuthState({ partialLoginStatus: { isKnown: true } });
-    await Promise.all([loadPostData(false), fetchUserPollResponseData(true)]);
+    await Promise.all([loadPostData(), fetchUserPollResponseData(true)]);
     incrementLocalPollIndex(selectedIndex);
     totalVoteCount.value += 1;
   } else {

--- a/services/agora/src/components/post/views/CommentGroup.vue
+++ b/services/agora/src/components/post/views/CommentGroup.vue
@@ -15,7 +15,7 @@
       class="commentListFlex"
     >
       <ZKCard
-        v-if="aiSummary !== undefined"
+        v-if="mode === 'analysis' && aiSummary !== undefined"
         padding="1rem"
         class="commentItemBackground"
       >

--- a/services/agora/src/components/post/views/CommentGroup.vue
+++ b/services/agora/src/components/post/views/CommentGroup.vue
@@ -15,7 +15,7 @@
       class="commentListFlex"
     >
       <ZKCard
-        v-if="mode === 'analysis' && aiSummary !== undefined"
+        v-if="aiSummary !== undefined"
         padding="1rem"
         class="commentItemBackground"
       >

--- a/services/agora/src/components/post/views/PostMetadata.vue
+++ b/services/agora/src/components/post/views/PostMetadata.vue
@@ -65,7 +65,7 @@ import { ref } from "vue";
 import ReportContentDialog from "src/components/report/ReportContentDialog.vue";
 import { useRoute, useRouter } from "vue-router";
 import { useBackendUserMuteApi } from "src/utils/api/muteUser";
-import { usePostStore } from "src/stores/post";
+import { useHomeFeedStore } from "src/stores/homeFeed";
 import UserIdentity from "./UserIdentity.vue";
 import PreLoginIntentionDialog from "src/components/authentication/intention/PreLoginIntentionDialog.vue";
 import { useAuthenticationStore } from "src/stores/authentication";
@@ -92,7 +92,7 @@ const { showPostOptionSelector } = useBottomSheet();
 const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 
 const { muteUser } = useBackendUserMuteApi();
-const { loadPostData } = usePostStore();
+const { loadPostData } = useHomeFeedStore();
 
 const showReportDialog = ref(false);
 
@@ -125,7 +125,7 @@ async function openUserReportsCallback() {
 async function muteUserCallback() {
   const isSuccessful = await muteUser(props.posterUserName, "mute");
   if (isSuccessful) {
-    await loadPostData(false);
+    await loadPostData();
   }
 }
 

--- a/services/agora/src/components/post/views/cluster/ClusterTabs.vue
+++ b/services/agora/src/components/post/views/cluster/ClusterTabs.vue
@@ -1,50 +1,45 @@
 <template>
-  <div class="tabStyle" :class="{ highlightTab: isHighlighted }">
-    <!--  TODO: proper icon color -->
-    <!-- :color="isHighlighted ? 'primary' : '#7D7A85'" -->
-    <ZKIcon
-      v-if="iconCode !== undefined"
-      :color="isHighlighted ? '#6b4eff' : '#7D7A85'"
-      :name="iconCode"
-      size="1rem"
-    />
-    <div v-if="text !== undefined" :style="{ paddingBottom: '3px' }">
-      {{ text }}
+  <div>
+    <div v-if="clusterMetadataList.length > 1" class="container">
+      <ZKTab
+        text="All"
+        :is-highlighted="model === 'all'"
+        @click="clickedTab('all')"
+      />
+
+      <div v-for="clusterItem in clusterMetadataList" :key="clusterItem.key">
+        <ZKTab
+          :text="
+            formatClusterLabel(clusterItem.key, false, clusterItem.aiLabel)
+          "
+          :is-highlighted="model === clusterItem.key"
+          @click="clickedTab(clusterItem.key)"
+        />
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import ZKIcon from "src/components/ui-library/ZKIcon.vue";
+import ZKTab from "src/components/ui-library/ZKTab.vue";
+import { ClusterMetadata, PolisKey } from "src/shared/types/zod";
+import { formatClusterLabel } from "src/utils/component/opinion";
+
+const model = defineModel({ required: true, type: String });
+
 defineProps<{
-  text?: string;
-  iconCode?: string;
-  isHighlighted: boolean;
+  clusterMetadataList: ClusterMetadata[];
 }>();
+
+function clickedTab(tabKey: PolisKey | "all") {
+  model.value = tabKey;
+}
 </script>
 
 <style lang="scss" scoped>
-.tabStyle {
+.container {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.3rem;
-  cursor: pointer;
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
-  padding-top: 0.5rem;
-  padding-bottom: 0.3rem;
-  font-weight: 500;
-  color: #7d7a85;
-  user-select: none;
-}
-
-.highlightTab {
-  border-bottom: 3px solid;
-  border-color: $primary;
-  color: transparent;
-  background-image: $gradient-hero;
-  -webkit-background-clip: text;
-  background-clip: text;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 </style>

--- a/services/agora/src/components/post/views/cluster/ClusterTabs.vue
+++ b/services/agora/src/components/post/views/cluster/ClusterTabs.vue
@@ -1,45 +1,50 @@
 <template>
-  <div>
-    <div v-if="clusterMetadataList.length > 1" class="container">
-      <ZKTab
-        text="All"
-        :is-highlighted="model === 'all'"
-        @click="clickedTab('all')"
-      />
-
-      <div v-for="clusterItem in clusterMetadataList" :key="clusterItem.key">
-        <ZKTab
-          :text="
-            formatClusterLabel(clusterItem.key, false, clusterItem.aiLabel)
-          "
-          :is-highlighted="model === clusterItem.key"
-          @click="clickedTab(clusterItem.key)"
-        />
-      </div>
+  <div class="tabStyle" :class="{ highlightTab: isHighlighted }">
+    <!--  TODO: proper icon color -->
+    <!-- :color="isHighlighted ? 'primary' : '#7D7A85'" -->
+    <ZKIcon
+      v-if="iconCode !== undefined"
+      :color="isHighlighted ? '#6b4eff' : '#7D7A85'"
+      :name="iconCode"
+      size="1rem"
+    />
+    <div v-if="text !== undefined" :style="{ paddingBottom: '3px' }">
+      {{ text }}
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import ZKTab from "src/components/ui-library/ZKTab.vue";
-import { ClusterMetadata, PolisKey } from "src/shared/types/zod";
-import { formatClusterLabel } from "src/utils/component/opinion";
-
-const model = defineModel({ required: true, type: String });
-
+import ZKIcon from "src/components/ui-library/ZKIcon.vue";
 defineProps<{
-  clusterMetadataList: ClusterMetadata[];
+  text?: string;
+  iconCode?: string;
+  isHighlighted: boolean;
 }>();
-
-function clickedTab(tabKey: PolisKey | "all") {
-  model.value = tabKey;
-}
 </script>
 
 <style lang="scss" scoped>
-.container {
+.tabStyle {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  cursor: pointer;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.3rem;
+  font-weight: 500;
+  color: #7d7a85;
+  user-select: none;
+}
+
+.highlightTab {
+  border-bottom: 3px solid;
+  border-color: $primary;
+  color: transparent;
+  background-image: $gradient-hero;
+  -webkit-background-clip: text;
+  background-clip: text;
 }
 </style>

--- a/services/agora/src/components/settings/MutedUsers.vue
+++ b/services/agora/src/components/settings/MutedUsers.vue
@@ -49,12 +49,12 @@ import { useTimeAgo } from "@vueuse/core";
 import UserAvatar from "src/components/account/UserAvatar.vue";
 import ZKCard from "src/components/ui-library/ZKCard.vue";
 import { UserMuteItem } from "src/shared/types/zod";
-import { usePostStore } from "src/stores/post";
+import { useHomeFeedStore } from "src/stores/homeFeed";
 import { useBackendUserMuteApi } from "src/utils/api/muteUser";
 import { ref, onMounted } from "vue";
 
 const { getMutedUsers, muteUser } = useBackendUserMuteApi();
-const { loadPostData } = usePostStore();
+const { loadPostData } = useHomeFeedStore();
 
 const userMuteItemList = ref<UserMuteItem[]>([]);
 const dataLoaded = ref(false);
@@ -71,7 +71,7 @@ async function loadMuteData() {
 async function removeMutedUser(targetUsername: string) {
   await muteUser(targetUsername, "unmute");
   await loadMuteData();
-  await loadPostData(false);
+  await loadPostData();
 }
 </script>
 

--- a/services/agora/src/components/ui-library/ZKTab.vue
+++ b/services/agora/src/components/ui-library/ZKTab.vue
@@ -40,11 +40,14 @@ defineProps<{
 }
 
 .highlightTab {
-  border-bottom: 3px solid;
-  border-color: $primary;
   color: transparent;
   background-image: $gradient-hero;
   -webkit-background-clip: text;
   background-clip: text;
+}
+
+.underlineTab {
+  border-bottom: 3px solid;
+  border-color: $primary;
 }
 </style>

--- a/services/agora/src/layouts/DrawerLayout.vue
+++ b/services/agora/src/layouts/DrawerLayout.vue
@@ -4,6 +4,7 @@
       <q-header
         :reveal="enableHeaderReveal"
         :model-value="props.generalProps.enableHeader"
+        class="headerStyle"
         @reveal="captureHeaderReval"
       >
         <slot name="header"></slot>
@@ -121,5 +122,9 @@ function captureHeaderReval(reveal: boolean) {
 .scrollContainer {
   width: 100%;
   height: 100%;
+}
+
+.headerStyle {
+  background-color: $app-background-color;
 }
 </style>

--- a/services/agora/src/pages/conversation/[postSlugId].vue
+++ b/services/agora/src/pages/conversation/[postSlugId].vue
@@ -23,7 +23,7 @@
       <WidthWrapper :enable="true">
         <PostDetails
           v-if="dataLoaded"
-          :key="postKey"
+          :key="postData.metadata.opinionCount"
           :extended-post-data="postData"
           :compact-mode="false"
           :skeleton-mode="false"
@@ -42,7 +42,7 @@ import DrawerLayout from "src/layouts/DrawerLayout.vue";
 import type { ExtendedConversation } from "src/shared/types/zod";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useLoginIntentionStore } from "src/stores/loginIntention";
-import { usePostStore } from "src/stores/post";
+import { useHomeFeedStore } from "src/stores/homeFeed";
 import { useBackendPostApi } from "src/utils/api/post";
 import { onMounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
@@ -51,14 +51,12 @@ const { fetchPostBySlugId } = useBackendPostApi();
 const { isGuestOrLoggedIn, isAuthInitialized } = storeToRefs(
   useAuthenticationStore()
 );
-const { emptyPost } = usePostStore();
+const { emptyPost } = useHomeFeedStore();
 const postData = ref<ExtendedConversation>(emptyPost);
 
 const dataLoaded = ref(false);
 
 const route = useRoute();
-
-const postKey = ref(0);
 
 const {
   clearVotingIntention,
@@ -108,7 +106,6 @@ async function loadData() {
 async function pullDownTriggered(done: () => void) {
   setTimeout(async () => {
     await loadData();
-    postKey.value = postKey.value + 1;
     done();
   }, 500);
 }

--- a/services/agora/src/pages/index.vue
+++ b/services/agora/src/pages/index.vue
@@ -112,6 +112,5 @@ function selectedTab(tab: HomeFeedSortOption) {
 
 .tabItem:hover {
   cursor: pointer;
-  background-color: white;
 }
 </style>

--- a/services/agora/src/pages/index.vue
+++ b/services/agora/src/pages/index.vue
@@ -91,22 +91,21 @@ function selectedTab(tab: HomeFeedSortOption) {
 }
 
 .tabCluster {
-  display: grid;
-  grid-template-columns: 50% 50%;
-  grid-template-rows: 1fr;
-  gap: 0px 0px;
-  grid-template-areas: ". .";
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
   font-weight: 600;
   font-size: 1rem;
-  padding-bottom: 1rem;
+  padding-bottom: 0.8rem;
 }
 
 .tabItem {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  min-width: 8rem;
   padding-top: 0.3rem;
   padding-bottom: 0.3rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
   border-radius: 15px;
 }
 

--- a/services/agora/src/pages/index.vue
+++ b/services/agora/src/pages/index.vue
@@ -74,6 +74,7 @@ const { currentHomeFeedTab } = storeToRefs(useHomeFeedStore());
 const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 
 function selectedTab(tab: HomeFeedSortOption) {
+  window.scrollTo({ top: 0, behavior: "smooth" });
   currentHomeFeedTab.value = tab;
 }
 </script>

--- a/services/agora/src/pages/index.vue
+++ b/services/agora/src/pages/index.vue
@@ -29,11 +29,6 @@
         <div class="tabCluster">
           <div class="tabItem" @click="selectedTab('following')">
             <ZKTab
-              class="commonTabBorder"
-              :class="{
-                selectedTab: currentHomeFeedTab === 'following',
-                unselectedTab: currentHomeFeedTab !== 'following',
-              }"
               :text="isLoggedIn ? 'Following' : 'Popular'"
               :is-highlighted="currentHomeFeedTab === 'following'"
               :show-underline="false"
@@ -42,11 +37,6 @@
 
           <div class="tabItem" @click="selectedTab('new')">
             <ZKTab
-              class="commonTabBorder"
-              :class="{
-                selectedTab: currentHomeFeedTab === 'new',
-                unselectedTab: currentHomeFeedTab !== 'new',
-              }"
               text="New"
               :is-highlighted="currentHomeFeedTab === 'new'"
               :show-underline="false"
@@ -108,34 +98,20 @@ function selectedTab(tab: HomeFeedSortOption) {
   grid-template-areas: ". .";
   font-weight: 600;
   font-size: 1rem;
+  padding-bottom: 1rem;
 }
 
 .tabItem {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-top: 0.5rem;
-  padding-bottom: 0.8rem;
-  margin-bottom: 0.5rem;
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
   border-radius: 15px;
 }
 
 .tabItem:hover {
   cursor: pointer;
-  background-color: white;
-}
-
-.commonTabBorder {
-  border-bottom: 3px solid;
-  padding-bottom: 8px;
-}
-
-.unselectedTab {
-  border-color: transparent;
-}
-
-.selectedTab {
-  border-color: $primary;
   background-color: white;
 }
 </style>

--- a/services/agora/src/pages/index.vue
+++ b/services/agora/src/pages/index.vue
@@ -24,6 +24,36 @@
           />
         </template>
       </DefaultMenuBar>
+
+      <WidthWrapper :enable="true">
+        <div class="tabCluster">
+          <div class="tabItem" @click="selectedTab('following')">
+            <ZKTab
+              class="commonTabBorder"
+              :class="{
+                selectedTab: currentHomeFeedTab === 'following',
+                unselectedTab: currentHomeFeedTab !== 'following',
+              }"
+              :text="isLoggedIn ? 'Following' : 'Popular'"
+              :is-highlighted="currentHomeFeedTab === 'following'"
+              :show-underline="false"
+            />
+          </div>
+
+          <div class="tabItem" @click="selectedTab('new')">
+            <ZKTab
+              class="commonTabBorder"
+              :class="{
+                selectedTab: currentHomeFeedTab === 'new',
+                unselectedTab: currentHomeFeedTab !== 'new',
+              }"
+              text="New"
+              :is-highlighted="currentHomeFeedTab === 'new'"
+              :show-underline="false"
+            />
+          </div>
+        </div>
+      </WidthWrapper>
     </template>
 
     <div class="container">
@@ -38,16 +68,27 @@
 import { storeToRefs } from "pinia";
 import CompactPostList from "src/components/feed/CompactPostList.vue";
 import DefaultMenuBar from "src/components/navigation/header/DefaultMenuBar.vue";
+import WidthWrapper from "src/components/navigation/WidthWrapper.vue";
 import NewPostButtonWrapper from "src/components/post/NewPostButtonWrapper.vue";
+import ZKTab from "src/components/ui-library/ZKTab.vue";
 import DrawerLayout from "src/layouts/DrawerLayout.vue";
+import { useAuthenticationStore } from "src/stores/authentication";
+import { HomeFeedSortOption, useHomeFeedStore } from "src/stores/homeFeed";
 import { useNavigationStore } from "src/stores/navigation";
 
 const agoraLogo = process.env.VITE_PUBLIC_DIR + "/images/icons/agora-wings.svg";
 
 const { drawerBehavior } = storeToRefs(useNavigationStore());
+
+const { currentHomeFeedTab } = storeToRefs(useHomeFeedStore());
+const { isLoggedIn } = storeToRefs(useAuthenticationStore());
+
+function selectedTab(tab: HomeFeedSortOption) {
+  currentHomeFeedTab.value = tab;
+}
 </script>
 
-<style scoped>
+<style scoped lang="scss">
 .container {
   display: flex;
   flex-direction: column;
@@ -57,5 +98,44 @@ const { drawerBehavior } = storeToRefs(useNavigationStore());
 .agoraLogoStyle {
   width: 2rem;
   height: 2rem;
+}
+
+.tabCluster {
+  display: grid;
+  grid-template-columns: 50% 50%;
+  grid-template-rows: 1fr;
+  gap: 0px 0px;
+  grid-template-areas: ". .";
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.tabItem {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-top: 0.5rem;
+  padding-bottom: 0.8rem;
+  margin-bottom: 0.5rem;
+  border-radius: 15px;
+}
+
+.tabItem:hover {
+  cursor: pointer;
+  background-color: white;
+}
+
+.commonTabBorder {
+  border-bottom: 3px solid;
+  padding-bottom: 8px;
+}
+
+.unselectedTab {
+  border-color: transparent;
+}
+
+.selectedTab {
+  border-color: $primary;
+  background-color: white;
 }
 </style>

--- a/services/agora/src/pages/moderate/conversation/[conversationSlugId]/index.vue
+++ b/services/agora/src/pages/moderate/conversation/[conversationSlugId]/index.vue
@@ -87,7 +87,7 @@ import {
   moderationActionPostsMapping,
   moderationReasonMapping,
 } from "src/utils/component/moderations";
-import { usePostStore } from "src/stores/post";
+import { useHomeFeedStore } from "src/stores/homeFeed";
 import DrawerLayout from "src/layouts/DrawerLayout.vue";
 import { useBackendPostApi } from "src/utils/api/post";
 import DefaultMenuBar from "src/components/navigation/header/DefaultMenuBar.vue";
@@ -101,7 +101,7 @@ const {
 const route = useRoute();
 const router = useRouter();
 
-const { loadPostData, emptyPost } = usePostStore();
+const { loadPostData, emptyPost } = useHomeFeedStore();
 const { fetchPostBySlugId } = useBackendPostApi();
 
 const DEFAULT_MODERATION_ACTION = "lock";
@@ -170,7 +170,7 @@ async function clickedWithdraw() {
     const isSuccessful = await cancelModerationPostReport(postSlugId);
     if (isSuccessful) {
       await initializeData();
-      await loadPostData(false);
+      await loadPostData();
       await redirectToPost();
     }
   } else {
@@ -188,7 +188,7 @@ async function clickedSubmit() {
     );
 
     if (isSuccessful) {
-      await loadPostData(false);
+      await loadPostData();
       await redirectToPost();
     }
   }

--- a/services/agora/src/pages/topic/[topicCode].vue
+++ b/services/agora/src/pages/topic/[topicCode].vue
@@ -1,0 +1,51 @@
+<template>
+  <DrawerLayout
+    :general-props="{
+      addGeneralPadding: false,
+      addBottomPadding: false,
+      enableHeader: true,
+      enableFooter: false,
+      reducedWidth: false,
+    }"
+  >
+    <template #header>
+      <DefaultMenuBar
+        :has-back-button="true"
+        :has-close-button="false"
+        :has-login-button="false"
+        :has-menu-button="false"
+        :fixed-height="true"
+      >
+        <template #middle> {{ topicCode }} </template>
+      </DefaultMenuBar>
+    </template>
+
+    <WidthWrapper :enable="true"> Load posts here </WidthWrapper>
+  </DrawerLayout>
+</template>
+
+<script setup lang="ts">
+import DefaultMenuBar from "src/components/navigation/header/DefaultMenuBar.vue";
+import WidthWrapper from "src/components/navigation/WidthWrapper.vue";
+import DrawerLayout from "src/layouts/DrawerLayout.vue";
+import { onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
+
+const route = useRoute();
+const topicCode = ref("");
+
+onMounted(async () => {
+  await loadData();
+});
+
+async function loadData() {
+  if (route.name == "/topic/[topicCode]") {
+    topicCode.value = route.params.topicCode;
+    console.log(topicCode.value);
+  } else {
+    return false;
+  }
+}
+</script>
+
+<style scoped lang="scss"></style>

--- a/services/agora/src/pages/topics/index.vue
+++ b/services/agora/src/pages/topics/index.vue
@@ -1,0 +1,65 @@
+<template>
+  <DrawerLayout
+    :general-props="{
+      addGeneralPadding: false,
+      addBottomPadding: true,
+      enableFooter: false,
+      enableHeader: true,
+      reducedWidth: true,
+    }"
+  >
+    <template #header>
+      <DefaultMenuBar
+        :has-back-button="true"
+        :has-close-button="false"
+        :has-login-button="false"
+        :has-menu-button="false"
+        :fixed-height="true"
+      >
+        <template #middle> Topics </template>
+      </DefaultMenuBar>
+    </template>
+
+    <div class="container">
+      <div class="topicContainer">
+        <div v-for="topic in fullTopicList" :key="topic.code">
+          <RouterLink
+            :to="{
+              name: '/topic/[topicCode]',
+              params: { topicCode: topic.code },
+            }"
+          >
+            <ZKButton
+              :button-type="'standardButton'"
+              :label="topic.name"
+              color="primary"
+            />
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+  </DrawerLayout>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import DefaultMenuBar from "src/components/navigation/header/DefaultMenuBar.vue";
+import ZKButton from "src/components/ui-library/ZKButton.vue";
+import DrawerLayout from "src/layouts/DrawerLayout.vue";
+import { useTopicStore } from "src/stores/topic";
+import { onMounted } from "vue";
+
+const { loadTopicList } = useTopicStore();
+const { fullTopicList } = storeToRefs(useTopicStore());
+
+onMounted(async () => {
+  await loadTopicList();
+});
+</script>
+
+<style scoped lang="scss">
+.topicContainer {
+  display: flex;
+  gap: 1rem;
+}
+</style>

--- a/services/agora/src/pages/user-profile.vue
+++ b/services/agora/src/pages/user-profile.vue
@@ -51,6 +51,7 @@
           <ZKTab
             :text="tabItem.label"
             :is-highlighted="currentTab === tabItem.value"
+            :show-underline="true"
             @click="selectedTab(tabItem.route)"
           />
         </div>

--- a/services/agora/src/shared/conversationLogic.ts
+++ b/services/agora/src/shared/conversationLogic.ts
@@ -44,7 +44,7 @@ export function isControversial({
     }
 }
 
-export function isPopular({
+export function isMajorityAgree({
     numAgrees,
     memberCount,
     threshold,
@@ -57,7 +57,7 @@ export function isPopular({
     }
 }
 
-export function isUnpopular({
+export function isMajorityDisagree({
     numDisagrees,
     memberCount,
     threshold,
@@ -77,8 +77,8 @@ export function isMajority({
     minVoters,
 }: ClassifyProps): boolean {
     if (
-        isPopular({ numAgrees, memberCount, threshold: minVoters }) ||
-        isUnpopular({ numDisagrees, memberCount, threshold: minVoters })
+        isMajorityAgree({ numAgrees, memberCount, threshold: minVoters }) ||
+        isMajorityDisagree({ numDisagrees, memberCount, threshold: minVoters })
     ) {
         return true;
     } else {

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -32,6 +32,8 @@ import {
     zodSupportedCountryCallingCode,
     zodOrganization,
     zodDeviceLoginStatus,
+    zodTopicObject,
+    zodFeedSortAlgorithm,
 } from "./zod.js";
 import { zodRarimoStatusAttributes } from "./zod.js";
 
@@ -102,12 +104,12 @@ export class Dto {
     ]);
     static fetchFeedRequest = z
         .object({
-            lastSlugId: zodSlugId.optional(),
+            sortAlgorithm: zodFeedSortAlgorithm,
         })
         .strict();
     static fetchFeedResponse = z.object({
         conversationDataList: z.array(zodExtendedConversationData),
-        reachedEndOfFeed: z.boolean(),
+        topConversationSlugIdList: z.array(zodSlugId), // used to determine if the feed is stale
     });
     static postFetchRequest = z
         .object({
@@ -399,6 +401,11 @@ export class Dto {
             organizationName: z.string(),
         })
         .strict();
+    static getAllTopicsResponse = z
+        .object({
+            topicList: z.array(zodTopicObject),
+        })
+        .strict();
     // this generates enum with openapigenerator without the verified state...
     // static verifyUserStatusAndAuthenticate200 = z.discriminatedUnion(
     //     "rarimoStatus",
@@ -498,3 +505,4 @@ export type GetOrganizationNamesByUsernameResponse = z.infer<
 export type GetAllOrganizationsResponse = z.infer<
     typeof Dto.getAllOrganizationsResponse
 >;
+export type GetAllTopicsResponse = z.infer<typeof Dto.getAllTopicsResponse>;

--- a/services/agora/src/shared/types/zod.ts
+++ b/services/agora/src/shared/types/zod.ts
@@ -28,6 +28,7 @@ export const zodModerationReason = z.enum([
     "sexual",
     "spam",
 ]);
+export const zodFeedSortAlgorithm = z.enum(["following", "new"]);
 export const zodConversationModerationAction = z.enum(["lock"]);
 export const zodOpinionModerationAction = z.enum(["move", "hide"]);
 export const zodPhoneNumber = z
@@ -191,6 +192,13 @@ export const zodRouteTarget = z
     .object({
         conversationSlugId: zodSlugId,
         opinionSlugId: zodSlugId,
+    })
+    .strict();
+
+export const zodTopicObject = z
+    .object({
+        code: z.string(),
+        name: z.string(),
     })
     .strict();
 
@@ -850,3 +858,5 @@ export type DeviceIsKnownTrueLoginStatus = z.infer<
 export type DeviceIsKnownTrueLoginStatusExtended = z.infer<
     typeof zodIsKnownTrueLoginStatusExtended
 >;
+export type ZodTopicObject = z.infer<typeof zodTopicObject>;
+export type FeedSortAlgorithm = z.infer<typeof zodFeedSortAlgorithm>;

--- a/services/agora/src/stores/profile.ts
+++ b/services/agora/src/stores/profile.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import {
   type DummyCommentFormat,
   type PossibleCommentRankingActions,
-} from "./post";
+} from "./homeFeed";
 
 export interface UserCommentHistoryitem {
   commentItem: DummyCommentFormat;

--- a/services/agora/src/stores/topic.ts
+++ b/services/agora/src/stores/topic.ts
@@ -1,0 +1,27 @@
+import { defineStore } from "pinia";
+import { ZodTopicObject } from "src/shared/types/zod";
+import { useCommonApi } from "src/utils/api/common";
+import { useBackendTopicApi } from "src/utils/api/topic";
+import { ref } from "vue";
+
+export const useTopicStore = defineStore("topic", () => {
+  const { getAllTopics } = useBackendTopicApi();
+  const { handleAxiosErrorStatusCodes } = useCommonApi();
+
+  const fullTopicList = ref<ZodTopicObject[]>([]);
+
+  async function loadTopicList() {
+    const response = await getAllTopics();
+
+    if (response.status == "success") {
+      fullTopicList.value = response.data.topicList;
+    } else {
+      handleAxiosErrorStatusCodes({
+        axiosErrorCode: response.code,
+        defaultMessage: "Error while trying to load topic list",
+      });
+    }
+  }
+
+  return { fullTopicList, loadTopicList };
+});

--- a/services/agora/src/utils/api/account.ts
+++ b/services/agora/src/utils/api/account.ts
@@ -11,7 +11,7 @@ import {
   useCommonApi,
 } from "./common";
 import { buildAuthorizationHeader } from "../crypto/ucan/operation";
-import { usePostStore } from "src/stores/post";
+import { useHomeFeedStore } from "src/stores/homeFeed";
 import { useUserStore } from "src/stores/user";
 
 export function useBackendAccountApi() {
@@ -21,7 +21,7 @@ export function useBackendAccountApi() {
     createRawAxiosRequestConfig,
   } = useCommonApi();
 
-  const { loadPostData } = usePostStore();
+  const { loadPostData } = useHomeFeedStore();
   const { loadUserProfile } = useUserStore();
 
   const { showNotifyMessage } = useNotify();
@@ -59,7 +59,7 @@ export function useBackendAccountApi() {
         params,
         createRawAxiosRequestConfig({ encodedUcan: encodedUcan })
       );
-      await loadPostData(false);
+      await loadPostData();
       await loadUserProfile();
       return {
         status: "success",

--- a/services/agora/src/utils/api/auth.ts
+++ b/services/agora/src/utils/api/auth.ts
@@ -16,7 +16,7 @@ import {
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useNewOpinionDraftsStore } from "src/stores/newOpinionDrafts";
 import { useNotificationStore } from "src/stores/notification";
-import { usePostStore } from "src/stores/post";
+import { useHomeFeedStore } from "src/stores/homeFeed";
 import { useUserStore } from "src/stores/user";
 import { useNewPostDraftsStore } from "../../stores/newConversationDrafts";
 import { getPlatform } from "../common";
@@ -51,7 +51,7 @@ export function useBackendAuthApi() {
   } = useCommonApi();
   const authStore = useAuthenticationStore();
   const { isAuthInitialized } = storeToRefs(authStore);
-  const { loadPostData } = usePostStore();
+  const { loadPostData } = useHomeFeedStore();
   const { loadUserProfile, clearProfileData } = useUserStore();
   const { loadNotificationData } = useNotificationStore();
   const { clearConversationDrafts } = useNewPostDraftsStore();
@@ -179,7 +179,7 @@ export function useBackendAuthApi() {
   async function loadAuthenticatedModules() {
     await Promise.all([
       loadUserProfile(),
-      loadPostData(false),
+      loadPostData(),
       loadNotificationData(false),
     ]);
   }
@@ -245,7 +245,7 @@ export function useBackendAuthApi() {
 
     authStore.setLoginStatus({ isKnown: false });
 
-    await loadPostData(false);
+    await loadPostData();
     clearProfileData();
 
     clearNotificationData();

--- a/services/agora/src/utils/api/notification.ts
+++ b/services/agora/src/utils/api/notification.ts
@@ -1,7 +1,7 @@
 import { api } from "boot/axios";
 import { buildAuthorizationHeader } from "../crypto/ucan/operation";
 import {
-  ApiV1ConversationFetchRecentPostRequest,
+  ApiV1NotificationFetchPostRequest,
   DefaultApiAxiosParamCreator,
   DefaultApiFactory,
 } from "src/api";
@@ -19,7 +19,7 @@ export function useBackendNotificationApi() {
     lastSlugId: string | undefined
   ): Promise<FetchNotificationsResponse | undefined> {
     try {
-      const params: ApiV1ConversationFetchRecentPostRequest = {
+      const params: ApiV1NotificationFetchPostRequest = {
         lastSlugId: lastSlugId,
       };
       const { url, options } =

--- a/services/agora/src/utils/api/topic.ts
+++ b/services/agora/src/utils/api/topic.ts
@@ -1,0 +1,36 @@
+import { DefaultApiFactory } from "src/api";
+import { api } from "src/boot/axios";
+import {
+  AxiosErrorResponse,
+  AxiosSuccessResponse,
+  useCommonApi,
+} from "./common";
+import { GetAllTopicsResponse } from "src/shared/types/dto";
+
+export function useBackendTopicApi() {
+  const { createRawAxiosRequestConfig, createAxiosErrorResponse } =
+    useCommonApi();
+
+  type GetAllTopicsSuccessResponse = AxiosSuccessResponse<GetAllTopicsResponse>;
+  type GetAllTopicsApiResponse =
+    | GetAllTopicsSuccessResponse
+    | AxiosErrorResponse;
+  async function getAllTopics(): Promise<GetAllTopicsApiResponse> {
+    try {
+      const response = await DefaultApiFactory(
+        undefined,
+        undefined,
+        api
+      ).apiV1TopicGetAllTopicsPost(createRawAxiosRequestConfig({}));
+
+      return {
+        status: "success",
+        data: response.data,
+      };
+    } catch (e) {
+      return createAxiosErrorResponse(e);
+    }
+  }
+
+  return { getAllTopics };
+}

--- a/services/agora/src/utils/ui/bottomSheet.ts
+++ b/services/agora/src/utils/ui/bottomSheet.ts
@@ -2,7 +2,7 @@ import { useQuasar } from "quasar";
 import { type Ref } from "vue";
 import { useBackendPostApi } from "../api/post";
 import { useUserStore } from "src/stores/user";
-import { usePostStore } from "src/stores/post";
+import { useHomeFeedStore } from "src/stores/homeFeed";
 import { useNotify } from "./notify";
 import { useRoute, useRouter } from "vue-router";
 import { storeToRefs } from "pinia";
@@ -20,7 +20,7 @@ export const useBottomSheet = () => {
 
   const { profileData } = storeToRefs(useUserStore());
   const { loadUserProfile } = useUserStore();
-  const { loadPostData } = usePostStore();
+  const { loadPostData } = useHomeFeedStore();
   const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 
   interface QuasarAction {
@@ -178,7 +178,7 @@ export const useBottomSheet = () => {
           const response = await deletePostBySlugId(postSlugId);
           if (response) {
             showNotifyMessage("Conversation deleted");
-            await loadPostData(false);
+            await loadPostData();
             await loadUserProfile();
             if (route.name == "/conversation/[postSlugId]") {
               await router.push({ name: "/" });

--- a/services/api/database/flyway/V0007__sturdy_rhino.sql
+++ b/services/api/database/flyway/V0007__sturdy_rhino.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "followed_topic" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "followed_topic_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"user_id" uuid NOT NULL,
+	"topic_id" integer NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "followed_topic_unique" UNIQUE("user_id","topic_id")
+);
+--> statement-breakpoint
+CREATE TABLE "topic" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "topic_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"code" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"score_weight" integer NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "topic_code_unique" UNIQUE("code"),
+	CONSTRAINT "topic_name_unique" UNIQUE("name"),
+	CONSTRAINT "topic_description_unique" UNIQUE("description")
+);
+--> statement-breakpoint
+ALTER TABLE "user_conversation_topic_preference" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "user_conversation_topic_preference" CASCADE;--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD COLUMN "conversation_id" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD COLUMN "topic_id" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "followed_topic" ADD CONSTRAINT "followed_topic_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "followed_topic" ADD CONSTRAINT "followed_topic_topic_id_topic_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."topic"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "followed_topic_index" ON "followed_topic" USING btree ("user_id");--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD CONSTRAINT "conversation_topic_conversation_id_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversation"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD CONSTRAINT "conversation_topic_topic_id_topic_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."topic"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "conversation_topic_index" ON "conversation_topic" USING btree ("conversation_id");--> statement-breakpoint
+ALTER TABLE "conversation_topic" DROP COLUMN "name";--> statement-breakpoint
+ALTER TABLE "conversation_topic" DROP COLUMN "code";--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD CONSTRAINT "conversation_topic_unique" UNIQUE("conversation_id","topic_id");

--- a/services/api/drizzle/0007_sturdy_rhino.sql
+++ b/services/api/drizzle/0007_sturdy_rhino.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "followed_topic" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "followed_topic_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"user_id" uuid NOT NULL,
+	"topic_id" integer NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "followed_topic_unique" UNIQUE("user_id","topic_id")
+);
+--> statement-breakpoint
+CREATE TABLE "topic" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "topic_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"code" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text NOT NULL,
+	"score_weight" integer NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "topic_code_unique" UNIQUE("code"),
+	CONSTRAINT "topic_name_unique" UNIQUE("name"),
+	CONSTRAINT "topic_description_unique" UNIQUE("description")
+);
+--> statement-breakpoint
+ALTER TABLE "user_conversation_topic_preference" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "user_conversation_topic_preference" CASCADE;--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD COLUMN "conversation_id" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD COLUMN "topic_id" integer NOT NULL;--> statement-breakpoint
+ALTER TABLE "followed_topic" ADD CONSTRAINT "followed_topic_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "followed_topic" ADD CONSTRAINT "followed_topic_topic_id_topic_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."topic"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "followed_topic_index" ON "followed_topic" USING btree ("user_id");--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD CONSTRAINT "conversation_topic_conversation_id_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversation"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD CONSTRAINT "conversation_topic_topic_id_topic_id_fk" FOREIGN KEY ("topic_id") REFERENCES "public"."topic"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "conversation_topic_index" ON "conversation_topic" USING btree ("conversation_id");--> statement-breakpoint
+ALTER TABLE "conversation_topic" DROP COLUMN "name";--> statement-breakpoint
+ALTER TABLE "conversation_topic" DROP COLUMN "code";--> statement-breakpoint
+ALTER TABLE "conversation_topic" ADD CONSTRAINT "conversation_topic_unique" UNIQUE("conversation_id","topic_id");

--- a/services/api/drizzle/meta/0007_snapshot.json
+++ b/services/api/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,4654 @@
+{
+  "id": "113a422e-da27-4cb8-9a00-c319cffbdba7",
+  "prevId": "583570c0-bb75-458b-a7d2-a9138d58a946",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_attempt_phone": {
+      "name": "auth_attempt_phone",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"auth_attempt_phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_content": {
+      "name": "conversation_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_proof_id": {
+          "name": "conversation_proof_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_content_conversation_id_conversation_id_fk": {
+          "name": "conversation_content_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_content",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_content_conversation_proof_id_conversation_proof_id_fk": {
+          "name": "conversation_content_conversation_proof_id_conversation_proof_id_fk",
+          "tableFrom": "conversation_content",
+          "tableTo": "conversation_proof",
+          "columnsFrom": [
+            "conversation_proof_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_content_poll_id_poll_id_fk": {
+          "name": "conversation_content_poll_id_poll_id_fk",
+          "tableFrom": "conversation_content",
+          "tableTo": "poll",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_content_conversation_proof_id_unique": {
+          "name": "conversation_content_conversation_proof_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_proof_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_moderation": {
+      "name": "conversation_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "conversation_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_moderation_conversation_id_conversation_id_fk": {
+          "name": "conversation_moderation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_moderation_author_id_user_id_fk": {
+          "name": "conversation_moderation_author_id_user_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_moderation_conversation_id_unique": {
+          "name": "conversation_moderation_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_proof": {
+      "name": "conversation_proof",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_proof_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_version": {
+          "name": "proof_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_proof_conversation_id_conversation_id_fk": {
+          "name": "conversation_proof_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_proof",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_proof_author_did_device_did_write_fk": {
+          "name": "conversation_proof_author_did_device_did_write_fk",
+          "tableFrom": "conversation_proof",
+          "tableTo": "device",
+          "columnsFrom": [
+            "author_did"
+          ],
+          "columnsTo": [
+            "did_write"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_report": {
+      "name": "conversation_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_id_idx": {
+          "name": "conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_report_conversation_id_conversation_id_fk": {
+          "name": "conversation_report_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_report_author_id_user_id_fk": {
+          "name": "conversation_report_author_id_user_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_polis_content_id": {
+          "name": "current_polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_conversation_at": {
+          "name": "index_conversation_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexed": {
+          "name": "is_indexed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_login_required": {
+          "name": "is_login_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "opinion_count": {
+          "name": "opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "conversation_createdAt_idx": {
+          "name": "conversation_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_author_id_user_id_fk": {
+          "name": "conversation_author_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_content_id_conversation_content_id_fk": {
+          "name": "conversation_current_content_id_conversation_content_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_polis_content_id_polis_content_id_fk": {
+          "name": "conversation_current_polis_content_id_polis_content_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "current_polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_slug_id_unique": {
+          "name": "conversation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_current_content_id_unique": {
+          "name": "conversation_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "conversation_current_polis_content_id_unique": {
+          "name": "conversation_current_polis_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_polis_content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_topic": {
+      "name": "conversation_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_topic_index": {
+          "name": "conversation_topic_index",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_topic_conversation_id_conversation_id_fk": {
+          "name": "conversation_topic_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_topic_topic_id_topic_id_fk": {
+          "name": "conversation_topic_topic_id_topic_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_topic_unique": {
+          "name": "conversation_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device": {
+      "name": "device",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id_proof_id": {
+          "name": "id_proof_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_expiry": {
+          "name": "session_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_user_id_user_id_fk": {
+          "name": "device_user_id_user_id_fk",
+          "tableFrom": "device",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "device_id_proof_id_id_proof_id_fk": {
+          "name": "device_id_proof_id_id_proof_id_fk",
+          "tableFrom": "device",
+          "tableTo": "id_proof",
+          "columnsFrom": [
+            "id_proof_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email": {
+      "name": "email",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_user_id_user_id_fk": {
+          "name": "email_user_id_user_id_fk",
+          "tableFrom": "email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followed_topic": {
+      "name": "followed_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "followed_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "followed_topic_index": {
+          "name": "followed_topic_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "followed_topic_user_id_user_id_fk": {
+          "name": "followed_topic_user_id_user_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "followed_topic_topic_id_topic_id_fk": {
+          "name": "followed_topic_topic_id_topic_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followed_topic_unique": {
+          "name": "followed_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.id_proof": {
+      "name": "id_proof",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "id_proof_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_version": {
+          "name": "proof_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "id_proof_user_id_user_id_fk": {
+          "name": "id_proof_user_id_user_id_fk",
+          "tableFrom": "id_proof",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_new_opinion": {
+      "name": "notification_new_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_new_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_new_opinion_notification_id_notification_id_fk": {
+          "name": "notification_new_opinion_notification_id_notification_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_author_id_user_id_fk": {
+          "name": "notification_new_opinion_author_id_user_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_opinion_id_opinion_id_fk": {
+          "name": "notification_new_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_conversation_id_conversation_id_fk": {
+          "name": "notification_new_opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_opinion_vote": {
+      "name": "notification_opinion_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_opinion_vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_votes": {
+          "name": "num_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_opinion_vote_notification_id_notification_id_fk": {
+          "name": "notification_opinion_vote_notification_id_notification_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_opinion_id_opinion_id_fk": {
+          "name": "notification_opinion_vote_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_conversation_id_conversation_id_fk": {
+          "name": "notification_opinion_vote_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_notification": {
+          "name": "user_idx_notification",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_createdAt_idx": {
+          "name": "notification_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_slug_id_unique": {
+          "name": "notification_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_content": {
+      "name": "opinion_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_proof_id": {
+          "name": "opinion_proof_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_content_opinion_id_opinion_id_fk": {
+          "name": "opinion_content_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "opinion_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_content_opinion_proof_id_opinion_proof_id_fk": {
+          "name": "opinion_content_opinion_proof_id_opinion_proof_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "opinion_proof",
+          "columnsFrom": [
+            "opinion_proof_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_moderation": {
+      "name": "opinion_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "opinion_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_moderation_opinion_id_opinion_id_fk": {
+          "name": "opinion_moderation_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_moderation_author_id_user_id_fk": {
+          "name": "opinion_moderation_author_id_user_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_moderation_opinion_id_unique": {
+          "name": "opinion_moderation_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_proof": {
+      "name": "opinion_proof",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_proof_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_version": {
+          "name": "proof_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_proof_opinion_id_opinion_id_fk": {
+          "name": "opinion_proof_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_proof",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_proof_author_did_device_did_write_fk": {
+          "name": "opinion_proof_author_did_device_did_write_fk",
+          "tableFrom": "opinion_proof",
+          "tableTo": "device",
+          "columnsFrom": [
+            "author_did"
+          ],
+          "columnsTo": [
+            "did_write"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_report": {
+      "name": "opinion_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_id_idx": {
+          "name": "opinion_id_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_report_opinion_id_opinion_id_fk": {
+          "name": "opinion_report_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_report_author_id_user_id_fk": {
+          "name": "opinion_report_author_id_user_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion": {
+      "name": "opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_priority": {
+          "name": "polis_priority",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_id": {
+          "name": "cluster_0_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_num_agrees": {
+          "name": "cluster_0_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_num_disagrees": {
+          "name": "cluster_0_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_id": {
+          "name": "cluster_1_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_num_agrees": {
+          "name": "cluster_1_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_num_disagrees": {
+          "name": "cluster_1_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_id": {
+          "name": "cluster_2_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_num_agrees": {
+          "name": "cluster_2_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_num_disagrees": {
+          "name": "cluster_2_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_id": {
+          "name": "cluster_3_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_num_agrees": {
+          "name": "cluster_3_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_num_disagrees": {
+          "name": "cluster_3_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_id": {
+          "name": "cluster_4_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_num_agrees": {
+          "name": "cluster_4_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_num_disagrees": {
+          "name": "cluster_4_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_id": {
+          "name": "cluster_5_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_num_agrees": {
+          "name": "cluster_5_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_num_disagrees": {
+          "name": "cluster_5_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_createdAt_idx": {
+          "name": "opinion_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_slugId_idx": {
+          "name": "opinion_slugId_idx",
+          "columns": [
+            {
+              "expression": "slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_author_id_user_id_fk": {
+          "name": "opinion_author_id_user_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_conversation_id_conversation_id_fk": {
+          "name": "opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_current_content_id_opinion_content_id_fk": {
+          "name": "opinion_current_content_id_opinion_content_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_0_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_0_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_0_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_1_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_1_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_2_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_2_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_3_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_3_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_3_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_4_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_4_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_4_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_5_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_5_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_5_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_slug_id_unique": {
+          "name": "opinion_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_polis_null": {
+          "name": "check_polis_null",
+          "value": "((\"opinion\".\"cluster_0_id\" IS NOT NULL AND \"opinion\".\"cluster_0_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_0_num_disagrees\" IS NOT NULL) OR (\"opinion\".\"cluster_0_id\" IS NULL AND \"opinion\".\"cluster_0_num_agrees\" IS NULL AND \"opinion\".\"cluster_0_num_disagrees\" IS NULL))\n                AND \n                ((\"opinion\".\"cluster_1_id\" IS NOT NULL AND \"opinion\".\"cluster_1_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_1_num_disagrees\" IS NOT NULL) OR (\"opinion\".\"cluster_1_id\" IS NULL AND \"opinion\".\"cluster_1_num_agrees\" IS NULL AND \"opinion\".\"cluster_1_num_disagrees\" IS NULL)) \n                AND \n                ((\"opinion\".\"cluster_2_id\" IS NOT NULL AND \"opinion\".\"cluster_2_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_2_num_disagrees\" IS NOT NULL) OR (\"opinion\".\"cluster_2_id\" IS NULL AND \"opinion\".\"cluster_2_num_agrees\" IS NULL AND \"opinion\".\"cluster_2_num_disagrees\" IS NULL))\n                AND \n                ((\"opinion\".\"cluster_3_id\" IS NOT NULL AND \"opinion\".\"cluster_3_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_3_num_disagrees\" IS NOT NULL) OR (\"opinion\".\"cluster_3_id\" IS NULL AND \"opinion\".\"cluster_3_num_agrees\" IS NULL AND \"opinion\".\"cluster_3_num_disagrees\" IS NULL)) \n                AND \n                ((\"opinion\".\"cluster_4_id\" IS NOT NULL AND \"opinion\".\"cluster_4_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_4_num_disagrees\" IS NOT NULL) OR (\"opinion\".\"cluster_4_id\" IS NULL AND \"opinion\".\"cluster_4_num_agrees\" IS NULL AND \"opinion\".\"cluster_4_num_disagrees\" IS NULL)) \n                AND \n                ((\"opinion\".\"cluster_5_id\" IS NOT NULL AND \"opinion\".\"cluster_5_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_5_num_disagrees\" IS NOT NULL) OR (\"opinion\".\"cluster_5_id\" IS NULL AND \"opinion\".\"cluster_5_num_agrees\" IS NULL AND \"opinion\".\"cluster_5_num_disagrees\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_full_image_path": {
+          "name": "is_full_image_path",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_name_unique": {
+          "name": "organization_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "organization_website_url_unique": {
+          "name": "organization_website_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phone": {
+      "name": "phone",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "phone_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "phone_user_id_user_id_fk": {
+          "name": "phone_user_id_user_id_fk",
+          "tableFrom": "phone",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster_opinion": {
+      "name": "polis_cluster_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_cluster_id": {
+          "name": "polis_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_slug_id": {
+          "name": "opinion_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_type": {
+          "name": "agreement_type",
+          "type": "vote_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentage_agreement": {
+          "name": "percentage_agreement",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_agreement": {
+          "name": "number_agreement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_repness": {
+          "name": "raw_repness",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_opinion_polis_cluster_id_polis_cluster_id_fk": {
+          "name": "polis_cluster_opinion_polis_cluster_id_polis_cluster_id_fk",
+          "tableFrom": "polis_cluster_opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "polis_cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_opinion_opinion_slug_id_opinion_slug_id_fk": {
+          "name": "polis_cluster_opinion_opinion_slug_id_opinion_slug_id_fk",
+          "tableFrom": "polis_cluster_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_slug_id"
+          ],
+          "columnsTo": [
+            "slug_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_perc_btwn_0_and_1": {
+          "name": "check_perc_btwn_0_and_1",
+          "value": "\"polis_cluster_opinion\".\"percentage_agreement\" BETWEEN 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster": {
+      "name": "polis_cluster",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_content_id": {
+          "name": "polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "polis_key_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_users": {
+          "name": "num_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_label": {
+          "name": "ai_label",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "math_center": {
+          "name": "math_center",
+          "type": "real[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_polis_content_id_polis_content_id_fk": {
+          "name": "polis_cluster_polis_content_id_polis_content_id_fk",
+          "tableFrom": "polis_cluster",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster_user": {
+      "name": "polis_cluster_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_content_id": {
+          "name": "polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polis_cluster_id": {
+          "name": "polis_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_user_polis_content_id_polis_content_id_fk": {
+          "name": "polis_cluster_user_polis_content_id_polis_content_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_user_polis_cluster_id_polis_cluster_id_fk": {
+          "name": "polis_cluster_user_polis_cluster_id_polis_cluster_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "polis_cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_user_user_id_user_id_fk": {
+          "name": "polis_cluster_user_user_id_user_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_belong_per_conv_at_a_time": {
+          "name": "unique_belong_per_conv_at_a_time",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polis_content_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polis_content": {
+      "name": "polis_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "math_tick": {
+          "name": "math_tick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_content_conversation_id_conversation_id_fk": {
+          "name": "polis_content_conversation_id_conversation_id_fk",
+          "tableFrom": "polis_content",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_response_content": {
+      "name": "poll_response_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "poll_response_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "poll_response_id": {
+          "name": "poll_response_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_response_proof_id": {
+          "name": "poll_response_proof_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_chosen": {
+          "name": "option_chosen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_response_content_poll_response_id_poll_response_id_fk": {
+          "name": "poll_response_content_poll_response_id_poll_response_id_fk",
+          "tableFrom": "poll_response_content",
+          "tableTo": "poll_response",
+          "columnsFrom": [
+            "poll_response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "poll_response_content_poll_response_proof_id_poll_response_proof_id_fk": {
+          "name": "poll_response_content_poll_response_proof_id_poll_response_proof_id_fk",
+          "tableFrom": "poll_response_content",
+          "tableTo": "poll_response_proof",
+          "columnsFrom": [
+            "poll_response_proof_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "poll_response_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "poll_response_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "poll_response_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_response_content_poll_response_proof_id_unique": {
+          "name": "poll_response_content_poll_response_proof_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poll_response_proof_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_response_proof": {
+      "name": "poll_response_proof",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "poll_response_proof_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_version": {
+          "name": "proof_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_response_proof_conversation_id_conversation_id_fk": {
+          "name": "poll_response_proof_conversation_id_conversation_id_fk",
+          "tableFrom": "poll_response_proof",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "poll_response_proof_author_did_device_did_write_fk": {
+          "name": "poll_response_proof_author_did_device_did_write_fk",
+          "tableFrom": "poll_response_proof",
+          "tableTo": "device",
+          "columnsFrom": [
+            "author_did"
+          ],
+          "columnsTo": [
+            "did_write"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_response": {
+      "name": "poll_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "poll_response_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_response_author_id_user_id_fk": {
+          "name": "poll_response_author_id_user_id_fk",
+          "tableFrom": "poll_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "poll_response_conversation_id_conversation_id_fk": {
+          "name": "poll_response_conversation_id_conversation_id_fk",
+          "tableFrom": "poll_response",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "poll_response_current_content_id_poll_response_content_id_fk": {
+          "name": "poll_response_current_content_id_poll_response_content_id_fk",
+          "tableFrom": "poll_response",
+          "tableTo": "poll_response_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_response_current_content_id_unique": {
+          "name": "poll_response_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "poll_response_author_id_conversation_id_unique": {
+          "name": "poll_response_author_id_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll": {
+      "name": "poll",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "poll_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option1": {
+          "name": "option1",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option2": {
+          "name": "option2",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option3": {
+          "name": "option3",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option4": {
+          "name": "option4",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option5": {
+          "name": "option5",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option6": {
+          "name": "option6",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option1_response": {
+          "name": "option1_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "option2_response": {
+          "name": "option2_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "option3_response": {
+          "name": "option3_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option4_response": {
+          "name": "option4_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option5_response": {
+          "name": "option5_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option6_response": {
+          "name": "option6_response",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poll_conversation_content_id_conversation_content_id_fk": {
+          "name": "poll_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "poll",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "poll_conversation_content_id_unique": {
+          "name": "poll_conversation_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_weight": {
+          "name": "score_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_code_unique": {
+          "name": "topic_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "topic_name_unique": {
+          "name": "topic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "topic_description_unique": {
+          "name": "topic_description_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language_preference": {
+      "name": "user_language_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_language_preference_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lang_id": {
+          "name": "lang_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_lang": {
+          "name": "user_idx_lang",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_language_preference_user_id_user_id_fk": {
+          "name": "user_language_preference_user_id_user_id_fk",
+          "tableFrom": "user_language_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_language_preference_lang_id_user_language_id_fk": {
+          "name": "user_language_preference_lang_id_user_language_id_fk",
+          "tableFrom": "user_language_preference",
+          "tableTo": "user_language",
+          "columnsFrom": [
+            "lang_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_unique_language": {
+          "name": "user_unique_language",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "lang_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_language": {
+      "name": "user_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_language_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mute_preference": {
+      "name": "user_mute_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_mute_preference_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_mute": {
+          "name": "user_idx_mute",
+          "columns": [
+            {
+              "expression": "source_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mute_preference_source_user_id_user_id_fk": {
+          "name": "user_mute_preference_source_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_mute_preference_target_user_id_user_id_fk": {
+          "name": "user_mute_preference_target_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_unique_mute": {
+          "name": "user_unique_mute",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_user_id",
+            "target_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organization_mapping": {
+      "name": "user_organization_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_organization_mapping_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_organization": {
+          "name": "user_idx_organization",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_organization_mapping_user_id_user_id_fk": {
+          "name": "user_organization_mapping_user_id_user_id_fk",
+          "tableFrom": "user_organization_mapping",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_organization_mapping_organization_id_organization_id_fk": {
+          "name": "user_organization_mapping_organization_id_organization_id_fk",
+          "tableFrom": "user_organization_mapping",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_orgaization_mapping": {
+          "name": "unique_user_orgaization_mapping",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_moderator": {
+          "name": "is_moderator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_anonymous": {
+          "name": "is_anonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_flagged_content": {
+          "name": "show_flagged_content",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active_conversation_count": {
+          "name": "active_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_conversation_count": {
+          "name": "total_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_content": {
+      "name": "vote_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_proof_id": {
+          "name": "vote_proof_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion_content_id": {
+          "name": "opinion_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "vote_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vote_content_vote_id_vote_id_fk": {
+          "name": "vote_content_vote_id_vote_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "vote",
+          "columnsFrom": [
+            "vote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_content_vote_proof_id_vote_proof_id_fk": {
+          "name": "vote_content_vote_proof_id_vote_proof_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "vote_proof",
+          "columnsFrom": [
+            "vote_proof_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_content_opinion_content_id_opinion_content_id_fk": {
+          "name": "vote_content_opinion_content_id_opinion_content_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "opinion_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_proof": {
+      "name": "vote_proof",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_proof_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "proof_type": {
+          "name": "proof_type",
+          "type": "proof_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_did": {
+          "name": "author_did",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof": {
+          "name": "proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proof_version": {
+          "name": "proof_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vote_proof_vote_id_vote_id_fk": {
+          "name": "vote_proof_vote_id_vote_id_fk",
+          "tableFrom": "vote_proof",
+          "tableTo": "vote",
+          "columnsFrom": [
+            "vote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_proof_author_did_device_did_write_fk": {
+          "name": "vote_proof_author_did_device_did_write_fk",
+          "tableFrom": "vote_proof",
+          "tableTo": "device",
+          "columnsFrom": [
+            "author_did"
+          ],
+          "columnsTo": [
+            "did_write"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vote_author_id_user_id_fk": {
+          "name": "vote_author_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_opinion_id_opinion_id_fk": {
+          "name": "vote_opinion_id_opinion_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_current_content_id_vote_content_id_fk": {
+          "name": "vote_current_content_id_vote_content_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "vote_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vote_author_id_opinion_id_unique": {
+          "name": "vote_author_id_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_id",
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zk_passport": {
+      "name": "zk_passport",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "zk_passport_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citizenship": {
+          "name": "citizenship",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sex": {
+          "name": "sex",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "zk_passport_user_id_user_id_fk": {
+          "name": "zk_passport_user_id_user_id_fk",
+          "tableFrom": "zk_passport",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zk_passport_nullifier_unique": {
+          "name": "zk_passport_nullifier_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nullifier"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_type": {
+      "name": "auth_type",
+      "schema": "public",
+      "values": [
+        "register",
+        "login_known_device",
+        "login_new_device"
+      ]
+    },
+    "public.conversation_moderation_action": {
+      "name": "conversation_moderation_action",
+      "schema": "public",
+      "values": [
+        "lock"
+      ]
+    },
+    "public.email_type": {
+      "name": "email_type",
+      "schema": "public",
+      "values": [
+        "primary",
+        "backup",
+        "secondary",
+        "other"
+      ]
+    },
+    "public.moderation_reason_enum": {
+      "name": "moderation_reason_enum",
+      "schema": "public",
+      "values": [
+        "misleading",
+        "antisocial",
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "opinion_vote",
+        "new_opinion"
+      ]
+    },
+    "public.opinion_moderation_action": {
+      "name": "opinion_moderation_action",
+      "schema": "public",
+      "values": [
+        "move",
+        "hide"
+      ]
+    },
+    "public.phone_country_code": {
+      "name": "phone_country_code",
+      "schema": "public",
+      "values": [
+        "AC",
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AO",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NU",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TA",
+        "TC",
+        "TD",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "XK",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW"
+      ]
+    },
+    "public.polis_key_enum": {
+      "name": "polis_key_enum",
+      "schema": "public",
+      "values": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5"
+      ]
+    },
+    "public.proof_type": {
+      "name": "proof_type",
+      "schema": "public",
+      "values": [
+        "creation",
+        "edit",
+        "deletion"
+      ]
+    },
+    "public.report_reason_enum": {
+      "name": "report_reason_enum",
+      "schema": "public",
+      "values": [
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam",
+        "misleading",
+        "antisocial"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "F",
+        "M",
+        "X"
+      ]
+    },
+    "public.vote_enum": {
+      "name": "vote_enum",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1746636272704,
       "tag": "0006_slim_gressill",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1746723515230,
+      "tag": "0007_sturdy_rhino",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -464,15 +464,22 @@
                             "schema": {
                                 "type": "object",
                                 "properties": {
-                                    "lastSlugId": {
+                                    "sortAlgorithm": {
                                         "type": "string",
-                                        "maxLength": 10
+                                        "enum": [
+                                            "following",
+                                            "new"
+                                        ]
                                     }
                                 },
+                                "required": [
+                                    "sortAlgorithm"
+                                ],
                                 "additionalProperties": false
                             }
                         }
-                    }
+                    },
+                    "required": true
                 },
                 "responses": {
                     "200": {
@@ -758,13 +765,17 @@
                                                 "additionalProperties": false
                                             }
                                         },
-                                        "reachedEndOfFeed": {
-                                            "type": "boolean"
+                                        "topConversationSlugIdList": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "maxLength": 10
+                                            }
                                         }
                                     },
                                     "required": [
                                         "conversationDataList",
-                                        "reachedEndOfFeed"
+                                        "topConversationSlugIdList"
                                     ],
                                     "additionalProperties": false
                                 }
@@ -4227,6 +4238,47 @@
                 "responses": {
                     "200": {
                         "description": "Default Response"
+                    }
+                }
+            }
+        },
+        "/api/v1/topic/get-all-topics": {
+            "post": {
+                "responses": {
+                    "200": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "topicList": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "code": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "code",
+                                                    "name"
+                                                ],
+                                                "additionalProperties": false
+                                            }
+                                        }
+                                    },
+                                    "required": [
+                                        "topicList"
+                                    ],
+                                    "additionalProperties": false
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -106,6 +106,7 @@ import type {
     DeviceIsKnownTrueLoginStatusExtended,
     DeviceLoginStatusExtended,
 } from "./shared/types/zod.js";
+import { getAllTopics } from "./service/topic.js";
 // import { Protocols, createLightNode } from "@waku/sdk";
 // import { WAKU_TOPIC_CREATE_POST } from "@/service/p2p.js";
 
@@ -777,15 +778,15 @@ server.after(() => {
 
                 return await feedService.fetchFeed({
                     db: db,
-                    lastSlugId: request.body.lastSlugId,
                     personalizationUserId: deviceStatus.userId,
                     baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
+                    sortAlgorithm: request.body.sortAlgorithm,
                 });
             } else {
                 return await feedService.fetchFeed({
                     db: db,
-                    lastSlugId: request.body.lastSlugId,
                     baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
+                    sortAlgorithm: request.body.sortAlgorithm,
                 });
             }
         },
@@ -2163,6 +2164,21 @@ server.after(() => {
             await markAllNotificationsAsRead({
                 db: db,
                 userId: deviceStatus.userId,
+            });
+        },
+    });
+
+    server.withTypeProvider<ZodTypeProvider>().route({
+        method: "POST",
+        url: `/api/${apiVersion}/topic/get-all-topics`,
+        schema: {
+            response: {
+                200: Dto.getAllTopicsResponse,
+            },
+        },
+        handler: async () => {
+            return await getAllTopics({
+                db: db,
             });
         },
     });

--- a/services/api/src/schema.ts
+++ b/services/api/src/schema.ts
@@ -635,6 +635,66 @@ export const userOrganizationMappingTable = pgTable(
     ],
 );
 
+export const conversationTopicTable = pgTable(
+    "conversation_topic",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        conversationId: integer("conversation_id")
+            .references(() => conversationTable.id)
+            .notNull(),
+        topicId: integer("topic_id")
+            .references(() => topicTable.id)
+            .notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (t) => [
+        index("conversation_topic_index").on(t.conversationId),
+        unique("conversation_topic_unique").on(t.conversationId, t.topicId),
+    ],
+);
+
+export const topicTable = pgTable("topic", {
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    code: text("code").unique().notNull(),
+    name: text("name").unique().notNull(),
+    description: text("description").unique().notNull(),
+    score_weight: integer("score_weight").notNull(),
+    createdAt: timestamp("created_at", {
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+});
+
+export const followedTopicTable = pgTable(
+    "followed_topic",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        userId: uuid("user_id")
+            .references(() => userTable.id)
+            .notNull(),
+        topicId: integer("topic_id")
+            .references(() => topicTable.id)
+            .notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (t) => [
+        index("followed_topic_index").on(t.userId),
+        unique("followed_topic_unique").on(t.userId, t.topicId),
+    ],
+);
+
 export const userMutePreferenceTable = pgTable(
     "user_mute_preference",
     {
@@ -692,41 +752,6 @@ export const userLanguageTable = pgTable("user_language", {
         .defaultNow()
         .notNull(),
 });
-
-export const conversationTopicTable = pgTable("conversation_topic", {
-    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-    name: text("name"),
-    code: text("code"),
-    createdAt: timestamp("created_at", {
-        mode: "date",
-        precision: 0,
-    })
-        .defaultNow()
-        .notNull(),
-});
-
-export const userConversationTopicPreferenceTable = pgTable(
-    "user_conversation_topic_preference",
-    {
-        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-        userId: uuid("user_id")
-            .references(() => userTable.id)
-            .notNull(),
-        conversationTagId: integer("conversation_tag_id")
-            .references(() => conversationTopicTable.id)
-            .notNull(),
-        createdAt: timestamp("created_at", {
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-    },
-    (t) => [
-        index("user_idx_topic").on(t.userId),
-        unique("user_unique_topic").on(t.userId, t.conversationTagId),
-    ],
-);
 
 export const organizationTable = pgTable("organization", {
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),

--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -284,6 +284,7 @@ export async function fetchPostBySlugId({
             excludeLockedPosts: false,
             removeMutedAuthors: false,
             baseImageServiceUrl,
+            sortAlgorithm: "new",
         });
 
         if (postData.size == 1) {

--- a/services/api/src/service/recommendationSystem.ts
+++ b/services/api/src/service/recommendationSystem.ts
@@ -1,0 +1,29 @@
+interface GetConversationEngagementScoreProps {
+    createdAt: Date;
+    opinionCount: number;
+    participantCount: number;
+}
+
+export function getConversationEngagementScore({
+    createdAt,
+    opinionCount,
+    participantCount,
+}: GetConversationEngagementScoreProps) {
+    // Scores place weights between 0.01 - 1.0 the higher value the higher impact
+    const weightCreatedAt = 0.2;
+    const weightOpinionCount = 0.6;
+    const weightParticipantCount = 0.4;
+
+    const now = new Date();
+    const ageInDays =
+        (now.getTime() - createdAt.getTime()) / (1000 * 60 * 60 * 24);
+
+    // Exponential functions for each variable
+    const scoreCreatedAt = Math.exp(-weightCreatedAt * ageInDays);
+    const scoreOpinionCount = Math.exp(weightOpinionCount * opinionCount);
+    const scoreParticipantCount = Math.exp(
+        weightParticipantCount * participantCount,
+    );
+
+    return scoreCreatedAt + scoreOpinionCount + scoreParticipantCount;
+}

--- a/services/api/src/service/topic.ts
+++ b/services/api/src/service/topic.ts
@@ -1,0 +1,55 @@
+import { topicTable } from "@/schema.js";
+import type { GetAllTopicsResponse } from "@/shared/types/dto.js";
+import { httpErrors } from "@fastify/sensible";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { ZodTopicObject } from "@/shared/types/zod.js";
+import { eq } from "drizzle-orm";
+
+interface MapTopicCodeToIdProps {
+    db: PostgresJsDatabase;
+    topicCode: string;
+}
+
+export async function mapTopicCodeToId({
+    db,
+    topicCode,
+}: MapTopicCodeToIdProps) {
+    const topicTableResponse = await db
+        .select({
+            id: topicTable.id,
+        })
+        .from(topicTable)
+        .where(eq(topicTable.code, topicCode));
+    if (topicTableResponse.length == 1) {
+        return topicTableResponse[0].id;
+    } else {
+        throw httpErrors.notFound("Failed to locate topic code: " + topicCode);
+    }
+}
+
+interface GetAllTopicsProps {
+    db: PostgresJsDatabase;
+}
+
+export async function getAllTopics({
+    db,
+}: GetAllTopicsProps): Promise<GetAllTopicsResponse> {
+    const topicTableResponse = await db
+        .select({
+            name: topicTable.name,
+            code: topicTable.code,
+        })
+        .from(topicTable);
+
+    const topicList: ZodTopicObject[] = [];
+    topicTableResponse.forEach((topicObject) => {
+        topicList.push({
+            code: topicObject.code,
+            name: topicObject.name,
+        });
+    });
+
+    return {
+        topicList: topicList,
+    };
+}

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -381,6 +381,7 @@ export async function getUserPosts({
                 excludeLockedPosts: false,
                 removeMutedAuthors: false,
                 baseImageServiceUrl,
+                sortAlgorithm: "new",
             });
 
         return conversations;

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -32,6 +32,8 @@ import {
     zodSupportedCountryCallingCode,
     zodOrganization,
     zodDeviceLoginStatus,
+    zodTopicObject,
+    zodFeedSortAlgorithm,
 } from "./zod.js";
 import { zodRarimoStatusAttributes } from "./zod.js";
 
@@ -102,12 +104,12 @@ export class Dto {
     ]);
     static fetchFeedRequest = z
         .object({
-            lastSlugId: zodSlugId.optional(),
+            sortAlgorithm: zodFeedSortAlgorithm,
         })
         .strict();
     static fetchFeedResponse = z.object({
         conversationDataList: z.array(zodExtendedConversationData),
-        reachedEndOfFeed: z.boolean(),
+        topConversationSlugIdList: z.array(zodSlugId), // used to determine if the feed is stale
     });
     static postFetchRequest = z
         .object({
@@ -399,6 +401,11 @@ export class Dto {
             organizationName: z.string(),
         })
         .strict();
+    static getAllTopicsResponse = z
+        .object({
+            topicList: z.array(zodTopicObject),
+        })
+        .strict();
     // this generates enum with openapigenerator without the verified state...
     // static verifyUserStatusAndAuthenticate200 = z.discriminatedUnion(
     //     "rarimoStatus",
@@ -498,3 +505,4 @@ export type GetOrganizationNamesByUsernameResponse = z.infer<
 export type GetAllOrganizationsResponse = z.infer<
     typeof Dto.getAllOrganizationsResponse
 >;
+export type GetAllTopicsResponse = z.infer<typeof Dto.getAllTopicsResponse>;

--- a/services/api/src/shared/types/zod.ts
+++ b/services/api/src/shared/types/zod.ts
@@ -28,6 +28,7 @@ export const zodModerationReason = z.enum([
     "sexual",
     "spam",
 ]);
+export const zodFeedSortAlgorithm = z.enum(["following", "new"]);
 export const zodConversationModerationAction = z.enum(["lock"]);
 export const zodOpinionModerationAction = z.enum(["move", "hide"]);
 export const zodPhoneNumber = z
@@ -191,6 +192,13 @@ export const zodRouteTarget = z
     .object({
         conversationSlugId: zodSlugId,
         opinionSlugId: zodSlugId,
+    })
+    .strict();
+
+export const zodTopicObject = z
+    .object({
+        code: z.string(),
+        name: z.string(),
     })
     .strict();
 
@@ -850,3 +858,5 @@ export type DeviceIsKnownTrueLoginStatus = z.infer<
 export type DeviceIsKnownTrueLoginStatusExtended = z.infer<
     typeof zodIsKnownTrueLoginStatusExtended
 >;
+export type ZodTopicObject = z.infer<typeof zodTopicObject>;
+export type FeedSortAlgorithm = z.infer<typeof zodFeedSortAlgorithm>;

--- a/services/shared/src/conversationLogic.ts
+++ b/services/shared/src/conversationLogic.ts
@@ -43,7 +43,7 @@ export function isControversial({
     }
 }
 
-export function isPopular({
+export function isMajorityAgree({
     numAgrees,
     memberCount,
     threshold,
@@ -56,7 +56,7 @@ export function isPopular({
     }
 }
 
-export function isUnpopular({
+export function isMajorityDisagree({
     numDisagrees,
     memberCount,
     threshold,
@@ -76,8 +76,8 @@ export function isMajority({
     minVoters,
 }: ClassifyProps): boolean {
     if (
-        isPopular({ numAgrees, memberCount, threshold: minVoters }) ||
-        isUnpopular({ numDisagrees, memberCount, threshold: minVoters })
+        isMajorityAgree({ numAgrees, memberCount, threshold: minVoters }) ||
+        isMajorityDisagree({ numDisagrees, memberCount, threshold: minVoters })
     ) {
         return true;
     } else {

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -31,6 +31,8 @@ import {
     zodSupportedCountryCallingCode,
     zodOrganization,
     zodDeviceLoginStatus,
+    zodTopicObject,
+    zodFeedSortAlgorithm,
 } from "./zod.js";
 import { zodRarimoStatusAttributes } from "./zod.js";
 
@@ -101,12 +103,12 @@ export class Dto {
     ]);
     static fetchFeedRequest = z
         .object({
-            lastSlugId: zodSlugId.optional(),
+            sortAlgorithm: zodFeedSortAlgorithm,
         })
         .strict();
     static fetchFeedResponse = z.object({
         conversationDataList: z.array(zodExtendedConversationData),
-        reachedEndOfFeed: z.boolean(),
+        topConversationSlugIdList: z.array(zodSlugId), // used to determine if the feed is stale
     });
     static postFetchRequest = z
         .object({
@@ -398,6 +400,11 @@ export class Dto {
             organizationName: z.string(),
         })
         .strict();
+    static getAllTopicsResponse = z
+        .object({
+            topicList: z.array(zodTopicObject),
+        })
+        .strict();
     // this generates enum with openapigenerator without the verified state...
     // static verifyUserStatusAndAuthenticate200 = z.discriminatedUnion(
     //     "rarimoStatus",
@@ -497,3 +504,4 @@ export type GetOrganizationNamesByUsernameResponse = z.infer<
 export type GetAllOrganizationsResponse = z.infer<
     typeof Dto.getAllOrganizationsResponse
 >;
+export type GetAllTopicsResponse = z.infer<typeof Dto.getAllTopicsResponse>;

--- a/services/shared/src/types/zod.ts
+++ b/services/shared/src/types/zod.ts
@@ -27,6 +27,7 @@ export const zodModerationReason = z.enum([
     "sexual",
     "spam",
 ]);
+export const zodFeedSortAlgorithm = z.enum(["following", "new"]);
 export const zodConversationModerationAction = z.enum(["lock"]);
 export const zodOpinionModerationAction = z.enum(["move", "hide"]);
 export const zodPhoneNumber = z
@@ -190,6 +191,13 @@ export const zodRouteTarget = z
     .object({
         conversationSlugId: zodSlugId,
         opinionSlugId: zodSlugId,
+    })
+    .strict();
+
+export const zodTopicObject = z
+    .object({
+        code: z.string(),
+        name: z.string(),
     })
     .strict();
 
@@ -849,3 +857,5 @@ export type DeviceIsKnownTrueLoginStatus = z.infer<
 export type DeviceIsKnownTrueLoginStatusExtended = z.infer<
     typeof zodIsKnownTrueLoginStatusExtended
 >;
+export type ZodTopicObject = z.infer<typeof zodTopicObject>;
+export type FeedSortAlgorithm = z.infer<typeof zodFeedSortAlgorithm>;


### PR DESCRIPTION
Changes:
- Added topics db changes (not really in use yet by the backend API)
- Added support for following sorting algorithm on the frontend
- Moved infinite scrolling of the home feed to the client side to simplify the refresh system and new conversation detection