### PR TITLE
fix(backend): prevent seed opinion creation failure due to read repli…

### DIFF
--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -282,6 +282,13 @@ export async function createNewPost({
                 userAgent: "Seed Opinion Creation",
                 now,
                 isSeed: true,
+                conversationMetadata: {
+                    conversationId,
+                    conversationContentId,
+                    conversationAuthorId: authorId,
+                    conversationIsIndexed: isIndexed,
+                    conversationIsLoginRequired: isIndexed ? true : isLoginRequired,
+                },
             });
         }
     }


### PR DESCRIPTION
…ca lag

When creating conversations with seed opinions in production, the seed opinion creation was failing with "Conversation slugId not found" errors. This occurred because postNewOpinion queried the conversation by slugId immediately after creation, hitting the read replica before replication completed.

Changes:
- Add optional conversationMetadata parameter to postNewOpinion interface
- When metadata is provided, skip database lookup and use provided values
- Skip lock check for seed opinions (just-created conversations cannot be locked)
- Pass conversation metadata from createNewPost when creating seed opinions
- Eliminates 2 unnecessary database queries per seed opinion

This fix resolves the production-only race condition while improving efficiency by avoiding redundant database queries for data already available in scope.