### PR TITLE
refactor(math-updater): add job concurrency control to protect database

### DIFF
--- a/services/math-updater/README.md
+++ b/services/math-updater/README.md
@@ -51,7 +51,8 @@ Configuration is managed via environment variables. See `env.example` for requir
 ### Math Updater Settings
 
 - `MATH_UPDATER_SCAN_INTERVAL_MS`: How often to scan for conversations needing updates (default: 2000ms = 2 seconds, min: 2000ms)
-- `MATH_UPDATER_PROCESS_CONCURRENCY`: Number of concurrent math update jobs (default: 10, max: 50)
+- `MATH_UPDATER_BATCH_SIZE`: Number of jobs to fetch per batch from the queue. Also determines database connection pool size (batch size + 5) (default: 10, max: 50)
+- `MATH_UPDATER_JOB_CONCURRENCY`: Number of jobs that execute concurrently within each batch. Limits concurrent heavy database operations to protect the database server (default: 3, max: 10)
 - `MATH_UPDATER_MIN_TIME_BETWEEN_UPDATES_MS`: Minimum time between updates for a single conversation (default: 20000ms = 20 seconds, min: 5000ms)
 
 ### AWS Configuration (for AI labels/summaries)

--- a/services/math-updater/env.example
+++ b/services/math-updater/env.example
@@ -9,13 +9,16 @@ DB_POOL_IDLE_TIMEOUT=60
 POLIS_BASE_URL=http://localhost:5000
 
 # Math Updater Settings
-# How often to scan for conversations needing updates (in milliseconds, min: 10000)
+# How often to scan for conversations needing updates (in milliseconds, min: 2000)
 MATH_UPDATER_SCAN_INTERVAL_MS=60000
 
-# Number of concurrent math update jobs (min: 1, max: 50, default: 10)
-MATH_UPDATER_PROCESS_CONCURRENCY=10
+# Number of jobs to fetch per batch from the queue (min: 1, max: 50, default: 10)
+MATH_UPDATER_BATCH_SIZE=10
 
-# Minimum time between updates for a single conversation (in milliseconds, min: 60000)
+# Number of jobs that execute concurrently within each batch (min: 1, max: 10, default: 3)
+MATH_UPDATER_JOB_CONCURRENCY=3
+
+# Minimum time between updates for a single conversation (in milliseconds, min: 5000)
 MATH_UPDATER_MIN_TIME_BETWEEN_UPDATES_MS=120000
 
 # AWS Configuration (Production)

--- a/services/math-updater/package.json
+++ b/services/math-updater/package.json
@@ -32,6 +32,7 @@
         "drizzle-orm": "^0.39.3",
         "extract-first-json": "^2.0.2",
         "libphonenumber-js": "^1.12.23",
+        "p-limit": "^7.1.1",
         "parse-json-object": "^3.0.1",
         "pg-boss": "^10.1.5",
         "pino": "^9.6.0",

--- a/services/math-updater/pnpm-lock.yaml
+++ b/services/math-updater/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       libphonenumber-js:
         specifier: ^1.12.23
         version: 1.12.23
+      p-limit:
+        specifier: ^7.1.1
+        version: 7.1.1
       parse-json-object:
         specifier: ^3.0.1
         version: 3.0.1
@@ -1357,6 +1360,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@7.1.1:
+    resolution: {integrity: sha512-i8PyM2JnsNChVSYWLr2BAjNoLi0BAYC+wecOnZnVV+YSNJkzP7cWmvI34dk0WArWfH9KwBHNoZI3P3MppImlIA==}
+    engines: {node: '>=20'}
+
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
@@ -1666,6 +1673,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.1:
+    resolution: {integrity: sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==}
+    engines: {node: '>=12.20'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -3271,6 +3282,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@7.1.1:
+    dependencies:
+      yocto-queue: 1.2.1
+
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
@@ -3551,5 +3566,7 @@ snapshots:
   xtend@4.0.2: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.1: {}
 
   zod@3.25.76: {}

--- a/services/math-updater/src/config.ts
+++ b/services/math-updater/src/config.ts
@@ -18,12 +18,18 @@ const mathUpdaterConfigSchema = sharedConfigSchema.extend({
         .int()
         .min(2000)
         .default(2000),
-    MATH_UPDATER_PROCESS_CONCURRENCY: z.coerce
+    MATH_UPDATER_BATCH_SIZE: z.coerce
         .number()
         .int()
         .min(1)
         .max(50)
         .default(10),
+    MATH_UPDATER_JOB_CONCURRENCY: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(10)
+        .default(3),
     MATH_UPDATER_MIN_TIME_BETWEEN_UPDATES_MS: z.coerce
         .number()
         .int()


### PR DESCRIPTION
  - Add MATH_UPDATER_JOB_CONCURRENCY config (default: 3, max: 10) to limit concurrent database operations and prevent overwhelming the database server
  - Rename MATH_UPDATER_PROCESS_CONCURRENCY to MATH_UPDATER_BATCH_SIZE to accurately reflect its purpose (controls job batch fetching, not execution)
  - Implement p-limit for controlled concurrent job execution within batches
  - Keep only the latest job per conversationId based on mathUpdateRequestedAt
  - Update documentation and env.example to clarify configuration options

  This change decouples batch size from execution concurrency, allowing larger
  batches to be fetched efficiently while protecting the database with controlled
  concurrent execution. For example, with batch_size=10 and concurrency=3, the
  service fetches 10 jobs but only processes 3 concurrently.