### PR TITLE
refactor(math-updater): use pg-boss singletonKey for job deduplication

### DIFF
--- a/services/math-updater/src/jobs/scanConversations.ts
+++ b/services/math-updater/src/jobs/scanConversations.ts
@@ -64,11 +64,20 @@ export async function scanConversationsJob(
 
         // Enqueue each conversation for processing
         for (const conversation of conversations) {
-            await boss.send("update-conversation-math", {
-                conversationId: conversation.id,
-                conversationSlugId: conversation.slugId,
-                mathUpdateRequestedAt: conversation.mathUpdateRequestedAt,
-            });
+            await boss.send(
+                "update-conversation-math",
+                {
+                    conversationId: conversation.id,
+                    conversationSlugId: conversation.slugId,
+                    mathUpdateRequestedAt: conversation.mathUpdateRequestedAt,
+                },
+                {
+                    // Use singletonKey to prevent duplicate jobs for the same conversation
+                    singletonKey: `update-math-${conversation.id}`,
+                    // if a job is throttled it will be sent in the next slot (debounced)
+                    singletonSeconds: 15, // same conversation events will be ignored for the next 15 seconds
+                },
+            );
 
             log.debug(
                 `[Scan] Enqueued conversation ${conversation.slugId} (id: ${conversation.id})`,


### PR DESCRIPTION
  Replace manual in-memory job deduplication with pg-boss's built-in
  singletonKey feature. This ensures only one update job per conversation
  is queued at the database level, preventing race conditions across
  service instances.

  Also add AWS Secrets Manager support for pg-boss configuration in
  production environments.

  This commit message:
  - Follows the type(scope): description format used in your repo
  - Clearly describes the main change (switching from manual to singletonKey-based deduplication)
  - Explains the benefit (preventing race conditions across instances)
  - Mentions the secondary change (AWS Secrets Manager support)
  - Uses "refactor" since you're improving the implementation without changing functionality