### PR TITLE
Fixed bug where unauthenticated users's display language preferences are being cleared on refresh

### DIFF
--- a/services/agora/src/components/feed/CompactPostList.vue
+++ b/services/agora/src/components/feed/CompactPostList.vue
@@ -29,19 +29,8 @@
           </div>
 
           <div>
-            <div v-if="!initializedFeed" class="postListFlex">
-              <div
-                v-for="postData in emptyPostDataList"
-                :key="postData.metadata.conversationSlugId"
-              >
-                <PostDetails
-                  v-model="currentTab"
-                  :conversation-data="postData"
-                  :compact-mode="true"
-                  class="showCursor"
-                  @click="openPost(postData.metadata.conversationSlugId)"
-                />
-              </div>
+            <div v-if="!initializedFeed" class="centerMessage">
+              <q-spinner-dots size="4rem" color="primary" />
             </div>
 
             <div
@@ -118,7 +107,6 @@ import {
 
 const {
   partialHomeFeedList,
-  emptyPostDataList,
   hasPendingNewPosts,
   initializedFeed,
   canLoadMore,

--- a/services/agora/src/stores/homeFeed.ts
+++ b/services/agora/src/stores/homeFeed.ts
@@ -131,13 +131,6 @@ export const useHomeFeedStore = defineStore("homeFeed", () => {
   let fullHomeFeedList: ExtendedConversation[] = [];
   const partialHomeFeedList = ref<ExtendedConversation[]>([]);
 
-  const emptyPostDataList = ref<ExtendedConversation[]>([
-    emptyPost,
-    emptyPost,
-    emptyPost,
-    emptyPost,
-  ]);
-
   watch(currentHomeFeedTab, async () => {
     await loadPostData();
   });
@@ -220,7 +213,6 @@ export const useHomeFeedStore = defineStore("homeFeed", () => {
     resetPostData,
     loadMore,
     partialHomeFeedList,
-    emptyPostDataList,
     emptyPost,
     hasPendingNewPosts,
     initializedFeed,

--- a/services/agora/src/utils/api/auth.ts
+++ b/services/agora/src/utils/api/auth.ts
@@ -207,7 +207,10 @@ export function useBackendAuthApi() {
         newLoginStatus.isKnown == false
       ) {
         console.log("Cleaning data from detecting change to unknown device");
-        await logoutDataCleanup();
+        await logoutDataCleanup({
+          shouldClearLanguagePreferences:
+            oldIsGuestOrLoggedIn && !newIsGuestOrLoggedIn,
+        });
         if (route.name) {
           await firstLoadGuard(route.name);
         }
@@ -222,7 +225,10 @@ export function useBackendAuthApi() {
           await loadAuthenticatedModules();
         } else {
           console.log("Cleaning data from logging out");
-          await logoutDataCleanup();
+          await logoutDataCleanup({
+            shouldClearLanguagePreferences:
+              oldIsGuestOrLoggedIn && !newIsGuestOrLoggedIn,
+          });
           if (route.name) {
             await firstLoadGuard(route.name);
           }
@@ -243,7 +249,11 @@ export function useBackendAuthApi() {
     });
   }
 
-  async function logoutDataCleanup() {
+  async function logoutDataCleanup({
+    shouldClearLanguagePreferences,
+  }: {
+    shouldClearLanguagePreferences: boolean;
+  }) {
     const platform: "mobile" | "web" = getPlatform($q.platform);
 
     await deleteDid(platform);
@@ -259,7 +269,9 @@ export function useBackendAuthApi() {
 
     clearTopicsData();
 
-    await clearLanguagePreferences();
+    if (shouldClearLanguagePreferences) {
+      await clearLanguagePreferences();
+    }
   }
 
   return {
@@ -269,6 +281,5 @@ export function useBackendAuthApi() {
     getDeviceLoginStatus,
     updateAuthState,
     initializeAuthState,
-    logoutDataCleanup,
   };
 }


### PR DESCRIPTION
Fixed:
- Display language for unauthenticated users will now persist
- Deprecated `emptyPostDataList` with `q-spinner-dots` as the loading screen