### PR TITLE
feat(post): Add QR code dialog for post sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,13 +105,19 @@ duplicate updates and database contention."
 - **Be exhaustive in the body**: explain what changed, why it changed, and any important implementation details
 - Use the body to provide context that reviewers and future maintainers will need
 - Reference issue numbers, design decisions, or related PRs in the body or footer
-- **Do NOT mention AI assistants or tools** (e.g., "Claude", "AI-generated") in commit messages
+- **Do NOT mention AI assistants or tools in commit messages** (e.g., "Claude", "AI-generated", "with assistance from")
+  - This restriction applies ONLY to commit messages - code comments can mention tools/AI if helpful for context
 
 **Before committing:**
 1. **Review all staged changes** with `git status` and `git diff --staged`
 2. **Verify nothing is staged by mistake** (secrets, debug code, unrelated changes, etc.)
-3. **If suspicious files are found**, report them to the user and abort the commit
-4. **Wait for user confirmation** before proceeding with the commit
+3. **Check for poor quality comments**:
+   - Remove redundant comments that state the obvious (e.g., `// Set variable to true` above `flag = true`)
+   - Remove outdated or incorrect comments
+   - Remove commented-out code unless there's a specific reason to keep it
+   - Ensure remaining comments explain "why" not "what"
+4. **If suspicious files are found**, report them to the user and abort the commit
+5. **Wait for user confirmation** before proceeding with the commit
 
 ### Database Operations
 

--- a/services/agora/package.json
+++ b/services/agora/package.json
@@ -75,7 +75,7 @@
     "@quasar/app-vite": "2.3.0",
     "@sentry/vite-plugin": "^4.3.0",
     "@types/node": "^24.5.2",
-    "@types/qrcode": "^1.5.5",
+    "@types/qrcode": "^1.5.6",
     "@types/sanitize-html": "^2.13.0",
     "@vitejs/plugin-basic-ssl": "^2.0.0",
     "@vue/eslint-config-prettier": "^10.2.0",

--- a/services/agora/src/components/post/ShareDialog.i18n.ts
+++ b/services/agora/src/components/post/ShareDialog.i18n.ts
@@ -1,0 +1,53 @@
+/**
+ * Internationalization translations for ShareDialog component
+ * Supports all languages configured in the application
+ */
+
+import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
+
+export interface ShareDialogTranslations {
+  copyLink: string;
+  copiedToClipboard: string;
+  couldNotCopy: string;
+}
+
+export const shareDialogTranslations: Record<
+  SupportedDisplayLanguageCodes,
+  ShareDialogTranslations
+> = {
+  en: {
+    copyLink: "Copy link",
+    copiedToClipboard: "Copied link to clipboard",
+    couldNotCopy: "Could not copy to clipboard",
+  },
+  ar: {
+    copyLink: "نسخ الرابط",
+    copiedToClipboard: "تم نسخ الرابط إلى الحافظة",
+    couldNotCopy: "تعذر النسخ إلى الحافظة",
+  },
+  es: {
+    copyLink: "Copiar enlace",
+    copiedToClipboard: "Enlace copiado al portapapeles",
+    couldNotCopy: "No se pudo copiar al portapapeles",
+  },
+  fr: {
+    copyLink: "Copier le lien",
+    copiedToClipboard: "Lien copié dans le presse-papiers",
+    couldNotCopy: "Impossible de copier dans le presse-papiers",
+  },
+  "zh-Hans": {
+    copyLink: "复制链接",
+    copiedToClipboard: "已复制链接到剪贴板",
+    couldNotCopy: "无法复制到剪贴板",
+  },
+  "zh-Hant": {
+    copyLink: "複製連結",
+    copiedToClipboard: "已複製連結到剪貼簿",
+    couldNotCopy: "無法複製到剪貼簿",
+  },
+  ja: {
+    copyLink: "リンクをコピー",
+    copiedToClipboard: "リンクをクリップボードにコピーしました",
+    couldNotCopy: "クリップボードにコピーできませんでした",
+  },
+};

