### PR TITLE
fix(frontend): prevent flash of empty seed opinion page during conver…

### DIFF
--- a/services/agora/src/pages/conversation/new/review/index.vue
+++ b/services/agora/src/pages/conversation/new/review/index.vue
@@ -312,50 +312,49 @@ async function onSubmit() {
 
     isSubmitButtonLoading.value = true;
 
-    try {
-      const response = await createNewPost({
-        postTitle: conversationDraft.value.title,
-        postBody:
-          conversationDraft.value.content == ""
-            ? undefined
-            : conversationDraft.value.content,
-        pollingOptionList: conversationDraft.value.poll.enabled
-          ? conversationDraft.value.poll.options
-          : undefined,
-        postAsOrganizationName: conversationDraft.value.postAs.postAsOrganization
-          ? conversationDraft.value.postAs.organizationName
-          : "",
-        targetIsoConvertDateString: conversationDraft.value
-          .privateConversationSettings.hasScheduledConversion
-          ? conversationDraft.value.privateConversationSettings.conversionDate.toISOString()
-          : undefined,
-        isIndexed: !conversationDraft.value.isPrivate,
-        isLoginRequired: !conversationDraft.value.isPrivate
-          ? false
-          : conversationDraft.value.privateConversationSettings.requiresLogin,
-        seedOpinionList: conversationDraft.value.seedOpinions,
+    const response = await createNewPost({
+      postTitle: conversationDraft.value.title,
+      postBody:
+        conversationDraft.value.content == ""
+          ? undefined
+          : conversationDraft.value.content,
+      pollingOptionList: conversationDraft.value.poll.enabled
+        ? conversationDraft.value.poll.options
+        : undefined,
+      postAsOrganizationName: conversationDraft.value.postAs.postAsOrganization
+        ? conversationDraft.value.postAs.organizationName
+        : "",
+      targetIsoConvertDateString: conversationDraft.value
+        .privateConversationSettings.hasScheduledConversion
+        ? conversationDraft.value.privateConversationSettings.conversionDate.toISOString()
+        : undefined,
+      isIndexed: !conversationDraft.value.isPrivate,
+      isLoginRequired: !conversationDraft.value.isPrivate
+        ? false
+        : conversationDraft.value.privateConversationSettings.requiresLogin,
+      seedOpinionList: conversationDraft.value.seedOpinions,
+    });
+
+    if (response.status == "success") {
+      conversationDraft.value = createEmptyDraft();
+
+      await loadPostData();
+
+      // Set navigation context to indicate user came from conversation creation
+      navigationStore.setConversationCreationContext(true);
+
+      await router.replace({
+        name: "/conversation/[postSlugId]",
+        params: { postSlugId: response.data.conversationSlugId },
       });
 
-      if (response.status == "success") {
-        conversationDraft.value = createEmptyDraft();
-
-        await loadPostData();
-
-        // Set navigation context to indicate user came from conversation creation
-        navigationStore.setConversationCreationContext(true);
-
-        await router.replace({
-          name: "/conversation/[postSlugId]",
-          params: { postSlugId: response.data.conversationSlugId },
-        });
-      } else {
-        handleAxiosErrorStatusCodes({
-          axiosErrorCode: response.code,
-          defaultMessage: t("errorCreatingConversation"),
-        });
-      }
-    } finally {
+      // Don't stop loading - let component unmount with loading state active
+    } else {
       isSubmitButtonLoading.value = false;
+      handleAxiosErrorStatusCodes({
+        axiosErrorCode: response.code,
+        defaultMessage: t("errorCreatingConversation"),
+      });
     }
   }
 }


### PR DESCRIPTION
…sation creation

When clicking "Publier" to create a conversation with seed opinions, the page briefly flashed the empty seed opinion creation form before navigating to the final conversation page. This occurred because the loading state was being cleared in a finally block that executed immediately after router.replace() was called, but before the navigation and component unmount completed.

Changes:
- Remove try/finally wrapper (unnecessary since createNewPost never throws)
- Keep loading state active during successful navigation
- Only clear loading state on error case when user stays on the page
- Component now unmounts with loading state still active, preventing flash

This ensures a smooth transition from the review page to the conversation page without showing intermediate UI states.