### PR TITLE
Show a confirmation dialog before user deletes a conversation/post or mutes a user

### DIFF
--- a/services/agora/src/components/post/comments/group/item/CommentActionOptions.vue
+++ b/services/agora/src/components/post/comments/group/item/CommentActionOptions.vue
@@ -29,8 +29,8 @@
 
   <!-- Action Dialog -->
   <ZKActionDialog
-    v-model="actionDialogVisible"
-    :actions="actionDialogActions"
+    v-model="commentActions.dialogState.value.isVisible"
+    :actions="commentActions.dialogState.value.actions"
     @action-selected="handleActionSelected"
     @dialog-closed="handleDialogClosed"
   />
@@ -87,10 +87,6 @@ const { showNotifyMessage } = useNotify();
 
 // Use the new content actions system
 const commentActions = useContentActions();
-
-// Action dialog state
-const actionDialogVisible = ref(false);
-const actionDialogActions = ref<ContentAction[]>([]);
 
 const showReportDialog = ref(false);
 
@@ -180,11 +176,6 @@ function optionButtonClicked() {
       shareOpinionCallback,
     }
   );
-
-  // Get the dialog state and display it
-  const state = commentActions.getDialogState();
-  actionDialogVisible.value = state.isVisible;
-  actionDialogActions.value = state.actions;
 }
 
 /**
@@ -199,8 +190,6 @@ async function handleActionSelected(action: ContentAction) {
  * Handle dialog close
  */
 function handleDialogClosed() {
-  actionDialogVisible.value = false;
-  actionDialogActions.value = [];
   commentActions.closeDialog();
 }
 </script>

--- a/services/agora/src/components/post/comments/group/item/CommentActionOptions.vue
+++ b/services/agora/src/components/post/comments/group/item/CommentActionOptions.vue
@@ -34,6 +34,17 @@
     @action-selected="handleActionSelected"
     @dialog-closed="handleDialogClosed"
   />
+
+  <!-- Confirmation Dialog -->
+  <ZKConfirmDialog
+    v-model="commentActions.confirmationState.value.isVisible"
+    :message="commentActions.confirmationState.value.message"
+    :confirm-text="commentActions.confirmationState.value.confirmText"
+    :cancel-text="commentActions.confirmationState.value.cancelText"
+    :variant="commentActions.confirmationState.value.variant"
+    @confirm="commentActions.handleConfirmation"
+    @cancel="commentActions.handleConfirmationCancel"
+  />
 </template>
 
 <script setup lang="ts">
@@ -43,6 +54,7 @@ import ReportContentDialog from "src/components/report/ReportContentDialog.vue";
 import ZKButton from "src/components/ui-library/ZKButton.vue";
 import ZKIcon from "src/components/ui-library/ZKIcon.vue";
 import ZKActionDialog from "src/components/ui-library/ZKActionDialog.vue";
+import ZKConfirmDialog from "src/components/ui-library/ZKConfirmDialog.vue";
 import type { OpinionItem } from "src/shared/types/zod";
 import type { ContentAction } from "src/utils/actions/core/types";
 import { useAuthenticationStore } from "src/stores/authentication";

--- a/services/agora/src/components/post/display/PostMetadata.vue
+++ b/services/agora/src/components/post/display/PostMetadata.vue
@@ -44,8 +44,8 @@
 
   <!-- Action Dialog -->
   <ZKActionDialog
-    v-model="actionDialogVisible"
-    :actions="actionDialogActions"
+    v-model="postActions.dialogState.value.isVisible"
+    :actions="postActions.dialogState.value.actions"
     @action-selected="handleActionSelected"
     @dialog-closed="handleDialogClosed"
   />
@@ -99,10 +99,6 @@ const route = useRoute();
 const postActions = useContentActions();
 
 const { isLoggedIn } = storeToRefs(useAuthenticationStore());
-
-// Action dialog state
-const actionDialogVisible = ref(false);
-const actionDialogActions = ref<ContentAction[]>([]);
 
 const { muteUser } = useBackendUserMuteApi();
 const { loadPostData } = useHomeFeedStore();
@@ -182,11 +178,6 @@ function clickedMoreIcon() {
     moderationHistoryCallback,
     copyEmbedLinkCallback,
   });
