### PR TITLE
feat(conversation): Display participant count

### DIFF
--- a/services/agora/src/components/post/PostDetails.vue
+++ b/services/agora/src/components/post/PostDetails.vue
@@ -18,6 +18,7 @@
           :opinion-count="
             conversationData.metadata.opinionCount + opinionCountOffset
           "
+          :participant-count="participantCountLocal"
           :is-loading="isCurrentTabLoading"
           @share="shareClicked()"
         />

--- a/services/agora/src/components/post/interactionBar/PostActionBar.vue
+++ b/services/agora/src/components/post/interactionBar/PostActionBar.vue
@@ -9,7 +9,11 @@
       />
     </div>
 
-    <div>
+    <div class="rightSection">
+      <div class="participantCountContainer">
+        <ZKIcon color="#7D7A85" name="ph:users" size="1rem" />
+        <span>{{ participantCount }}</span>
+      </div>
       <ZKButton
         button-type="standardButton"
         @click.stop.prevent="$emit('share')"
@@ -38,6 +42,7 @@ import {
 const props = defineProps<{
   compactMode: boolean;
   opinionCount: number;
+  participantCount: number;
   isLoading?: boolean;
 }>();
 
@@ -71,7 +76,18 @@ defineEmits(["share"]);
   align-items: center;
   gap: 0.75rem;
 }
-
+.rightSection {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.participantCountContainer{
+  gap: 0.3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #7d7a85;
+}
 .shareButtonContentContainer {
   gap: 0.3rem;
   display: flex;
@@ -79,4 +95,5 @@ defineEmits(["share"]);
   justify-content: center;
   color: #7d7a85;
 }
+
 </style>


### PR DESCRIPTION
Adds the participant count to the action bar on the conversation details page, next to the share button.