### PR TITLE
fix(frontend): prevent flash of empty seed opinion page during conver…

### DIFF
--- a/services/agora/src/pages/conversation/new/review/index.vue
+++ b/services/agora/src/pages/conversation/new/review/index.vue
@@ -336,8 +336,6 @@ async function onSubmit() {
     });
 
     if (response.status == "success") {
-      conversationDraft.value = createEmptyDraft();
-
       await loadPostData();
 
       // Set navigation context to indicate user came from conversation creation
@@ -347,6 +345,9 @@ async function onSubmit() {
         name: "/conversation/[postSlugId]",
         params: { postSlugId: response.data.conversationSlugId },
       });
+
+      // Clear draft after navigation to prevent re-render with empty data
+      conversationDraft.value = createEmptyDraft();
 
       // Don't stop loading - let component unmount with loading state active
     } else {


### PR DESCRIPTION
…sation creation

When creating a conversation with seed opinions, the page briefly flashed showing the seed opinion form without any opinions before navigating to the final conversation page.

The issue was caused by clearing the conversation draft (via createEmptyDraft) before router navigation completed. Since conversationDraft is a reactive Pinia store, clearing it immediately triggered a re-render with empty seed opinions, creating a visible flash of the empty state.

Changes:
- Move createEmptyDraft() call to after router.replace()
- This ensures the component keeps its seed opinion data visible during navigation
- The component unmounts with data intact, preventing the empty state flash

This provides a smooth transition from the review page to the conversation page without intermediate UI flashes.