-
-  // Get the dialog state and display it
-  const state = postActions.getDialogState();
-  actionDialogVisible.value = state.isVisible;
-  actionDialogActions.value = state.actions;
 }
 
 /**
@@ -201,8 +192,6 @@ async function handleActionSelected(action: ContentAction) {
  * Handle dialog close
  */
 function handleDialogClosed() {
-  actionDialogVisible.value = false;
-  actionDialogActions.value = [];
   postActions.closeDialog();
 }
 </script>

--- a/services/agora/src/components/post/display/PostMetadata.vue
+++ b/services/agora/src/components/post/display/PostMetadata.vue
@@ -49,11 +49,23 @@
     @action-selected="handleActionSelected"
     @dialog-closed="handleDialogClosed"
   />
+
+  <!-- Confirmation Dialog -->
+  <ZKConfirmDialog
+    v-model="postActions.confirmationState.value.isVisible"
+    :message="postActions.confirmationState.value.message"
+    :confirm-text="postActions.confirmationState.value.confirmText"
+    :cancel-text="postActions.confirmationState.value.cancelText"
+    :variant="postActions.confirmationState.value.variant"
+    @confirm="postActions.handleConfirmation"
+    @cancel="postActions.handleConfirmationCancel"
+  />
 </template>
 
 <script setup lang="ts">
 import ZKButton from "src/components/ui-library/ZKButton.vue";
 import ZKActionDialog from "src/components/ui-library/ZKActionDialog.vue";
+import ZKConfirmDialog from "src/components/ui-library/ZKConfirmDialog.vue";
 import { useContentActions } from "src/utils/actions/definitions/content-actions";
 import { ref } from "vue";
 import type { ContentAction } from "src/utils/actions/core/types";

--- a/services/agora/src/components/ui-library/ZKBottomDialogContainer.vue
+++ b/services/agora/src/components/ui-library/ZKBottomDialogContainer.vue
@@ -10,7 +10,7 @@
   flex-direction: column;
   gap: 1rem;
   padding: 2rem;
-  background-color: $app-background-color;
+  background-color: white;
   border-radius: 25px 25px 0 0;
   width: min(30rem, 100%);
 }

--- a/services/agora/src/components/ui-library/ZKConfirmDialog.vue
+++ b/services/agora/src/components/ui-library/ZKConfirmDialog.vue
@@ -1,0 +1,126 @@
+<template>
+  <q-dialog v-model="showDialog" position="bottom">
+    <ZKBottomDialogContainer>
+      <div class="confirm-dialog">
+        <div class="dialog-header">
+          <h3 v-if="title" class="dialog-title">{{ title }}</h3>
+          <p class="dialog-message">{{ message }}</p>
+        </div>
+
+        <div class="dialog-actions">
+          <PrimeButton
+            :label="cancelText"
+            severity="secondary"
+            outlined
+            class="cancel-button"
+            @click="handleCancel"
+          />
+          <PrimeButton
+            :label="confirmText"
+            :severity="variant === 'destructive' ? 'danger' : 'primary'"
+            class="confirm-button"
+            @click="handleConfirm"
+          />
+        </div>
+      </div>
+    </ZKBottomDialogContainer>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { watch } from "vue";
+import ZKBottomDialogContainer from "./ZKBottomDialogContainer.vue";
+
+interface Props {
+  title?: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: "default" | "destructive";
+}
+
+interface Emits {
+  (e: "confirm"): void;
+  (e: "cancel"): void;
+  (e: "dialogClosed"): void;
+}
+
+withDefaults(defineProps<Props>(), {
+  title: undefined,
+  confirmText: "Confirm",
+  cancelText: "Cancel",
+  variant: "default",
+});
+
+const emit = defineEmits<Emits>();
+
+const showDialog = defineModel<boolean>();
+
+/**
+ * Handle confirm button click
+ */
+const handleConfirm = (): void => {
+  emit("confirm");
+  showDialog.value = false;
+};
+
+/**
+ * Handle cancel button click
+ */
+const handleCancel = (): void => {
+  emit("cancel");
+  showDialog.value = false;
+};
+
+/**
+ * Handle dialog close
+ */
+const handleDialogClose = (): void => {
+  emit("dialogClosed");
+};
+
+// Watch dialog state changes
+watch(showDialog, (newValue) => {
+  if (!newValue) {
+    handleDialogClose();
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.confirm-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  color: $primary;
+}
+
+.dialog-header {
+  text-align: center;
+
+  .dialog-title {
+    margin: 0 0 1rem 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: $color-text-strong;
+  }
+
+  .dialog-message {
+    margin: 0;
+    font-size: 1rem;
+    color: black;
+    line-height: 1.5;
+  }
+}
+
+.dialog-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: stretch;
+
+  .cancel-button,
+  .confirm-button {
+    flex: 1;
+  }
+}
+</style>

--- a/services/agora/src/utils/actions/core/handlers.ts
+++ b/services/agora/src/utils/actions/core/handlers.ts
@@ -91,58 +91,8 @@ export function useActionHandlers() {
     }
   };
 
