### PR TITLE
fix(llm): "clusters" was given empty to the prompt

### DIFF
--- a/services/api/src/service/llmLabelSummary.ts
+++ b/services/api/src/service/llmLabelSummary.ts
@@ -4,7 +4,7 @@ import {
     conversationTable,
     opinionContentTable,
     opinionTable,
-    polisClusterOpinionTable,
+    // polisClusterOpinionTable,
     polisClusterTable,
     polisContentTable,
 } from "@/schema.js";
@@ -13,8 +13,8 @@ import {
     isGroupAwareConsensusAgree,
     isMajorityAgree,
     isMajorityDisagree,
-    isRepresentativeAgree,
-    isRepresentativeDisagree,
+    // isRepresentativeAgree,
+    // isRepresentativeDisagree,
 } from "@/shared/conversationLogic.js";
 import { toUnionUndefined } from "@/shared/shared.js";
 import {
@@ -30,7 +30,7 @@ import {
     isSqlWhereControversial,
     isSqlWhereGroupAwareConsensusAgree,
     isSqlWhereMajority,
-    isSqlWhereRepresentative,
+    // isSqlWhereRepresentative,
 } from "@/utils/sqlLogic.js";
 import {
     BedrockRuntimeClient,
@@ -249,18 +249,25 @@ async function invokeRemoteModel({
 }: InvokeRemoteModelProps): Promise<
     GenLabelSummaryOutputStrict | GenLabelSummaryOutputLoose
 > {
+    const clustersWithoutRepresentatives: Record<
+        string,
+        ClusterInsightsWithoutRepresentatives
+    > = {};
+
+    for (const [key, cluster] of Object.entries(
+        conversationInsights.clusters,
+    )) {
+        clustersWithoutRepresentatives[key] = {
+            memberCount: cluster.memberCount,
+            majorityAgreeOpinions: cluster.majorityAgreeOpinions,
+            majorityDisagreeOpinions: cluster.majorityDisagreeOpinions,
+            controversialOpinions: cluster.controversialOpinions,
+        };
+    }
     const transformedConversationInsights: ConversationInsightsWithoutRepresentatives =
         {
             ...conversationInsights,
-            clusters: {
-                memberCount: conversationInsights.clusters.memberCount,
-                majorityAgreeOpinions:
-                    conversationInsights.clusters.majorityAgreeOpinions,
-                majorityDisagreeOpinions:
-                    conversationInsights.clusters.majorityDisagreeOpinions,
-                controversialOpinions:
-                    conversationInsights.clusters.controversialOpinions,
-            },
+            clusters: clustersWithoutRepresentatives,
         };
     const userPrompt = JSON.stringify(transformedConversationInsights);
     const conversation: Message[] = [
@@ -393,30 +400,30 @@ async function getCoreOpinions({
     const polisClusterTableAlias4 = alias(polisClusterTable, "cluster_4 ");
     const polisClusterTableAlias5 = alias(polisClusterTable, "cluster_5 ");
 
-    const polisClusterOpinionTableAlias0 = alias(
-        polisClusterOpinionTable,
-        "cluster_opinion_0 ",
-    );
-    const polisClusterOpinionTableAlias1 = alias(
-        polisClusterOpinionTable,
-        "cluster_opinion_1 ",
-    );
-    const polisClusterOpinionTableAlias2 = alias(
-        polisClusterOpinionTable,
-        "cluster_opinion_2 ",
-    );
-    const polisClusterOpinionTableAlias3 = alias(
-        polisClusterOpinionTable,
-        "cluster_opinion_3 ",
-    );
-    const polisClusterOpinionTableAlias4 = alias(
-        polisClusterOpinionTable,
-        "cluster_opinion_4 ",
-    );
-    const polisClusterOpinionTableAlias5 = alias(
-        polisClusterOpinionTable,
-        "cluster_opinion_5 ",
-    );
+    // const polisClusterOpinionTableAlias0 = alias(
+    //     polisClusterOpinionTable,
+    //     "cluster_opinion_0 ",
+    // );
+    // const polisClusterOpinionTableAlias1 = alias(
+    //     polisClusterOpinionTable,
+    //     "cluster_opinion_1 ",
+    // );
+    // const polisClusterOpinionTableAlias2 = alias(
+    //     polisClusterOpinionTable,
+    //     "cluster_opinion_2 ",
+    // );
+    // const polisClusterOpinionTableAlias3 = alias(
+    //     polisClusterOpinionTable,
+    //     "cluster_opinion_3 ",
+    // );
+    // const polisClusterOpinionTableAlias4 = alias(
+    //     polisClusterOpinionTable,
+    //     "cluster_opinion_4 ",
+    // );
+    // const polisClusterOpinionTableAlias5 = alias(
+    //     polisClusterOpinionTable,
+    //     "cluster_opinion_5 ",
+    // );
 
     const conversationDataResults = await db
         .select({
@@ -429,45 +436,45 @@ async function getCoreOpinions({
             cluster0NumUsers: polisClusterTableAlias0.numUsers,
             cluster0NumAgrees: opinionTable.polisCluster0NumAgrees,
             cluster0NumDisagrees: opinionTable.polisCluster0NumDisagrees,
-            cluster0RepnessProbability:
-                polisClusterOpinionTableAlias0.probabilityAgreement,
-            cluster0RepnessAgreementType:
-                polisClusterOpinionTableAlias0.agreementType,
+            // cluster0RepnessProbability:
+            //     polisClusterOpinionTableAlias0.probabilityAgreement,
+            // cluster0RepnessAgreementType:
+            //     polisClusterOpinionTableAlias0.agreementType,
             cluster1NumUsers: polisClusterTableAlias1.numUsers,
             cluster1NumAgrees: opinionTable.polisCluster1NumAgrees,
             cluster1NumDisagrees: opinionTable.polisCluster1NumDisagrees,
-            cluster1RepnessProbability:
-                polisClusterOpinionTableAlias1.probabilityAgreement,
-            cluster1RepnessAgreementType:
-                polisClusterOpinionTableAlias1.agreementType,
+            // cluster1RepnessProbability:
+            //     polisClusterOpinionTableAlias1.probabilityAgreement,
+            // cluster1RepnessAgreementType:
+            //     polisClusterOpinionTableAlias1.agreementType,
             cluster2NumUsers: polisClusterTableAlias2.numUsers,
             cluster2NumAgrees: opinionTable.polisCluster2NumAgrees,
             cluster2NumDisagrees: opinionTable.polisCluster2NumDisagrees,
-            cluster2RepnessProbability:
-                polisClusterOpinionTableAlias2.probabilityAgreement,
-            cluster2RepnessAgreementType:
-                polisClusterOpinionTableAlias2.agreementType,
+            // cluster2RepnessProbability:
+            //     polisClusterOpinionTableAlias2.probabilityAgreement,
+            // cluster2RepnessAgreementType:
+            //     polisClusterOpinionTableAlias2.agreementType,
             cluster3NumUsers: polisClusterTableAlias3.numUsers,
             cluster3NumAgrees: opinionTable.polisCluster3NumAgrees,
             cluster3NumDisagrees: opinionTable.polisCluster3NumDisagrees,
-            cluster3RepnessProbability:
-                polisClusterOpinionTableAlias3.probabilityAgreement,
-            cluster3RepnessAgreementType:
-                polisClusterOpinionTableAlias3.agreementType,
+            // cluster3RepnessProbability:
+            //     polisClusterOpinionTableAlias3.probabilityAgreement,
+            // cluster3RepnessAgreementType:
+            //     polisClusterOpinionTableAlias3.agreementType,
             cluster4NumUsers: polisClusterTableAlias4.numUsers,
             cluster4NumAgrees: opinionTable.polisCluster4NumAgrees,
             cluster4NumDisagrees: opinionTable.polisCluster4NumDisagrees,
-            cluster4RepnessProbability:
-                polisClusterOpinionTableAlias4.probabilityAgreement,
-            cluster4RepnessAgreementType:
-                polisClusterOpinionTableAlias4.agreementType,
+            // cluster4RepnessProbability:
+            //     polisClusterOpinionTableAlias4.probabilityAgreement,
+            // cluster4RepnessAgreementType:
+            //     polisClusterOpinionTableAlias4.agreementType,
             cluster5NumUsers: polisClusterTableAlias5.numUsers,
             cluster5NumAgrees: opinionTable.polisCluster5NumAgrees,
             cluster5NumDisagrees: opinionTable.polisCluster5NumDisagrees,
-            cluster5RepnessProbability:
-                polisClusterOpinionTableAlias5.probabilityAgreement,
-            cluster5RepnessAgreementType:
-                polisClusterOpinionTableAlias5.agreementType,
+            // cluster5RepnessProbability:
+            //     polisClusterOpinionTableAlias5.probabilityAgreement,
+            // cluster5RepnessAgreementType:
+            //     polisClusterOpinionTableAlias5.agreementType,
             conversationBody: conversationContentTable.body,
         })
         .from(opinionTable)
@@ -547,48 +554,48 @@ async function getCoreOpinions({
                 eq(polisClusterTableAlias5.key, "5"),
             ),
         )
-        .leftJoin(
-            polisClusterOpinionTableAlias0,
-            eq(
-                polisClusterOpinionTableAlias0.polisClusterId,
-                polisClusterTableAlias0.id,
-            ),
-        )
-        .leftJoin(
-            polisClusterOpinionTableAlias1,
-            eq(
-                polisClusterOpinionTableAlias1.polisClusterId,
-                polisClusterTableAlias1.id,
-            ),
-        )
-        .leftJoin(
-            polisClusterOpinionTableAlias2,
-            eq(
-                polisClusterOpinionTableAlias2.polisClusterId,
-                polisClusterTableAlias2.id,
-            ),
-        )
-        .leftJoin(
-            polisClusterOpinionTableAlias3,
-            eq(
-                polisClusterOpinionTableAlias3.polisClusterId,
-                polisClusterTableAlias3.id,
-            ),
-        )
-        .leftJoin(
-            polisClusterOpinionTableAlias4,
-            eq(
-                polisClusterOpinionTableAlias4.polisClusterId,
-                polisClusterTableAlias4.id,
-            ),
-        )
-        .leftJoin(
-            polisClusterOpinionTableAlias5,
-            eq(
-                polisClusterOpinionTableAlias5.polisClusterId,
-                polisClusterTableAlias5.id,
-            ),
-        )
+        // .leftJoin(
+        //     polisClusterOpinionTableAlias0,
+        //     eq(
+        //         polisClusterOpinionTableAlias0.polisClusterId,
+        //         polisClusterTableAlias0.id,
+        //     ),
+        // )
+        // .leftJoin(
+        //     polisClusterOpinionTableAlias1,
+        //     eq(
+        //         polisClusterOpinionTableAlias1.polisClusterId,
+        //         polisClusterTableAlias1.id,
+        //     ),
+        // )
+        // .leftJoin(
+        //     polisClusterOpinionTableAlias2,
+        //     eq(
+        //         polisClusterOpinionTableAlias2.polisClusterId,
+        //         polisClusterTableAlias2.id,
+        //     ),
+        // )
+        // .leftJoin(
+        //     polisClusterOpinionTableAlias3,
+        //     eq(
+        //         polisClusterOpinionTableAlias3.polisClusterId,
+        //         polisClusterTableAlias3.id,
+        //     ),
+        // )
+        // .leftJoin(
+        //     polisClusterOpinionTableAlias4,
+        //     eq(
+        //         polisClusterOpinionTableAlias4.polisClusterId,
+        //         polisClusterTableAlias4.id,
+        //     ),
+        // )
+        // .leftJoin(
+        //     polisClusterOpinionTableAlias5,
+        //     eq(
+        //         polisClusterOpinionTableAlias5.polisClusterId,
+        //         polisClusterTableAlias5.id,
+        //     ),
+        // )
         .where(
             and(
                 eq(opinionTable.conversationId, conversationId),
@@ -632,10 +639,10 @@ async function getCoreOpinions({
                             opinionTable.polisCluster0NumDisagrees,
                         memberCountColumn: polisClusterTableAlias0.numUsers,
                     }),
-                    isSqlWhereRepresentative({
-                        polisClusterOpinionIdColumn:
-                            polisClusterOpinionTableAlias0.id,
-                    }),
+                    // isSqlWhereRepresentative({
+                    //     polisClusterOpinionIdColumn:
+                    //         polisClusterOpinionTableAlias0.id,
+                    // }),
                     // 1
                     isSqlWhereMajority({
                         numAgreesColumn: opinionTable.polisCluster1NumAgrees,
@@ -649,10 +656,10 @@ async function getCoreOpinions({
                             opinionTable.polisCluster1NumDisagrees,
                         memberCountColumn: polisClusterTableAlias1.numUsers,
                     }),
-                    isSqlWhereRepresentative({
-                        polisClusterOpinionIdColumn:
-                            polisClusterOpinionTableAlias1.id,
-                    }),
+                    // isSqlWhereRepresentative({
+                    //     polisClusterOpinionIdColumn:
+                    //         polisClusterOpinionTableAlias1.id,
+                    // }),
                     // 2
                     isSqlWhereMajority({
                         numAgreesColumn: opinionTable.polisCluster2NumAgrees,
@@ -666,10 +673,10 @@ async function getCoreOpinions({
                             opinionTable.polisCluster2NumDisagrees,
                         memberCountColumn: polisClusterTableAlias2.numUsers,
                     }),
-                    isSqlWhereRepresentative({
-                        polisClusterOpinionIdColumn:
-                            polisClusterOpinionTableAlias2.id,
-                    }),
+                    // isSqlWhereRepresentative({
+                    //     polisClusterOpinionIdColumn:
+                    //         polisClusterOpinionTableAlias2.id,
+                    // }),
                     // 3
                     isSqlWhereMajority({
                         numAgreesColumn: opinionTable.polisCluster3NumAgrees,
@@ -683,10 +690,10 @@ async function getCoreOpinions({
                             opinionTable.polisCluster3NumDisagrees,
                         memberCountColumn: polisClusterTableAlias3.numUsers,
                     }),
-                    isSqlWhereRepresentative({
-                        polisClusterOpinionIdColumn:
-                            polisClusterOpinionTableAlias3.id,
-                    }),
+                    // isSqlWhereRepresentative({
+                    //     polisClusterOpinionIdColumn:
+                    //         polisClusterOpinionTableAlias3.id,
+                    // }),
                     // 4
                     isSqlWhereMajority({
                         numAgreesColumn: opinionTable.polisCluster4NumAgrees,
@@ -700,10 +707,10 @@ async function getCoreOpinions({
                             opinionTable.polisCluster4NumDisagrees,
                         memberCountColumn: polisClusterTableAlias4.numUsers,
                     }),
-                    isSqlWhereRepresentative({
-                        polisClusterOpinionIdColumn:
-                            polisClusterOpinionTableAlias4.id,
-                    }),
+                    // isSqlWhereRepresentative({
+                    //     polisClusterOpinionIdColumn:
+                    //         polisClusterOpinionTableAlias4.id,
+                    // }),
                     // 5
                     isSqlWhereMajority({
                         numAgreesColumn: opinionTable.polisCluster5NumAgrees,
@@ -717,10 +724,10 @@ async function getCoreOpinions({
                             opinionTable.polisCluster5NumDisagrees,
                         memberCountColumn: polisClusterTableAlias5.numUsers,
                     }),
-                    isSqlWhereRepresentative({
-                        polisClusterOpinionIdColumn:
-                            polisClusterOpinionTableAlias5.id,
-                    }),
+                    // isSqlWhereRepresentative({
+                    //     polisClusterOpinionIdColumn:
+                    //         polisClusterOpinionTableAlias5.id,
+                    // }),
                 ),
             ),
         );
@@ -865,56 +872,56 @@ async function getCoreOpinions({
                     };
                 }
             }
-            if (
-                isRepresentativeAgree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster0RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster0RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("0" in clusters) {
-                    clusters["0"].representativeAgreeOpinions.push(
-                        newOpinionCluster0,
-                    );
-                } else {
-                    clusters["0"] = {
-                        memberCount: conversationData.cluster0NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [newOpinionCluster0],
-                        representativeDisagreeOpinions: [],
-                    };
-                }
-            }
-            if (
-                isRepresentativeDisagree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster0RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster0RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("0" in clusters) {
-                    clusters["0"].representativeDisagreeOpinions.push(
-                        newOpinionCluster0,
-                    );
-                } else {
-                    clusters["0"] = {
-                        memberCount: conversationData.cluster0NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [],
-                        representativeDisagreeOpinions: [newOpinionCluster0],
-                    };
-                }
-            }
+            // if (
+            //     isRepresentativeAgree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster0RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster0RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("0" in clusters) {
+            //         clusters["0"].representativeAgreeOpinions.push(
+            //             newOpinionCluster0,
+            //         );
+            //     } else {
+            //         clusters["0"] = {
+            //             memberCount: conversationData.cluster0NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [newOpinionCluster0],
+            //             representativeDisagreeOpinions: [],
+            //         };
+            //     }
+            // }
+            // if (
+            //     isRepresentativeDisagree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster0RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster0RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("0" in clusters) {
+            //         clusters["0"].representativeDisagreeOpinions.push(
+            //             newOpinionCluster0,
+            //         );
+            //     } else {
+            //         clusters["0"] = {
+            //             memberCount: conversationData.cluster0NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [],
+            //             representativeDisagreeOpinions: [newOpinionCluster0],
+            //         };
+            //     }
+            // }
         }
         if (
             conversationData.cluster1NumAgrees !== null &&
@@ -994,56 +1001,56 @@ async function getCoreOpinions({
                     };
                 }
             }
-            if (
-                isRepresentativeAgree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster1RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster1RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("1" in clusters) {
-                    clusters["1"].representativeAgreeOpinions.push(
-                        newOpinionCluster1,
-                    );
-                } else {
-                    clusters["1"] = {
-                        memberCount: conversationData.cluster1NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [newOpinionCluster1],
-                        representativeDisagreeOpinions: [],
-                    };
-                }
-            }
-            if (
-                isRepresentativeDisagree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster1RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster1RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("1" in clusters) {
-                    clusters["1"].representativeDisagreeOpinions.push(
-                        newOpinionCluster1,
-                    );
-                } else {
-                    clusters["1"] = {
-                        memberCount: conversationData.cluster1NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [],
-                        representativeDisagreeOpinions: [newOpinionCluster1],
-                    };
-                }
-            }
+            // if (
+            //     isRepresentativeAgree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster1RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster1RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("1" in clusters) {
+            //         clusters["1"].representativeAgreeOpinions.push(
+            //             newOpinionCluster1,
+            //         );
+            //     } else {
+            //         clusters["1"] = {
+            //             memberCount: conversationData.cluster1NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [newOpinionCluster1],
+            //             representativeDisagreeOpinions: [],
+            //         };
+            //     }
+            // }
+            // if (
+            //     isRepresentativeDisagree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster1RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster1RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("1" in clusters) {
+            //         clusters["1"].representativeDisagreeOpinions.push(
+            //             newOpinionCluster1,
+            //         );
+            //     } else {
+            //         clusters["1"] = {
+            //             memberCount: conversationData.cluster1NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [],
+            //             representativeDisagreeOpinions: [newOpinionCluster1],
+            //         };
+            //     }
+            // }
         }
         if (
             conversationData.cluster2NumAgrees !== null &&
@@ -1123,56 +1130,56 @@ async function getCoreOpinions({
                     };
                 }
             }
-            if (
-                isRepresentativeAgree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster2RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster2RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("2" in clusters) {
-                    clusters["2"].representativeAgreeOpinions.push(
-                        newOpinionCluster2,
-                    );
-                } else {
-                    clusters["2"] = {
-                        memberCount: conversationData.cluster2NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [newOpinionCluster2],
-                        representativeDisagreeOpinions: [],
-                    };
-                }
-            }
-            if (
-                isRepresentativeDisagree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster2RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster2RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("2" in clusters) {
-                    clusters["2"].representativeDisagreeOpinions.push(
-                        newOpinionCluster2,
-                    );
-                } else {
-                    clusters["2"] = {
-                        memberCount: conversationData.cluster2NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [],
-                        representativeDisagreeOpinions: [newOpinionCluster2],
-                    };
-                }
-            }
+            // if (
+            //     isRepresentativeAgree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster2RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster2RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("2" in clusters) {
+            //         clusters["2"].representativeAgreeOpinions.push(
+            //             newOpinionCluster2,
+            //         );
+            //     } else {
+            //         clusters["2"] = {
+            //             memberCount: conversationData.cluster2NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [newOpinionCluster2],
+            //             representativeDisagreeOpinions: [],
+            //         };
+            //     }
+            // }
+            // if (
+            //     isRepresentativeDisagree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster2RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster2RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("2" in clusters) {
+            //         clusters["2"].representativeDisagreeOpinions.push(
+            //             newOpinionCluster2,
+            //         );
+            //     } else {
+            //         clusters["2"] = {
+            //             memberCount: conversationData.cluster2NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [],
+            //             representativeDisagreeOpinions: [newOpinionCluster2],
+            //         };
+            //     }
+            // }
         }
         if (
             conversationData.cluster3NumAgrees !== null &&
@@ -1252,56 +1259,56 @@ async function getCoreOpinions({
                     };
                 }
             }
-            if (
-                isRepresentativeAgree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster3RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster3RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("3" in clusters) {
-                    clusters["3"].representativeAgreeOpinions.push(
-                        newOpinionCluster3,
-                    );
-                } else {
-                    clusters["3"] = {
-                        memberCount: conversationData.cluster3NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [newOpinionCluster3],
-                        representativeDisagreeOpinions: [],
-                    };
-                }
-            }
-            if (
-                isRepresentativeDisagree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster3RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster3RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("3" in clusters) {
-                    clusters["3"].representativeDisagreeOpinions.push(
-                        newOpinionCluster3,
-                    );
-                } else {
-                    clusters["3"] = {
-                        memberCount: conversationData.cluster3NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [],
-                        representativeDisagreeOpinions: [newOpinionCluster3],
-                    };
-                }
-            }
+            // if (
+            //     isRepresentativeAgree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster3RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster3RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("3" in clusters) {
+            //         clusters["3"].representativeAgreeOpinions.push(
+            //             newOpinionCluster3,
+            //         );
+            //     } else {
+            //         clusters["3"] = {
+            //             memberCount: conversationData.cluster3NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [newOpinionCluster3],
+            //             representativeDisagreeOpinions: [],
+            //         };
+            //     }
+            // }
+            // if (
+            //     isRepresentativeDisagree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster3RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster3RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("3" in clusters) {
+            //         clusters["3"].representativeDisagreeOpinions.push(
+            //             newOpinionCluster3,
+            //         );
+            //     } else {
+            //         clusters["3"] = {
+            //             memberCount: conversationData.cluster3NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [],
+            //             representativeDisagreeOpinions: [newOpinionCluster3],
+            //         };
+            //     }
+            // }
         }
         if (
             conversationData.cluster4NumAgrees !== null &&
@@ -1381,56 +1388,56 @@ async function getCoreOpinions({
                     };
                 }
             }
-            if (
-                isRepresentativeAgree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster4RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster4RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("4" in clusters) {
-                    clusters["4"].representativeAgreeOpinions.push(
-                        newOpinionCluster4,
-                    );
-                } else {
-                    clusters["4"] = {
-                        memberCount: conversationData.cluster4NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [newOpinionCluster4],
-                        representativeDisagreeOpinions: [],
-                    };
-                }
-            }
-            if (
-                isRepresentativeDisagree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster4RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster4RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("4" in clusters) {
-                    clusters["4"].representativeDisagreeOpinions.push(
-                        newOpinionCluster4,
-                    );
-                } else {
-                    clusters["4"] = {
-                        memberCount: conversationData.cluster4NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [],
-                        representativeDisagreeOpinions: [newOpinionCluster4],
-                    };
-                }
-            }
+            // if (
+            //     isRepresentativeAgree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster4RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster4RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("4" in clusters) {
+            //         clusters["4"].representativeAgreeOpinions.push(
+            //             newOpinionCluster4,
+            //         );
+            //     } else {
+            //         clusters["4"] = {
+            //             memberCount: conversationData.cluster4NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [newOpinionCluster4],
+            //             representativeDisagreeOpinions: [],
+            //         };
+            //     }
+            // }
+            // if (
+            //     isRepresentativeDisagree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster4RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster4RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("4" in clusters) {
+            //         clusters["4"].representativeDisagreeOpinions.push(
+            //             newOpinionCluster4,
+            //         );
+            //     } else {
+            //         clusters["4"] = {
+            //             memberCount: conversationData.cluster4NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [],
+            //             representativeDisagreeOpinions: [newOpinionCluster4],
+            //         };
+            //     }
+            // }
         }
         if (
             conversationData.cluster5NumAgrees !== null &&
@@ -1510,56 +1517,56 @@ async function getCoreOpinions({
                     };
                 }
             }
-            if (
-                isRepresentativeAgree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster5RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster5RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("5" in clusters) {
-                    clusters["5"].representativeAgreeOpinions.push(
-                        newOpinionCluster5,
-                    );
-                } else {
-                    clusters["5"] = {
-                        memberCount: conversationData.cluster5NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [newOpinionCluster5],
-                        representativeDisagreeOpinions: [],
-                    };
-                }
-            }
-            if (
-                isRepresentativeDisagree({
-                    clusterRepnessProbability: toUnionUndefined(
-                        conversationData.cluster5RepnessProbability,
-                    ),
-                    clusterRepnessAgreementType: toUnionUndefined(
-                        conversationData.cluster5RepnessAgreementType,
-                    ),
-                })
-            ) {
-                if ("5" in clusters) {
-                    clusters["5"].representativeDisagreeOpinions.push(
-                        newOpinionCluster5,
-                    );
-                } else {
-                    clusters["5"] = {
-                        memberCount: conversationData.cluster5NumUsers,
-                        majorityAgreeOpinions: [],
-                        majorityDisagreeOpinions: [],
-                        controversialOpinions: [],
-                        representativeAgreeOpinions: [],
-                        representativeDisagreeOpinions: [newOpinionCluster5],
-                    };
-                }
-            }
+            // if (
+            //     isRepresentativeAgree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster5RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster5RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("5" in clusters) {
+            //         clusters["5"].representativeAgreeOpinions.push(
+            //             newOpinionCluster5,
+            //         );
+            //     } else {
+            //         clusters["5"] = {
+            //             memberCount: conversationData.cluster5NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [newOpinionCluster5],
+            //             representativeDisagreeOpinions: [],
+            //         };
+            //     }
+            // }
+            // if (
+            //     isRepresentativeDisagree({
+            //         clusterRepnessProbability: toUnionUndefined(
+            //             conversationData.cluster5RepnessProbability,
+            //         ),
+            //         clusterRepnessAgreementType: toUnionUndefined(
+            //             conversationData.cluster5RepnessAgreementType,
+            //         ),
+            //     })
+            // ) {
+            //     if ("5" in clusters) {
+            //         clusters["5"].representativeDisagreeOpinions.push(
+            //             newOpinionCluster5,
+            //         );
+            //     } else {
+            //         clusters["5"] = {
+            //             memberCount: conversationData.cluster5NumUsers,
+            //             majorityAgreeOpinions: [],
+            //             majorityDisagreeOpinions: [],
+            //             controversialOpinions: [],
+            //             representativeAgreeOpinions: [],
+            //             representativeDisagreeOpinions: [newOpinionCluster5],
+            //         };
+            //     }
+            // }
         }
     }
     return {


### PR DESCRIPTION
Temporarily removing "representative" opinions to the LLM input, because it reaches the LLM context :/

TODO: 
- only use representative opinions
- put the same opinion content together instead of repeating the text, which can be long!
- use multiple prompts: this is the only stable way going forward, since comments are designed to be potentially long...