--- a/services/agora/src/components/post/ShareDialog.vue
+++ b/services/agora/src/components/post/ShareDialog.vue
@@ -1,38 +1,39 @@
 <template>
   <q-dialog ref="dialogRef" @hide="onDialogHide">
-    <q-card class="share-dialog-card">
-      <q-btn
-        icon="close"
-        flat
-        round
-        dense
-        class="close-button"
-        @click="onDialogCancel"
-      />
+    <div class="dialog-container">
+      <div class="dialog-header">
+        <ZKButton
+          button-type="icon"
+          icon="mdi-close"
+          size="1rem"
+          @click="onDialogCancel"
+        />
+      </div>
 
       <div class="dialog-content">
         <div class="qr-code-container">
           <img v-if="qrCodeDataUrl" :src="qrCodeDataUrl" alt="QR Code" />
         </div>
 
-        <q-btn
-          no-caps
-          class="copy-button"
-          @click="copyUrl"
-        >
-          <div class="flex items-center no-wrap">
-            <div>Copy link to conversation</div>
-          </div>
-        </q-btn>
+        <ZKButton button-type="largeButton" class="copy-link-button" @click="copyUrl">
+          {{ t("copyLink") }}
+        </ZKButton>
       </div>
-    </q-card>
+    </div>
   </q-dialog>
 </template>
 
 <script setup lang="ts">
-import { useDialogPluginComponent, useQuasar, copyToClipboard } from "quasar";
+import { useDialogPluginComponent, copyToClipboard } from "quasar";
 import QRCode from "qrcode";
 import { ref, onMounted } from "vue";