-  /**
-   * Create a wrapper for handling confirmation dialogs
-   */
-  const withConfirmation = (
-    handler: () => void | Promise<void>,
-    message: string = "Are you sure you want to perform this action?"
-  ) => {
-    return async () => {
-      if (confirm(message)) {
-        await handler();
-      }
-    };
-  };
-
-  /**
-   * Handle action with proper error handling and notifications
-   */
-  const handleActionSafely = async (
-    actionId: string,
-    context: ContentActionContext,
-    handler: () => void | Promise<void>,
-    confirmationMessage?: string
-  ): Promise<ContentActionResult> => {
-    try {
-      let wrappedHandler = handler;
-
-      // Add confirmation wrapper if needed
-      if (confirmationMessage) {
-        wrappedHandler = withConfirmation(handler, confirmationMessage);
-      }
-
-      const result = await executeAction(actionId, context, wrappedHandler);
-
-      // Show success notification for certain actions
-      if (result.success && result.message) {
-        showNotifyMessage(result.message);
-      }
-
-      return result;
-    } catch (error) {
-      console.error(`Error in handleActionSafely for ${actionId}:`, error);
-      const errorMessage =
-        error instanceof Error ? error.message : "Unknown error occurred";
-      showNotifyMessage(`Error: ${errorMessage}`);
-      return { success: false, error: errorMessage };
-    }
-  };
-
   return {
     executeAction,
     handlePostDelete,
-    handleActionSafely,
-    withConfirmation,
   };
 }

--- a/services/agora/src/utils/actions/core/types.ts
+++ b/services/agora/src/utils/actions/core/types.ts
@@ -10,7 +10,6 @@ export interface BaseContentAction {
   description?: string;
   icon: string;
   variant?: "default" | "destructive" | "warning";
-  requiresConfirmation?: boolean;
 }
 
 // Context for determining available content actions

