### PR TITLE
fix(math-updater): prevent duplicate job processing via early queue l…

### DIFF
--- a/script/docker-compose-production.yml
+++ b/script/docker-compose-production.yml
@@ -5,9 +5,9 @@ x-logging-options: &aws-logging-options
 services:
   polis-server:
     container_name: polis-server
-    image: quay.io/zkorum/agora-python-bridge:2.0.0
+    image: quay.io/zkorum/agora-python-bridge:2.0.2
     environment:
-      TOTAL_VCPUS: "2"  # t3.medium = 2 vCPUs (adjust for your instance type)
+      TOTAL_VCPUS: "2" # t3.medium = 2 vCPUs (adjust for your instance type)
     expose:
       - 8004
     restart: unless-stopped
@@ -18,7 +18,7 @@ services:
         awslogs-stream: polis-server
   api:
     container_name: agora_api
-    image: quay.io/zkorum/agora-api:4.0.1
+    image: quay.io/zkorum/agora-api:4.0.2
     environment:
       CONNECTION_STRING: "postgres://postgres:CHANGEME@postgres:5432/agora"
       CORS_ORIGIN_LIST: "https://www.agoracitizen.network,https://agoracitizen.network,https://agoracitizen.app,https://www.agoracitizen.app"
@@ -35,12 +35,12 @@ services:
     restart: unless-stopped
   math-updater:
     container_name: agora_math_updater
-    image: quay.io/zkorum/agora-math-updater:2.0.2
+    image: quay.io/zkorum/agora-math-updater:2.0.3
     environment:
       CONNECTION_STRING: "postgres://postgres:CHANGEME@postgres:5432/agora"
       NODE_ENV: "production"
       POLIS_BASE_URL: "http://polis-server:8004"
-      TOTAL_VCPUS: "2"  # t3.medium = 2 vCPUs (adjust for your instance type)
+      TOTAL_VCPUS: "2" # t3.medium = 2 vCPUs (adjust for your instance type)
     restart: unless-stopped
     logging:
       driver: awslogs
@@ -64,7 +64,7 @@ services:
         awslogs-stream: verificator-svc
   app:
     container_name: agora_app
-    image: quay.io/zkorum/agora-app-production:4.0.0
+    image: quay.io/zkorum/agora-app-production:4.0.1
     expose:
       - "80"
     restart: unless-stopped

--- a/services/agora/src/shared/types/zod.ts
+++ b/services/agora/src/shared/types/zod.ts
@@ -832,7 +832,7 @@ export const zodSupportedCountryCallingCode = z.enum([
 const zodGenLabelSummaryOutputClusterValue = z.object({
     label: z
         .string()
-        .max(60)
+        .max(100)
         .regex(/^\S+(?:\s\S+)?$/, "Label must be exactly 1 or 2 words"),
     summary: z.string().max(1000),
 });

--- a/services/api/src/shared/types/zod.ts
+++ b/services/api/src/shared/types/zod.ts
@@ -832,7 +832,7 @@ export const zodSupportedCountryCallingCode = z.enum([
 const zodGenLabelSummaryOutputClusterValue = z.object({
     label: z
         .string()
-        .max(60)
+        .max(100)
         .regex(/^\S+(?:\s\S+)?$/, "Label must be exactly 1 or 2 words"),
     summary: z.string().max(1000),
 });

--- a/services/load-testing/src/shared/types/zod.ts
+++ b/services/load-testing/src/shared/types/zod.ts
@@ -832,7 +832,7 @@ export const zodSupportedCountryCallingCode = z.enum([
 const zodGenLabelSummaryOutputClusterValue = z.object({
     label: z
         .string()
-        .max(60)
+        .max(100)
         .regex(/^\S+(?:\s\S+)?$/, "Label must be exactly 1 or 2 words"),
     summary: z.string().max(1000),
 });

--- a/services/math-updater/src/shared/types/zod.ts
+++ b/services/math-updater/src/shared/types/zod.ts
@@ -832,7 +832,7 @@ export const zodSupportedCountryCallingCode = z.enum([
 const zodGenLabelSummaryOutputClusterValue = z.object({
     label: z
         .string()
-        .max(60)
+        .max(100)
         .regex(/^\S+(?:\s\S+)?$/, "Label must be exactly 1 or 2 words"),
     summary: z.string().max(1000),
 });

--- a/services/python-bridge/.dockerignore
+++ b/services/python-bridge/.dockerignore
@@ -15,4 +15,3 @@ dist/
 tests/
 
 Makefile
-gunicorn.conf.py

--- a/services/shared/src/types/zod.ts
+++ b/services/shared/src/types/zod.ts
@@ -831,7 +831,7 @@ export const zodSupportedCountryCallingCode = z.enum([
 const zodGenLabelSummaryOutputClusterValue = z.object({
     label: z
         .string()
-        .max(60)
+        .max(100)
         .regex(/^\S+(?:\s\S+)?$/, "Label must be exactly 1 or 2 words"),
     summary: z.string().max(1000),
 });


### PR DESCRIPTION
…ocking

Problem:
  Observed duplicate math calculations for the same conversation within seconds
  despite pg-boss singleton protection (singletonSeconds: 30).

  Investigation found pg-boss creating jobs with incorrect singleton_on timestamps:
  - Job 1: created 18:18:53 UTC, singleton_on 18:19:00 UTC (only 7 seconds)
  - Job 2: created 18:19:01 UTC, singleton_on 18:19:00 UTC (same timestamp)
  - Both had same singletonKey but singleton_on was rounded to same time slot

  Root cause: Queue-level policy: singleton interferes with per-job singletonSeconds,
  causing singleton_on rounding instead of proper duration calculation.

  Solution:
  Lock queue entry immediately at job start by setting processedAt before any work.
  Scanner checks WHERE processedAt IS NULL, preventing re-enqueueing during processing.

  Changes:
  - Set processedAt at job start with requestedAt validation
  - Skip if already processed or requestedAt changed
  - Move lastMathUpdateAt update to completion
  - Document production issue with raw data for future reference