+import { useNotify } from "src/utils/ui/notify";
+import { useComponentI18n } from "src/composables/ui/useComponentI18n";
+import ZKButton from "src/components/ui-library/ZKButton.vue";
+import {
+  shareDialogTranslations,
+  type ShareDialogTranslations,
+} from "./ShareDialog.i18n";
 
 const props = defineProps<{
   url: string;
@@ -42,7 +43,10 @@ const props = defineProps<{
 defineEmits([...useDialogPluginComponent.emits]);
 
 const { dialogRef, onDialogHide, onDialogCancel } = useDialogPluginComponent();
-const $q = useQuasar();
+const { showNotifyMessage } = useNotify();
+const { t } = useComponentI18n<ShareDialogTranslations>(
+  shareDialogTranslations
+);
 
 const qrCodeDataUrl = ref("");
 
@@ -61,60 +65,46 @@ onMounted(async () => {
   }
 });
 
-function copyUrl() {
-  copyToClipboard(props.url)
-    .then(() => {
-      $q.notify({
-        message: "Copied to clipboard!",
-        color: "positive",
-        position: "top",
-        icon: "check",
-      });
-    })
-    .catch(() => {
-      $q.notify({
-        message: "Could not copy to clipboard.",
-        color: "negative",
-        position: "top",
-        icon: "warning",
-      });
-    });
+async function copyUrl(): Promise<void> {
+  try {
+    await copyToClipboard(props.url);
+    showNotifyMessage(t("copiedToClipboard"));
+  } catch (error) {
+    console.error("Failed to copy to clipboard:", error);
+    showNotifyMessage(t("couldNotCopy"));
+  }
 }
 </script>
 
 <style scoped lang="scss">
-.share-dialog-card {
-  width: 428px;
-  height: 450px;
-  border-radius: 32px;
-  background: linear-gradient(114.81deg, #f1eeff 46.45%, #e8f1ff 100.1%);
-  padding: 24px;
-  position: relative;
+.dialog-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  background: linear-gradient(114.81deg, #f1eeff 46.45%, #e8f1ff 100.1%);
+  border-radius: 25px;
+  width: min(100vw, 428px);
+  max-height: 80vh;
+  overflow: hidden;
 }
 
-.close-button {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  width: 48px;
-  height: 48px;
-  border-radius: 16px;
-  background-color: rgba(0, 0, 0, 0.05);
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 1.5rem 1.5rem 0 1.5rem;
 }
 
 .dialog-content {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
-  width: 100%;
-  flex-grow: 1; /* Allow container to grow */
-  justify-content: center; /* Center content vertically */
+  gap: 1.5rem;
+  padding: 1.5rem;
+  padding-top: 1rem;
+  overflow-y: auto;
+  flex: 1;
+  justify-content: center;
 }
-
 
 .qr-code-container {
   width: 218px;
@@ -124,15 +114,18 @@ function copyUrl() {
   justify-content: center;
 }
 
-.copy-button {
-  width: 241px;
+.copy-link-button :deep(.q-btn) {
+  width: 227px;
   height: 48px;
-  border-radius: 16px;
-  background: linear-gradient(180deg, #6b4eff 30.96%, #4f92f6 99.99%);
+  background: $gradient-hero;
   color: white;
-  font-family: "Albert Sans", sans-serif;
-  font-weight: 500;
-  font-size: 16px; // Adjusted to fit better
-  line-height: 24px;
+}
+
+.copy-link-button :deep(.q-btn:hover) {
+  background: $gradient-hover;
+}
+
+.copy-link-button :deep(.q-btn:active) {
+  background: $gradient-pressed;
 }
 </style>

--- a/services/agora/src/composables/share/useShareActions.ts
+++ b/services/agora/src/composables/share/useShareActions.ts
@@ -1,0 +1,152 @@
+/**
+ * Share actions composable
+ * Manages share action menu state and execution
+ */
+
+import { ref, type Ref } from "vue";
+import type {
+  ContentAction,
+  ContentActionDialogState,
+} from "src/utils/actions/core/types";
+import { createActionContext } from "src/utils/actions/core/permissions";
+import { getAvailableShareActions } from "src/utils/actions/definitions/share-actions";
+import {
+  shareActionsTranslations,
+  type ShareActionsTranslations,
+} from "src/utils/actions/definitions/share-actions.i18n";
+import { useComponentI18n } from "src/composables/ui/useComponentI18n";
+import { storeToRefs } from "pinia";
+import { useUserStore } from "src/stores/user";
+import { useAuthenticationStore } from "src/stores/authentication";
+import { useEmbedMode } from "src/utils/ui/embedMode";
+
+export interface ShareActionsComposable {
+  dialogState: Ref<ContentActionDialogState>;
+  showShareActions: (params: {
+    targetType: "post" | "comment";
+    targetId: string;
+    targetAuthor: string;
+    copyLinkCallback: () => void | Promise<void>;
+    openQrCodeCallback: () => void | Promise<void>;
+    shareViaCallback: () => void | Promise<void>;
+    isWebShareAvailable: boolean;
+  }) => void;
+  executeAction: (action: ContentAction) => Promise<void>;
+  closeDialog: () => void;
+}
+
+/**
+ * Composable for managing share actions
+ */
+export function useShareActions(): ShareActionsComposable {
+  const { profileData } = storeToRefs(useUserStore());
+  const { isLoggedIn } = storeToRefs(useAuthenticationStore());
+  const { isEmbeddedMode } = useEmbedMode();
+  const { t } = useComponentI18n<ShareActionsTranslations>(
+    shareActionsTranslations
+  );
+
+  // Dialog state management
+  const dialogStateRef = ref<ContentActionDialogState>({
+    isVisible: false,
+    context: null,
+    actions: [],
+  });
+
+  /**
+   * Show share actions dialog
+   */
+  const showShareActions = ({
+    targetType,
+    targetId,
+    targetAuthor,
+    copyLinkCallback,
+    openQrCodeCallback,
+    shareViaCallback,
+    isWebShareAvailable,
+  }: {
+    targetType: "post" | "comment";
+    targetId: string;
+    targetAuthor: string;
+    copyLinkCallback: () => void | Promise<void>;
+    openQrCodeCallback: () => void | Promise<void>;
+    shareViaCallback: () => void | Promise<void>;
+    isWebShareAvailable: boolean;
+  }): void => {
+    const context = createActionContext(
+      targetType,
+      targetId,
+      targetAuthor,
+      profileData.value.userName,
+      profileData.value.isModerator,
+      isLoggedIn.value,
+      isEmbeddedMode()
+    );
+
+    const translations = {
+      copyLink: t("copyLink"),
+      showQrCode: t("showQrCode"),
+      shareVia: t("shareVia"),
+    };
+
+    const availableActions = getAvailableShareActions({
+      context,
+      copyLinkCallback,
+      openQrCodeCallback,
+      shareViaCallback,
+      translations,
+      isWebShareAvailable,
+    });
+
+    dialogStateRef.value = {
+      isVisible: true,
+      context,
+      actions: availableActions,
+    };
+  };
+
+  /**
+   * Execute a share action
+   */
+  const executeAction = async (action: ContentAction): Promise<void> => {
+    if (!dialogStateRef.value.context) {
+      console.warn("No context available for action execution");
+      return;
+    }
+
+    try {
+      await action.handler(dialogStateRef.value.context);
+      // Close dialog after successful execution
+      closeDialog();
+    } catch (error) {
+      // AbortError is thrown when user cancels native share dialog - this is expected behavior
+      if (error instanceof Error && error.name === "AbortError") {
+        // User canceled share - just close dialog, don't log as error
+        closeDialog();
+        return;
+      }
+      // Log other errors
+      console.error("Error executing share action:", error);
+      // Close dialog even on error to prevent stuck state
+      closeDialog();
+    }
+  };
+
+  /**
+   * Close the share actions dialog
+   */
+  const closeDialog = (): void => {
+    dialogStateRef.value = {
+      isVisible: false,
+      context: null,
+      actions: [],
+    };
+  };
+
+  return {
+    dialogState: dialogStateRef,
+    showShareActions,
+    executeAction,
+    closeDialog,
+  };
+}

--- a/services/agora/src/css/quasar.variables.scss
+++ b/services/agora/src/css/quasar.variables.scss
@@ -87,6 +87,8 @@ $feed-flex-gap: 0.5rem;
 }
 
 $gradient-hero: linear-gradient(#6b4eff, #4f92f6);
+$gradient-hover: linear-gradient(#836bff, #5c9dff);
+$gradient-pressed: linear-gradient(#5c43dd, #4582dd);
 $container-padding: 1.5rem;
 
 // Import hover effects styles to make mixins available globally

--- a/services/agora/src/utils/actions/definitions/share-actions.i18n.ts
+++ b/services/agora/src/utils/actions/definitions/share-actions.i18n.ts
@@ -1,0 +1,53 @@
+/**
+ * Internationalization translations for share actions
+ * Supports all languages configured in the application
+ */
+
+import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
+
+export interface ShareActionsTranslations {
+  copyLink: string;
+  showQrCode: string;
+  shareVia: string;
+}
+
+export const shareActionsTranslations: Record<
+  SupportedDisplayLanguageCodes,
+  ShareActionsTranslations
+> = {
+  en: {
+    copyLink: "Copy link",
+    showQrCode: "Show QR Code",
+    shareVia: "Share via...",
+  },
+  ar: {
+    copyLink: "نسخ الرابط",
+    showQrCode: "عرض رمز الاستجابة السريعة",
+    shareVia: "مشاركة عبر...",
+  },
+  es: {
+    copyLink: "Copiar enlace",
+    showQrCode: "Mostrar código QR",
+    shareVia: "Compartir mediante...",
+  },
+  fr: {
+    copyLink: "Copier le lien",
+    showQrCode: "Afficher le QR code",
+    shareVia: "Partager via...",
+  },
+  "zh-Hans": {
+    copyLink: "复制链接",
+    showQrCode: "显示二维码",
+    shareVia: "分享至...",
+  },
+  "zh-Hant": {
+    copyLink: "複製連結",
+    showQrCode: "顯示二維碼",
+    shareVia: "分享至...",
+  },
+  ja: {
+    copyLink: "リンクをコピー",
+    showQrCode: "QRコードを表示",
+    shareVia: "共有する...",
+  },
+};

--- a/services/agora/src/utils/actions/definitions/share-actions.ts
+++ b/services/agora/src/utils/actions/definitions/share-actions.ts
@@ -1,0 +1,91 @@
+/**
+ * Share action definitions for the share menu system
+ * Provides actions for sharing content via different methods
+ */
+
+import type { ContentAction, ContentActionContext } from "../core/types";
+
+export interface ShareActionTranslations {
+  copyLink: string;
+  showQrCode: string;
+  shareVia: string;
+}
+
+export interface ShareActionCallbacks {
+  copyLinkCallback: () => void | Promise<void>;
+  openQrCodeCallback: () => void | Promise<void>;
+  shareViaCallback: () => void | Promise<void>;
+}
+
+/**
+ * Get all share actions with their configurations
+ */
+export function getShareActions({
+  copyLinkCallback,
+  openQrCodeCallback,
+  shareViaCallback,
+  translations,
+  isWebShareAvailable,
+}: {
+  copyLinkCallback: () => void | Promise<void>;
+  openQrCodeCallback: () => void | Promise<void>;
+  shareViaCallback: () => void | Promise<void>;
+  translations: ShareActionTranslations;
+  isWebShareAvailable: boolean;
+}): ContentAction[] {
+  return [
+    {
+      id: "copyLink",
+      label: translations.copyLink,
+      icon: "mdi-content-copy",
+      variant: "default",
+      handler: copyLinkCallback,
+      isVisible: () => true, // Always show copy link
+    },
+    {
+      id: "showQrCode",
+      label: translations.showQrCode,
+      icon: "mdi-qrcode",
+      variant: "default",
+      handler: openQrCodeCallback,
+      isVisible: () => true, // Always show QR code option
+    },
+    {
+      id: "shareVia",
+      label: translations.shareVia,
+      icon: "mdi-share-variant",
+      variant: "default",
+      handler: shareViaCallback,
+      isVisible: () => isWebShareAvailable, // Only show if Web Share API is available
+    },
+  ];
+}
+
+/**
+ * Get available share actions filtered by visibility rules
+ */
+export function getAvailableShareActions({
+  context,
+  copyLinkCallback,
+  openQrCodeCallback,
+  shareViaCallback,
+  translations,
+  isWebShareAvailable,
+}: {
+  context: ContentActionContext;
+  copyLinkCallback: () => void | Promise<void>;
+  openQrCodeCallback: () => void | Promise<void>;
+  shareViaCallback: () => void | Promise<void>;
+  translations: ShareActionTranslations;
+  isWebShareAvailable: boolean;
+}): ContentAction[] {
+  const allActions = getShareActions({
+    copyLinkCallback,
+    openQrCodeCallback,
+    shareViaCallback,
+    translations,
+    isWebShareAvailable,
+  });
+
+  return allActions.filter((action) => action.isVisible(context));
+}

--- a/services/agora/yarn.lock
+++ b/services/agora/yarn.lock
@@ -1502,10 +1502,10 @@
   dependencies:
     undici-types "~7.12.0"
 
-"@types/qrcode@^1.5.5":
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/@types/qrcode/-/qrcode-1.5.5.tgz#993ff7c6b584277eee7aac0a20861eab682f9dac"
-  integrity sha512-CdfBi/e3Qk+3Z/fXYShipBT13OJ2fDO2Q2w5CIP5anLTLIndQG9z6P1cnm+8zCWSpm5dnxMFd/uREtb0EXuQzg==
+"@types/qrcode@^1.5.6":
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/@types/qrcode/-/qrcode-1.5.6.tgz#07c33cb9ec0ad88be4636e636e28e54d99b65f42"
+  integrity sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
- Adds a new 'ShareDialog.vue' component to display the post URL as a QR code and provide a "copy link" button.
- Modifies 'PostDetails.vue' to call this dialog from the share button.
- The previous Web Share API logic is preserved as a comment for potential future use as a fallback mechanism.
(I apologize in advance if there's any redundant or unnecessary code.)