--- a/services/agora/src/utils/actions/definitions/comments.ts
+++ b/services/agora/src/utils/actions/definitions/comments.ts
@@ -54,7 +54,6 @@ export function getCommentActions(
       label: translations.delete,
       icon: "mdi-delete",
       variant: "destructive",
-      requiresConfirmation: true,
       handler: deleteCommentCallback,
       isVisible: (context: ContentActionContext) =>
         context.userRole === "owner",

--- a/services/agora/src/utils/actions/definitions/content-actions.i18n.ts
+++ b/services/agora/src/utils/actions/definitions/content-actions.i18n.ts
@@ -7,6 +7,11 @@ export interface ActionsTranslations {
   share: string;
   moderationHistory: string;
   embedLink: string;
+  cancel: string;
+  confirm: string;
+  confirmDeletePost: string;
+  confirmDeleteComment: string;
+  confirmGenericAction: string;
 }
 
 export const actionsTranslations: Record<string, ActionsTranslations> = {
@@ -19,6 +24,11 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     share: "Share",
     moderationHistory: "Moderation History",
     embedLink: "Copy Embed Link",
+    cancel: "Cancel",
+    confirm: "Confirm",
+    confirmDeletePost: "Are you sure you want to delete this conversation?",
+    confirmDeleteComment: "Are you sure you want to delete this opinion?",
+    confirmGenericAction: "Are you sure you want to perform this action?",
   },
   es: {
     report: "Reportar",
@@ -29,6 +39,11 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     share: "Compartir",
     moderationHistory: "Historial de Moderación",
     embedLink: "Copiar Enlace de Inserción",
+    cancel: "Cancelar",
+    confirm: "Confirmar",
+    confirmDeletePost: "¿Está seguro de que desea eliminar esta conversación?",
+    confirmDeleteComment: "¿Está seguro de que desea eliminar esta opinión?",
+    confirmGenericAction: "¿Está seguro de que desea realizar esta acción?",
   },
   fr: {
     report: "Signaler",
@@ -39,6 +54,12 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     share: "Partager",
     moderationHistory: "Historique de Modération",
     embedLink: "Copier le Lien d'Intégration",
+    cancel: "Annuler",
+    confirm: "Confirmer",
+    confirmDeletePost:
+      "Êtes-vous sûr de vouloir supprimer cette conversation ?",
+    confirmDeleteComment: "Êtes-vous sûr de vouloir supprimer cette opinion ?",
+    confirmGenericAction: "Êtes-vous sûr de vouloir effectuer cette action ?",
   },
   "zh-Hans": {
     report: "举报",
@@ -49,6 +70,11 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     share: "分享",
     moderationHistory: "审核历史",
     embedLink: "复制嵌入链接",
+    cancel: "取消",
+    confirm: "确认",
+    confirmDeletePost: "您确定要删除此对话吗？",
+    confirmDeleteComment: "您确定要删除此观点吗？",
+    confirmGenericAction: "您确定要执行此操作吗？",
   },
   "zh-Hant": {
     report: "舉報",
@@ -59,6 +85,11 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     share: "分享",
     moderationHistory: "審核歷史",
     embedLink: "複製嵌入連結",
+    cancel: "取消",
+    confirm: "確認",
+    confirmDeletePost: "您確定要刪除此對話嗎？",
+    confirmDeleteComment: "您確定要刪除此觀點嗎？",
+    confirmGenericAction: "您確定要執行此操作嗎？",
   },
   ja: {
     report: "報告",
@@ -69,5 +100,10 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     share: "共有",
     moderationHistory: "審査履歴",
     embedLink: "埋め込みリンクをコピー",
+    cancel: "キャンセル",
+    confirm: "確認",
+    confirmDeletePost: "この会話を削除してもよろしいですか？",
+    confirmDeleteComment: "この意見を削除してもよろしいですか？",
+    confirmGenericAction: "この操作を実行してもよろしいですか？",
   },
 };

--- a/services/agora/src/utils/actions/definitions/content-actions.i18n.ts
+++ b/services/agora/src/utils/actions/definitions/content-actions.i18n.ts
@@ -11,6 +11,7 @@ export interface ActionsTranslations {
   confirm: string;
   confirmDeletePost: string;
   confirmDeleteComment: string;
+  confirmMuteUser: string;
   confirmGenericAction: string;
 }
 
@@ -28,6 +29,8 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     confirm: "Confirm",
     confirmDeletePost: "Are you sure you want to delete this conversation?",
     confirmDeleteComment: "Are you sure you want to delete this opinion?",
