### PR TITLE
Fix the excessive conversation API calls by moving data management into a pinia store

### DIFF
--- a/services/agora/src/components/post/comments/group/item/CommentActionBar.vue
+++ b/services/agora/src/components/post/comments/group/item/CommentActionBar.vue
@@ -62,7 +62,7 @@ import { formatPercentage } from "src/utils/common";
 import { useNotify } from "src/utils/ui/notify";
 import { computed, ref } from "vue";
 import VotingButton from "src/components/features/opinion/VotingButton.vue";
-import { useConversationData } from "src/composables/useConversationData";
+import { useConversationLoginIntentions } from "src/composables/useConversationLoginIntentions";
 
 const props = defineProps<{
   commentItem: OpinionItem;
@@ -75,7 +75,7 @@ const props = defineProps<{
 const emit = defineEmits(["changeVote"]);
 
 const showLoginDialog = ref(false);
-const { createOpinionAgreementLoginIntention } = useConversationData();
+const { setOpinionAgreementIntention } = useConversationLoginIntentions();
 
 const { showNotifyMessage } = useNotify();
 
@@ -112,7 +112,7 @@ const relativeTotalPercentagePasses = computed(() => {
 });
 
 function onLoginCallback() {
-  createOpinionAgreementLoginIntention(props.commentItem.opinionSlugId);
+  setOpinionAgreementIntention(props.commentItem.opinionSlugId);
 }
 
 async function castPersonalVote(

--- a/services/agora/src/components/post/comments/group/item/CommentActionOptions.vue
+++ b/services/agora/src/components/post/comments/group/item/CommentActionOptions.vue
@@ -43,7 +43,7 @@ import { useBottomSheet } from "src/utils/ui/bottomSheet";
 import { useNotify } from "src/utils/ui/notify";
 import { ref } from "vue";
 import { useRouter } from "vue-router";
-import { useConversationData } from "src/composables/useConversationData";
+import { useConversationLoginIntentions } from "src/composables/useConversationLoginIntentions";
 
 const emit = defineEmits(["deleted", "mutedComment"]);
 
@@ -69,10 +69,10 @@ const { deleteCommentBySlugId } = useBackendCommentApi();
 
 const showLoginDialog = ref(false);
 
-const { createReportUserContentLoginIntention } = useConversationData();
+const { setReportIntention } = useConversationLoginIntentions();
 
 function onLoginConfirmationOk() {
-  createReportUserContentLoginIntention(props.commentItem.opinionSlugId);
+  setReportIntention(props.commentItem.opinionSlugId);
 }
 
 function reportContentCallback() {

--- a/services/agora/src/components/post/display/PostMetadata.vue
+++ b/services/agora/src/components/post/display/PostMetadata.vue
@@ -57,7 +57,7 @@ import { useAuthenticationStore } from "src/stores/authentication";
 import { storeToRefs } from "pinia";
 import { useWebShare } from "src/utils/share/WebShare";
 import { useConversationUrl } from "src/utils/url/conversationUrl";
-import { useConversationData } from "src/composables/useConversationData";
+import { useConversationLoginIntentions } from "src/composables/useConversationLoginIntentions";
 
 const emit = defineEmits(["openModerationHistory"]);
 
@@ -84,13 +84,13 @@ const showReportDialog = ref(false);
 
 const showLoginDialog = ref(false);
 
-const { createReportUserContentLoginIntention } = useConversationData();
+const { setReportIntention } = useConversationLoginIntentions();
 
 const webShare = useWebShare();
 const { getEmbedUrl } = useConversationUrl();
 
 function onLoginConfirmationOk() {
-  createReportUserContentLoginIntention("");
+  setReportIntention("");
 }
 
 function reportContentCallback() {

--- a/services/agora/src/components/post/display/poll/PollWrapper.vue
+++ b/services/agora/src/components/post/display/poll/PollWrapper.vue
@@ -84,7 +84,7 @@ import PreLoginIntentionDialog from "../../../authentication/intention/PreLoginI
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useBackendAuthApi } from "src/utils/api/auth";
 import PollOption from "./PollOption.vue";
-import { useConversationData } from "src/composables/useConversationData";
+import { useConversationLoginIntentions } from "src/composables/useConversationLoginIntentions";
 
 const props = defineProps<{
   userResponse: UserInteraction;
@@ -103,7 +103,7 @@ const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 const { loadPostData } = useHomeFeedStore();
 const { updateAuthState } = useBackendAuthApi();
 
-const { createVotingLoginIntention } = useConversationData();
+const { setVotingIntention } = useConversationLoginIntentions();
 
 enum DisplayModes {
   Vote,
@@ -222,7 +222,7 @@ async function clickedVotingOption(selectedIndex: number, event: MouseEvent) {
 }
 
 function onLoginCallback() {
-  createVotingLoginIntention();
+  setVotingIntention();
 }
 </script>
 

--- a/services/agora/src/composables/useConversationData.ts
+++ b/services/agora/src/composables/useConversationData.ts
@@ -1,34 +1,20 @@
 import { storeToRefs } from "pinia";
-import type { ExtendedConversation } from "src/shared/types/zod";
-import { useAuthenticationStore } from "src/stores/authentication";
 import { useLoginIntentionStore } from "src/stores/loginIntention";
-import { useHomeFeedStore } from "src/stores/homeFeed";
-import { useBackendPostApi } from "src/utils/api/post";
-import { onMounted, ref, watch } from "vue";
+import { useConversationStore } from "src/stores/conversation";
+import { onMounted } from "vue";
 import { useRoute } from "vue-router";
-import { useEmbedMode } from "src/utils/ui/embedMode";
 
 export function useConversationData() {
-  const { fetchPostBySlugId } = useBackendPostApi();
-  const { isGuestOrLoggedIn, isAuthInitialized } = storeToRefs(
-    useAuthenticationStore()
-  );
-  const { emptyPost } = useHomeFeedStore();
-  const postData = ref<ExtendedConversation>(emptyPost);
-
-  const dataLoaded = ref(false);
+  const conversationStore = useConversationStore();
+  const { conversationData, conversationLoaded } =
+    storeToRefs(conversationStore);
 
   const route = useRoute();
-  const { isEmbeddedMode } = useEmbedMode();
 
   const {
     clearVotingIntention,
     clearOpinionAgreementIntention,
     clearReportUserContentIntention,
-    createVotingIntention,
-    createOpinionAgreementIntention,
-    createReportUserContentIntention,
-    setActiveUserIntention,
   } = useLoginIntentionStore();
 
   // Clear intentions on initialization
@@ -37,98 +23,49 @@ export function useConversationData() {
   clearReportUserContentIntention();
 
   onMounted(async () => {
-    await initialize();
+    await loadConversationData();
   });
 
-  watch(isAuthInitialized, async () => {
-    await initialize();
-  });
-
-  async function initialize() {
-    if (isAuthInitialized.value) {
-      const isSuccessful = await loadData();
-      if (isSuccessful) {
-        dataLoaded.value = true;
-      }
-    }
-  }
-
-  async function loadData() {
-    // Handle both main conversation page and embed page routes
+  function getConversationSlugId(): string | null {
     const isConversationRoute =
       route.name === "/conversation/[postSlugId]" ||
       route.name === "/conversation/[postSlugId].embed";
-    if (isConversationRoute) {
-      const slugId: string = Array.isArray(route.params.postSlugId)
-        ? route.params.postSlugId[0]
-        : route.params.postSlugId;
-      const response = await fetchPostBySlugId(slugId, isGuestOrLoggedIn.value);
-      if (response != null) {
-        postData.value = response;
-        return true;
-      } else {
-        postData.value = emptyPost;
-        return false;
-      }
-    } else {
-      postData.value = emptyPost;
-      return false;
+
+    if (!isConversationRoute) {
+      console.error(
+        "Should not be calling conversation initialization outside of the conversation routes"
+      );
+      return null;
     }
+
+    return Array.isArray(route.params.postSlugId)
+      ? route.params.postSlugId[0]
+      : route.params.postSlugId;
   }
 
-  function pullDownTriggered(done: () => void) {
+  async function loadConversationData(refresh = false) {
+    const slugId = getConversationSlugId();
+
+    if (slugId) {
+      return await conversationStore.loadConversationData(slugId, refresh);
+    }
+
+    return false;
+  }
+
+  function refreshConversation(done: () => void) {
     setTimeout(() => {
       void (async () => {
-        await loadData();
+        await loadConversationData(true);
         done();
       })();
     }, 500);
   }
 
-  function createVotingLoginIntention() {
-    if (
-      route.name === "/conversation/[postSlugId]" ||
-      route.name === "/conversation/[postSlugId].embed"
-    ) {
-      const isEmbedView = isEmbeddedMode();
-      const postSlugId = route.params.postSlugId;
-      createVotingIntention(postSlugId, isEmbedView);
-      setActiveUserIntention("voting");
-    }
-  }
-
-  function createOpinionAgreementLoginIntention(opinionSlugId: string) {
-    if (
-      route.name === "/conversation/[postSlugId]" ||
-      route.name === "/conversation/[postSlugId].embed"
-    ) {
-      const isEmbedView = isEmbeddedMode();
-      const postSlugId = route.params.postSlugId;
-      createOpinionAgreementIntention(postSlugId, opinionSlugId, isEmbedView);
-      setActiveUserIntention("agreement");
-    }
-  }
-
-  function createReportUserContentLoginIntention(opinionSlugId: string) {
-    if (
-      route.name === "/conversation/[postSlugId]" ||
-      route.name === "/conversation/[postSlugId].embed"
-    ) {
-      const isEmbedView = isEmbeddedMode();
-      const postSlugId = route.params.postSlugId;
-      createReportUserContentIntention(postSlugId, opinionSlugId, isEmbedView);
-      setActiveUserIntention("reportUserContent");
-    }
-  }
-
   return {
-    postData,
-    dataLoaded,
-    initialize,
-    loadData,
-    pullDownTriggered,
-    createVotingLoginIntention,
-    createOpinionAgreementLoginIntention,
-    createReportUserContentLoginIntention,
+    conversationData,
+    conversationLoaded,
+    loadConversationData,
+    refreshConversation,
   };
 }

--- a/services/agora/src/composables/useConversationLoginIntentions.ts
+++ b/services/agora/src/composables/useConversationLoginIntentions.ts
@@ -1,0 +1,57 @@
+import { useLoginIntentionStore } from "src/stores/loginIntention";
+import { useRoute } from "vue-router";
+import { useEmbedMode } from "src/utils/ui/embedMode";
+
+export function useConversationLoginIntentions() {
+  const route = useRoute();
+  const { isEmbeddedMode } = useEmbedMode();
+
+  const {
+    createVotingIntention,
+    createOpinionAgreementIntention,
+    createReportUserContentIntention,
+    setActiveUserIntention,
+  } = useLoginIntentionStore();
+
+  function setVotingIntention() {
+    if (
+      route.name === "/conversation/[postSlugId]" ||
+      route.name === "/conversation/[postSlugId].embed"
+    ) {
+      const isEmbedView = isEmbeddedMode();
+      const postSlugId = route.params.postSlugId;
+      createVotingIntention(postSlugId, isEmbedView);
+      setActiveUserIntention("voting");
+    }
+  }
+
+  function setOpinionAgreementIntention(opinionSlugId: string) {
+    if (
+      route.name === "/conversation/[postSlugId]" ||
+      route.name === "/conversation/[postSlugId].embed"
+    ) {
+      const isEmbedView = isEmbeddedMode();
+      const postSlugId = route.params.postSlugId;
+      createOpinionAgreementIntention(postSlugId, opinionSlugId, isEmbedView);
+      setActiveUserIntention("agreement");
+    }
+  }
+
+  function setReportIntention(opinionSlugId: string) {
+    if (
+      route.name === "/conversation/[postSlugId]" ||
+      route.name === "/conversation/[postSlugId].embed"
+    ) {
+      const isEmbedView = isEmbeddedMode();
+      const postSlugId = route.params.postSlugId;
+      createReportUserContentIntention(postSlugId, opinionSlugId, isEmbedView);
+      setActiveUserIntention("reportUserContent");
+    }
+  }
+
+  return {
+    setVotingIntention,
+    setOpinionAgreementIntention,
+    setReportIntention,
+  };
+}

--- a/services/agora/src/pages/conversation/[postSlugId].embed.vue
+++ b/services/agora/src/pages/conversation/[postSlugId].embed.vue
@@ -1,10 +1,10 @@
 <template>
   <EmbedLayout>
     <PostDetails
-      v-if="dataLoaded"
+      v-if="conversationLoaded"
       :key="String(isGuestOrLoggedIn)"
       v-model="currentTab"
-      :extended-post-data="postData"
+      :extended-post-data="conversationData"
       :compact-mode="false"
     />
   </EmbedLayout>
@@ -18,7 +18,7 @@ import { storeToRefs } from "pinia";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { ref } from "vue";
 
-const { postData, dataLoaded } = useConversationData();
+const { conversationData, conversationLoaded } = useConversationData();
 const { isGuestOrLoggedIn } = storeToRefs(useAuthenticationStore());
 const currentTab = ref<"comment" | "analysis">("comment");
 </script>

--- a/services/agora/src/pages/conversation/[postSlugId].vue
+++ b/services/agora/src/pages/conversation/[postSlugId].vue
@@ -19,13 +19,13 @@
       </DefaultMenuBar>
     </template>
 
-    <q-pull-to-refresh @refresh="pullDownTriggered">
+    <q-pull-to-refresh @refresh="refreshConversation">
       <WidthWrapper :enable="true">
         <PostDetails
-          v-if="dataLoaded"
-          :key="postData.metadata.lastReactedAt.toISOString()"
+          v-if="conversationLoaded"
+          :key="conversationData.metadata.lastReactedAt.toISOString()"
           v-model="currentTab"
-          :extended-post-data="postData"
+          :extended-post-data="conversationData"
           :compact-mode="false"
         />
       </WidthWrapper>
@@ -42,7 +42,8 @@ import { useConversationData } from "src/composables/useConversationData";
 import { ref } from "vue";
 
 const currentTab = ref<"comment" | "analysis">("comment");
-const { postData, dataLoaded, pullDownTriggered } = useConversationData();
+const { conversationData, conversationLoaded, refreshConversation } =
+  useConversationData();
 </script>
 
 <style scoped lang="scss"></style>

--- a/services/agora/src/stores/conversation.ts
+++ b/services/agora/src/stores/conversation.ts
@@ -1,0 +1,116 @@
+import { defineStore } from "pinia";
+import { ref, computed, watch } from "vue";
+import type { ExtendedConversation } from "src/shared/types/zod";
+import { useHomeFeedStore } from "src/stores/homeFeed";
+import { useBackendPostApi } from "src/utils/api/post";
+import { useAuthenticationStore } from "src/stores/authentication";
+import { storeToRefs } from "pinia";
+
+export const useConversationStore = defineStore("conversation", () => {
+  const { fetchPostBySlugId } = useBackendPostApi();
+  const { emptyPost } = useHomeFeedStore();
+  const { isGuestOrLoggedIn, isAuthInitialized } = storeToRefs(
+    useAuthenticationStore()
+  );
+
+  // State
+  const conversationData = ref<ExtendedConversation>(emptyPost);
+  const conversationLoaded = ref(false);
+  const isLoading = ref(false);
+  // Tracks the slug ID of the currently loaded conversation to avoid duplicate loading
+  const currentPostSlugId = ref<string>("");
+  // Stores a post slug ID when a load request is made before auth is initialized,
+  // allowing the request to be processed once auth becomes ready
+  const pendingPostSlugId = ref<string>("");
+
+  const hasConversationData = computed(
+    () =>
+      conversationLoaded.value &&
+      conversationData.value.metadata.conversationSlugId !== ""
+  );
+
+  // Wait for auth initialization to handle pending requests
+  watch(isAuthInitialized, async (isReady) => {
+    if (isReady && pendingPostSlugId.value) {
+      const slugId = pendingPostSlugId.value;
+      pendingPostSlugId.value = "";
+      await loadConversationData(slugId, true);
+    }
+  });
+
+  // Actions
+  async function loadConversationData(postSlugId: string, forceReload = false) {
+    // Avoid duplicate loading for the same post
+    if (
+      !forceReload &&
+      currentPostSlugId.value === postSlugId &&
+      hasConversationData.value
+    ) {
+      return true;
+    }
+
+    // If auth is not initialized yet, store the request for later
+    if (!isAuthInitialized.value) {
+      pendingPostSlugId.value = postSlugId;
+      return false;
+    }
+
+    isLoading.value = true;
+    try {
+      const response = await fetchPostBySlugId(
+        postSlugId,
+        isGuestOrLoggedIn.value
+      );
+      if (response != null) {
+        conversationData.value = response;
+        conversationLoaded.value = true;
+        currentPostSlugId.value = postSlugId;
+        return true;
+      } else {
+        conversationData.value = emptyPost;
+        conversationLoaded.value = false;
+        currentPostSlugId.value = "";
+        return false;
+      }
+    } catch (error) {
+      console.error("Failed to load conversation data:", error);
+      conversationData.value = emptyPost;
+      conversationLoaded.value = false;
+      currentPostSlugId.value = "";
+      return false;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  async function refreshConversationData() {
+    if (currentPostSlugId.value) {
+      return await loadConversationData(currentPostSlugId.value, true);
+    }
+    return false;
+  }
+
+  function clearConversationData() {
+    conversationData.value = emptyPost;
+    conversationLoaded.value = false;
+    currentPostSlugId.value = "";
+    pendingPostSlugId.value = "";
+    isLoading.value = false;
+  }
+
+  return {
+    // State
+    conversationData,
+    conversationLoaded,
+    isLoading,
+    currentPostSlugId,
+
+    // Computed
+    hasConversationData,
+
+    // Actions
+    loadConversationData,
+    refreshConversationData,
+    clearConversationData,
+  };
+});


### PR DESCRIPTION
- Improved authentication initialization in the conversation page
- Broken off the core data management of conversations into its own Pinia store ```services/agora/src/stores/conversation.ts```
- Separated login intentions into its own composable ```services/agora/src/composables/useConversationLoginIntentions.ts```