+    confirmMuteUser:
+      "Are you sure you want to mute this user? You won't see their conversations and opinions anymore.",
     confirmGenericAction: "Are you sure you want to perform this action?",
   },
   es: {
@@ -43,6 +46,8 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     confirm: "Confirmar",
     confirmDeletePost: "¿Está seguro de que desea eliminar esta conversación?",
     confirmDeleteComment: "¿Está seguro de que desea eliminar esta opinión?",
+    confirmMuteUser:
+      "¿Está seguro de que desea silenciar a este usuario? Ya no verá sus conversaciones y opiniones.",
     confirmGenericAction: "¿Está seguro de que desea realizar esta acción?",
   },
   fr: {
@@ -59,6 +64,8 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     confirmDeletePost:
       "Êtes-vous sûr de vouloir supprimer cette conversation ?",
     confirmDeleteComment: "Êtes-vous sûr de vouloir supprimer cette opinion ?",
+    confirmMuteUser:
+      "Êtes-vous sûr de vouloir mettre cet utilisateur en sourdine ? Vous ne verrez plus ses conversations et opinions.",
     confirmGenericAction: "Êtes-vous sûr de vouloir effectuer cette action ?",
   },
   "zh-Hans": {
@@ -74,6 +81,7 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     confirm: "确认",
     confirmDeletePost: "您确定要删除此对话吗？",
     confirmDeleteComment: "您确定要删除此观点吗？",
+    confirmMuteUser: "您确定要屏蔽此用户吗？您将不再看到他们的对话和观点。",
     confirmGenericAction: "您确定要执行此操作吗？",
   },
   "zh-Hant": {
@@ -89,6 +97,7 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     confirm: "確認",
     confirmDeletePost: "您確定要刪除此對話嗎？",
     confirmDeleteComment: "您確定要刪除此觀點嗎？",
+    confirmMuteUser: "您確定要屏蔽此用戶嗎？您將不再看到他們的對話和觀點。",
     confirmGenericAction: "您確定要執行此操作嗎？",
   },
   ja: {
@@ -104,6 +113,8 @@ export const actionsTranslations: Record<string, ActionsTranslations> = {
     confirm: "確認",
     confirmDeletePost: "この会話を削除してもよろしいですか？",
     confirmDeleteComment: "この意見を削除してもよろしいですか？",
+    confirmMuteUser:
+      "このユーザーをミュートしてもよろしいですか？このユーザーの会話や意見は表示されなくなります。",
     confirmGenericAction: "この操作を実行してもよろしいですか？",
   },
 };

--- a/services/agora/src/utils/actions/definitions/content-actions.ts
+++ b/services/agora/src/utils/actions/definitions/content-actions.ts
@@ -299,15 +299,9 @@ export function useContentActions() {
     };
   };
 
-  /**
-   * Get current dialog state
-   */
-  const getDialogState = () => dialogState.value;
-
   return {
     // Dialog state
     dialogState,
-    getDialogState,
     confirmationState,
 
     // Action functions

--- a/services/agora/src/utils/actions/definitions/content-actions.ts
+++ b/services/agora/src/utils/actions/definitions/content-actions.ts
@@ -268,9 +268,6 @@ export function useContentActions() {
    */
   const handleConfirmationCancel = (): void => {
     closeConfirmationDialog();
-
-    // Show action dialog again
-    dialogState.value.isVisible = true;
   };
 
   /**

--- a/services/agora/src/utils/actions/definitions/content-actions.ts
+++ b/services/agora/src/utils/actions/definitions/content-actions.ts
@@ -36,7 +36,7 @@ import {
 } from "./content-actions.i18n";
 
 // Actions that require confirmation before execution
-const DESTRUCTIVE_ACTIONS = ["delete"];
+const DESTRUCTIVE_ACTIONS = ["delete", "muteUser"];
 
 /**
  * Main composable for content actions management
@@ -204,17 +204,23 @@ export function useContentActions() {
     const targetType = dialogState.value.context?.targetType;
 
     let confirmMessage = t("confirmGenericAction");
+    let confirmText = t("confirm");
+
     if (action.id === "delete") {
       confirmMessage =
         targetType === "post"
           ? t("confirmDeletePost")
           : t("confirmDeleteComment");
+      confirmText = t("delete");
+    } else if (action.id === "muteUser") {
+      confirmMessage = t("confirmMuteUser");
+      confirmText = t("muteUser");
     }
 
     confirmationState.value = {
       isVisible: true,
       message: confirmMessage,
-      confirmText: t("delete"),
+      confirmText: confirmText,
       cancelText: t("cancel"),
       variant: action.variant === "destructive" ? "destructive" : "default",
       pendingAction: action,

--- a/services/agora/src/utils/actions/definitions/posts.ts
+++ b/services/agora/src/utils/actions/definitions/posts.ts
@@ -56,7 +56,6 @@ export function getPostActions(
       label: translations.delete,
       icon: "mdi-delete",
       variant: "destructive",
-      requiresConfirmation: true,
       handler: deletePostCallback,
       isVisible: (context: ContentActionContext) =>
         context.userRole === "owner" && !context.isEmbeddedMode,


### PR DESCRIPTION
Changes:
- Revised the system with a new ZKConfirmDialog for when user executes a function that requires confirmation.
- Require confirmation before a user deletes a conversation/post or mutes a user