### PR TITLE
refactor(api): split opinion fetching for analysis views

### DIFF
--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -2023,16 +2023,16 @@ export interface ApiV1OpinionFetchAnalysisByConversationPost200Response {
     'polisContentId'?: number;
     /**
      * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
+     * @type {Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>}
      * @memberof ApiV1OpinionFetchAnalysisByConversationPost200Response
      */
-    'consensus': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
+    'consensus': Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>;
     /**
      * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
+     * @type {Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>}
      * @memberof ApiV1OpinionFetchAnalysisByConversationPost200Response
      */
-    'controversial': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
+    'controversial': Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>;
     /**
      * 
      * @type {ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters}
@@ -2121,10 +2121,10 @@ export interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0
     'isUserInCluster': boolean;
     /**
      * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
+     * @type {Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>}
      * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0
      */
-    'representative': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
+    'representative': Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>;
 }
 
 export const ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyEnum = {
@@ -2137,6 +2137,140 @@ export const ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyE
 } as const;
 
 export type ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyEnum = typeof ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyEnum[keyof typeof ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyEnum];
+
+/**
+ * 
+ * @export
+ * @interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+ */
+export interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner {
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'opinionSlugId': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'createdAt': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'updatedAt': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'opinion': string;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'numParticipants': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'numAgrees': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'numDisagrees': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'numPasses': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'username': string;
+    /**
+     * 
+     * @type {ApiV1ModerationOpinionGetPost200Response}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'moderation': ApiV1ModerationOpinionGetPost200Response;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'isSeed': boolean;
+    /**
+     * 
+     * @type {Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner>}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'clustersStats': Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner>;
+}
+/**
+ * 
+ * @export
+ * @interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+ */
+export interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner {
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'key': ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'isAuthorInCluster': boolean;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'numUsers': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'numAgrees': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'numDisagrees': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'numPasses': number;
+}
+
+export const ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum = {
+    _0: '0',
+    _1: '1',
+    _2: '2',
+    _3: '3',
+    _4: '4',
+    _5: '5'
+} as const;
+
+export type ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum = typeof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum[keyof typeof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum];
 
 /**
  * 
@@ -2168,11 +2302,7 @@ export const ApiV1OpinionFetchByConversationPostRequestFilterEnum = {
     Hidden: 'hidden',
     Moderated: 'moderated',
     New: 'new',
-    Discover: 'discover',
-    GroupAwareConsensus: 'group-aware-consensus',
-    Majority: 'majority',
-    Controversial: 'controversial',
-    Cluster: 'cluster'
+    Discover: 'discover'
 } as const;
 
 export type ApiV1OpinionFetchByConversationPostRequestFilterEnum = typeof ApiV1OpinionFetchByConversationPostRequestFilterEnum[keyof typeof ApiV1OpinionFetchByConversationPostRequestFilterEnum];
@@ -2218,49 +2348,6 @@ export interface ApiV1OpinionFetchHiddenByConversationPostRequest {
      * @memberof ApiV1OpinionFetchHiddenByConversationPostRequest
      */
     'createdAt'?: string;
-}
-/**
- * 
- * @export
- * @interface ApiV1OpinionFetchRepresentativeByConversationPost200Response
- */
-export interface ApiV1OpinionFetchRepresentativeByConversationPost200Response {
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '0': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '1': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '2': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '3': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '4': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '5': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
 }
 /**
  * 
@@ -2750,12 +2837,6 @@ export interface ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem {
     'username': string;
     /**
      * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner>}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem
-     */
-    'clustersStats': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner>;
-    /**
-     * 
      * @type {ApiV1ModerationOpinionGetPost200Response}
      * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem
      */
@@ -2767,67 +2848,6 @@ export interface ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem {
      */
     'isSeed': boolean;
 }
-/**
- * 
- * @export
- * @interface ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
- */
-export interface ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner {
-    /**
-     * 
-     * @type {string}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'key': ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum;
-    /**
-     * 
-     * @type {string}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'aiLabel'?: string;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'isAuthorInCluster': boolean;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'numUsers': number;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'numAgrees': number;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'numDisagrees': number;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'numPasses': number;
-}
-
-export const ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum = {
-    _0: '0',
-    _1: '1',
-    _2: '2',
-    _3: '3',
-    _4: '4',
-    _5: '5'
-} as const;
-
-export type ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum = typeof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum[keyof typeof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum];
-
 /**
  * 
  * @export
@@ -4271,84 +4291,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchConsensusByConversationPost: async (apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1ModerationConversationWithdrawPostRequest' is not null or undefined
-            assertParamExists('apiV1OpinionFetchConsensusByConversationPost', 'apiV1ModerationConversationWithdrawPostRequest', apiV1ModerationConversationWithdrawPostRequest)
-            const localVarPath = `/api/v1/opinion/fetch-consensus-by-conversation`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationConversationWithdrawPostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchControversialByConversationPost: async (apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1ModerationConversationWithdrawPostRequest' is not null or undefined
-            assertParamExists('apiV1OpinionFetchControversialByConversationPost', 'apiV1ModerationConversationWithdrawPostRequest', apiV1ModerationConversationWithdrawPostRequest)
-            const localVarPath = `/api/v1/opinion/fetch-controversial-by-conversation`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationConversationWithdrawPostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
          * @param {ApiV1OpinionFetchHiddenByConversationPostRequest} apiV1OpinionFetchHiddenByConversationPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -4380,84 +4322,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(apiV1OpinionFetchHiddenByConversationPostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchMajorityByConversationPost: async (apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1ModerationConversationWithdrawPostRequest' is not null or undefined
-            assertParamExists('apiV1OpinionFetchMajorityByConversationPost', 'apiV1ModerationConversationWithdrawPostRequest', apiV1ModerationConversationWithdrawPostRequest)
-            const localVarPath = `/api/v1/opinion/fetch-majority-by-conversation`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationConversationWithdrawPostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchRepresentativeByConversationPost: async (apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1ModerationConversationWithdrawPostRequest' is not null or undefined
-            assertParamExists('apiV1OpinionFetchRepresentativeByConversationPost', 'apiV1ModerationConversationWithdrawPostRequest', apiV1ModerationConversationWithdrawPostRequest)
-            const localVarPath = `/api/v1/opinion/fetch-representative-by-conversation`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationConversationWithdrawPostRequest, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -5586,30 +5450,6 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchConsensusByConversationPost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchControversialByConversationPost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
          * @param {ApiV1OpinionFetchHiddenByConversationPostRequest} apiV1OpinionFetchHiddenByConversationPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5618,30 +5458,6 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchHiddenByConversationPost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchMajorityByConversationPost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1OpinionFetchRepresentativeByConversationPost200Response>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchRepresentativeByConversationPost']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -6179,48 +5995,12 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>> {
-            return localVarFp.apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>> {
-            return localVarFp.apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
          * @param {ApiV1OpinionFetchHiddenByConversationPostRequest} apiV1OpinionFetchHiddenByConversationPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest: ApiV1OpinionFetchHiddenByConversationPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>> {
             return localVarFp.apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>> {
-            return localVarFp.apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1OpinionFetchRepresentativeByConversationPost200Response> {
-            return localVarFp.apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -6768,28 +6548,6 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
      * @param {ApiV1OpinionFetchHiddenByConversationPostRequest} apiV1OpinionFetchHiddenByConversationPostRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -6797,28 +6555,6 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest: ApiV1OpinionFetchHiddenByConversationPostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/services/agora/src/components/post/PostDetails.vue
+++ b/services/agora/src/components/post/PostDetails.vue
@@ -142,34 +142,39 @@ const participantCountLocal = ref(
 
 const { profileData } = storeToRefs(useUserStore());
 
-// Preload both analysis and comment data immediately when component mounts (only if not in compact mode)
+// Lazy load analysis data only when user clicks Analysis tab
+const isAnalysisEnabled = computed(() => !props.compactMode && currentTab.value === 'analysis');
 const analysisQuery = useAnalysisQuery({
   conversationSlugId: props.conversationData.metadata.conversationSlugId,
   voteCount: props.conversationData.metadata.voteCount,
-  enabled: !props.compactMode,
+  enabled: isAnalysisEnabled,
 });
 
 // Preload comment queries for all filter types (only if not in compact mode)
 const commentsDiscoverQuery = useCommentsQuery({
   conversationSlugId: props.conversationData.metadata.conversationSlugId,
   filter: "discover",
+  voteCount: props.conversationData.metadata.voteCount,
   enabled: !props.compactMode,
 });
 
 const commentsNewQuery = useCommentsQuery({
   conversationSlugId: props.conversationData.metadata.conversationSlugId,
   filter: "new",
+  voteCount: props.conversationData.metadata.voteCount,
   enabled: !props.compactMode,
 });
 
 const commentsModeratedQuery = useCommentsQuery({
   conversationSlugId: props.conversationData.metadata.conversationSlugId,
   filter: "moderated",
+  voteCount: props.conversationData.metadata.voteCount,
   enabled: !props.compactMode,
 });
 
 const hiddenCommentsQuery = useHiddenCommentsQuery({
   conversationSlugId: props.conversationData.metadata.conversationSlugId,
+  voteCount: props.conversationData.metadata.voteCount,
   enabled: !props.compactMode && profileData.value.isModerator,
 });
 

--- a/services/agora/src/components/post/analysis/AnalysisPage.vue
+++ b/services/agora/src/components/post/analysis/AnalysisPage.vue
@@ -13,6 +13,8 @@
           :item-list="analysisQuery.data.value?.consensus || []"
           :compact-mode="currentTab === 'Summary'"
           :clusters="analysisQuery.data.value?.polisClusters || {}"
+          :cluster-labels="clusterLabels"
+          :vote-count="props.participantCount"
         />
       </div>
 
@@ -26,6 +28,8 @@
           :item-list="analysisQuery.data.value?.controversial || []"
           :compact-mode="currentTab === 'Summary'"
           :clusters="analysisQuery.data.value?.polisClusters || {}"
+          :cluster-labels="clusterLabels"
+          :vote-count="props.participantCount"
         />
       </div>
 
@@ -57,11 +61,15 @@ import {
   type AnalysisPageTranslations,
 } from "./AnalysisPage.i18n";
 import type { UseQueryReturnType } from "@tanstack/vue-query";
-import type { OpinionItem, PolisClusters } from "src/shared/types/zod";
+import type {
+  AnalysisOpinionItem,
+  PolisClusters,
+  PolisKey,
+} from "src/shared/types/zod";
 
 type AnalysisData = {
-  consensus: OpinionItem[];
-  controversial: OpinionItem[];
+  consensus: AnalysisOpinionItem[];
+  controversial: AnalysisOpinionItem[];
   polisClusters: Partial<PolisClusters>;
 };
 
@@ -79,6 +87,19 @@ const currentTab = ref<ShortcutItem>("Summary");
 
 // Use the passed-in analysis query instead of creating our own
 const analysisQuery = props.analysisQuery;
+
+// Extract only cluster labels for optimal performance (300 bytes instead of 300KB)
+const clusterLabels = computed(() => {
+  const labels: Partial<Record<PolisKey, string>> = {};
+  if (!analysisQuery.data.value?.polisClusters) return labels;
+
+  for (const [key, cluster] of Object.entries(analysisQuery.data.value.polisClusters)) {
+    if (cluster?.aiLabel) {
+      labels[key as PolisKey] = cluster.aiLabel;
+    }
+  }
+  return labels;
+});
 
 const asyncStateConfig = {
   loading: {

--- a/services/agora/src/components/post/analysis/consensusTab/ConsensusItem.vue
+++ b/services/agora/src/components/post/analysis/consensusTab/ConsensusItem.vue
@@ -30,6 +30,8 @@
     v-model="showDialog"
     :conversation-slug-id="props.conversationSlugId"
     :opinion-item="props.opinionItem"
+    :vote-count="props.voteCount"
+    :cluster-labels="props.clusterLabels"
   />
 </template>
 
@@ -38,7 +40,11 @@ import { computed, ref } from "vue";
 import VoteCountVisualizer from "../common/VoteCountVisualizer.vue";
 import OpinionAnalysisDialog from "./OpinionAnalysisDialog.vue";
 import OpinionGridLayout from "../common/OpinionGridLayout.vue";
-import type { OpinionItem } from "src/shared/types/zod";
+import type {
+  AnalysisOpinionItem,
+  PolisClusters,
+  PolisKey,
+} from "src/shared/types/zod";
 import ZKHtmlContent from "src/components/ui-library/ZKHtmlContent.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import {
@@ -48,8 +54,11 @@ import {
 
 const props = defineProps<{
   conversationSlugId: string;
-  opinionItem: OpinionItem;
-  opinionItemForVisualizer: OpinionItem;
+  opinionItem: AnalysisOpinionItem;
+  opinionItemForVisualizer: AnalysisOpinionItem;
+  voteCount: number;
+  polisClusters: Partial<PolisClusters>;
+  clusterLabels: Partial<Record<PolisKey, string>>;
 }>();
 
 const { t } = useComponentI18n<ConsensusItemTranslations>(

--- a/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.vue
+++ b/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.vue
@@ -30,6 +30,9 @@
           :conversation-slug-id="props.conversationSlugId"
           :opinion-item="consensusItem"
           :opinion-item-for-visualizer="consensusItem"
+          :vote-count="props.voteCount"
+          :polis-clusters="props.clusters"
+          :cluster-labels="props.clusterLabels"
         />
       </template>
     </AnalysisSectionWrapper>
@@ -43,7 +46,11 @@ import AnalysisActionButton from "../common/AnalysisActionButton.vue";
 import EmptyStateMessage from "../common/EmptyStateMessage.vue";
 import ConsensusItem from "./ConsensusItem.vue";
 import type { ShortcutItem } from "src/utils/component/analysis/shortcutBar";
-import type { OpinionItem, PolisClusters } from "src/shared/types/zod";
+import type {
+  AnalysisOpinionItem,
+  PolisClusters,
+  PolisKey,
+} from "src/shared/types/zod";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import {
   consensusTabTranslations,
@@ -52,9 +59,11 @@ import {
 
 const props = defineProps<{
   conversationSlugId: string;
-  itemList: OpinionItem[];
+  itemList: AnalysisOpinionItem[];
   compactMode: boolean;
   clusters: Partial<PolisClusters>;
+  clusterLabels: Partial<Record<PolisKey, string>>;
+  voteCount: number;
 }>();
 
 const currentTab = defineModel<ShortcutItem>();

--- a/services/agora/src/components/post/analysis/consensusTab/OpinionAnalysisDialog.vue
+++ b/services/agora/src/components/post/analysis/consensusTab/OpinionAnalysisDialog.vue
@@ -126,7 +126,7 @@
                   >
                     <td class="group-name">
                       {{
-                        `${formatClusterLabel(group.key, true, group.aiLabel)} (${formatAmount(group.numUsers)})`
+                        `${formatClusterLabel(group.key, true, getClusterLabel(group.key))} (${formatAmount(group.numUsers)})`
                       }}
                     </td>
                     <td class="agree-cell">
@@ -177,7 +177,10 @@
 import ZKButton from "src/components/ui-library/ZKButton.vue";
 import ZKHtmlContent from "src/components/ui-library/ZKHtmlContent.vue";
 import OpinionIdentityCard from "src/components/post/comments/OpinionIdentityCard.vue";
-import type { OpinionItem } from "src/shared/types/zod";
+import type {
+  AnalysisOpinionItem,
+  PolisKey,
+} from "src/shared/types/zod";
 import { formatClusterLabel } from "src/utils/component/opinion";
 import { calculatePercentage } from "src/shared/util";
 import { formatAmount, formatPercentage } from "src/utils/common";
@@ -191,7 +194,9 @@ import {
 
 const props = defineProps<{
   conversationSlugId: string;
-  opinionItem: OpinionItem;
+  opinionItem: AnalysisOpinionItem;
+  voteCount: number;
+  clusterLabels: Partial<Record<PolisKey, string>>;
 }>();
 
 const { forceOpenComment } = useRouterNavigation();
@@ -201,6 +206,10 @@ const { t } = useComponentI18n<OpinionAnalysisDialogTranslations>(
 );
 
 const showDialog = defineModel<boolean>({ required: true });
+
+function getClusterLabel(key: PolisKey): string | undefined {
+  return props.clusterLabels[key];
+}
 
 const noGroupStats = computed(() => {
   const totalClusteredAgrees = props.opinionItem.clustersStats.reduce(

--- a/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.vue
+++ b/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.vue
@@ -30,6 +30,9 @@
           :conversation-slug-id="props.conversationSlugId"
           :opinion-item="consensusItem"
           :opinion-item-for-visualizer="consensusItem"
+          :vote-count="props.voteCount"
+          :polis-clusters="props.clusters"
+          :cluster-labels="props.clusterLabels"
         />
       </template>
     </AnalysisSectionWrapper>
@@ -43,7 +46,11 @@ import AnalysisActionButton from "../common/AnalysisActionButton.vue";
 import EmptyStateMessage from "../common/EmptyStateMessage.vue";
 import ConsensusItem from "../consensusTab/ConsensusItem.vue";
 import type { ShortcutItem } from "src/utils/component/analysis/shortcutBar";
-import type { OpinionItem, PolisClusters } from "src/shared/types/zod";
+import type {
+  AnalysisOpinionItem,
+  PolisClusters,
+  PolisKey,
+} from "src/shared/types/zod";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import {
   divisiveTabTranslations,
@@ -52,9 +59,11 @@ import {
 
 const props = defineProps<{
   conversationSlugId: string;
-  itemList: OpinionItem[];
+  itemList: AnalysisOpinionItem[];
   compactMode: boolean;
   clusters: Partial<PolisClusters>;
+  clusterLabels: Partial<Record<PolisKey, string>>;
+  voteCount: number;
 }>();
 
 const currentTab = defineModel<ShortcutItem>();

--- a/services/agora/src/components/post/analysis/opinionGroupTab/OpinionGroupComments.vue
+++ b/services/agora/src/components/post/analysis/opinionGroupTab/OpinionGroupComments.vue
@@ -36,6 +36,9 @@
         :conversation-slug-id="props.conversationSlugId"
         :opinion-item="comment"
         :opinion-item-for-visualizer="getModifiedOpinionItem(comment)"
+        :vote-count="props.voteCount"
+        :polis-clusters="props.polisClusters"
+        :cluster-labels="props.clusterLabels"
       />
     </div>
   </div>
@@ -43,8 +46,11 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import type { OpinionItem } from "src/shared/types/zod";
-import type { PolisKey } from "src/shared/types/zod";
+import type {
+  AnalysisOpinionItem,
+  PolisClusters,
+  PolisKey,
+} from "src/shared/types/zod";
 import ConsensusItem from "../consensusTab/ConsensusItem.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import {
@@ -54,9 +60,12 @@ import {
 
 const props = defineProps<{
   conversationSlugId: string;
-  itemList: OpinionItem[];
+  itemList: AnalysisOpinionItem[];
   currentClusterTab: PolisKey;
   hasUngroupedParticipants: boolean;
+  voteCount: number;
+  polisClusters: Partial<PolisClusters>;
+  clusterLabels: Partial<Record<PolisKey, string>>;
 }>();
 
 const { t } = useComponentI18n<OpinionGroupCommentsTranslations>(
@@ -74,7 +83,7 @@ watch(
   }
 );
 
-function getActiveVotes(comment: OpinionItem) {
+function getActiveVotes(comment: AnalysisOpinionItem) {
   const currentClusterStats = comment.clustersStats.find(
     (cv) => cv.key === props.currentClusterTab
   );
@@ -136,7 +145,7 @@ function getActiveVotes(comment: OpinionItem) {
   }
 }
 
-function getModifiedOpinionItem(comment: OpinionItem): OpinionItem {
+function getModifiedOpinionItem(comment: AnalysisOpinionItem): AnalysisOpinionItem {
   const activeVotes = getActiveVotes(comment);
   return {
     ...comment,

--- a/services/agora/src/components/post/analysis/opinionGroupTab/OpinionGroupTab.vue
+++ b/services/agora/src/components/post/analysis/opinionGroupTab/OpinionGroupTab.vue
@@ -52,11 +52,13 @@
           <OpinionGroupComments
             :conversation-slug-id="props.conversationSlugId"
             :item-list="
-              props.clusters[currentClusterTab]?.representative ??
-              ([] as OpinionItem[])
+              props.clusters[currentClusterTab]?.representative ?? []
             "
             :current-cluster-tab="currentClusterTab"
             :has-ungrouped-participants="hasUngroupedParticipants"
+            :vote-count="props.totalParticipantCount"
+            :polis-clusters="props.clusters"
+            :cluster-labels="clusterLabels"
             @update:current-cluster-tab="currentClusterTab = $event"
           />
         </template>
@@ -69,7 +71,6 @@
 
 <script setup lang="ts">
 import type {
-  OpinionItem,
   PolisClusters,
   PolisKey,
 } from "src/shared/types/zod";
@@ -123,5 +124,16 @@ const currentAiSummary = computed(() => {
     return props.clusters[currentClusterTab.value]?.aiSummary;
   }
   return undefined;
+});
+
+// Extract only cluster labels for optimal performance
+const clusterLabels = computed(() => {
+  const labels: Partial<Record<PolisKey, string>> = {};
+  for (const [key, cluster] of Object.entries(props.clusters)) {
+    if (cluster?.aiLabel) {
+      labels[key as PolisKey] = cluster.aiLabel;
+    }
+  }
+  return labels;
 });
 </script>

--- a/services/agora/src/pages/dev/opinion-group-visualization.vue
+++ b/services/agora/src/pages/dev/opinion-group-visualization.vue
@@ -70,9 +70,9 @@ import { StandardMenuBar } from "src/components/navigation/header/variants";
 import DrawerLayout from "src/layouts/DrawerLayout.vue";
 import OpinionGroupTab from "src/components/post/analysis/opinionGroupTab/OpinionGroupTab.vue";
 import type {
+  AnalysisOpinionItem,
   PolisClusters,
   PolisKey,
-  OpinionItem,
 } from "src/shared/types/zod";
 import {
   opinionGroupVisualizationTranslations,
@@ -121,8 +121,8 @@ const clusterSummaries = [
   "This group is driven by idealistic principles and long-term vision.",
 ];
 
-function generateMockOpinions(count: number = 3): OpinionItem[] {
-  const mockOpinions: OpinionItem[] = [];
+function generateMockOpinions(count: number = 3): AnalysisOpinionItem[] {
+  const mockOpinions: AnalysisOpinionItem[] = [];
 
   for (let i = 0; i < count; i++) {
     mockOpinions.push({

--- a/services/agora/src/pages/moderate/conversation/[conversationSlugId]/opinion/[opinionSlugId]/index.vue
+++ b/services/agora/src/pages/moderate/conversation/[conversationSlugId]/opinion/[opinionSlugId]/index.vue
@@ -128,7 +128,6 @@ const opinionItem = ref<OpinionItem>({
   moderation: {
     status: "unmoderated",
   },
-  clustersStats: [],
 });
 
 onMounted(async () => {

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -6,6 +6,7 @@ import {
     zodUserId,
     zodSlugId,
     zodOpinionItem,
+    zodAnalysisOpinionItem,
     zodPollOptionTitle,
     zodConversationTitle,
     zodConversationBody,
@@ -147,8 +148,8 @@ export class Dto {
     static fetchAnalysisResponse = z
         .object({
             polisContentId: z.number().int().nonnegative().optional(), // for logging/debugging purpose, undefined if no polis calculated
-            consensus: z.array(zodOpinionItem),
-            controversial: z.array(zodOpinionItem),
+            consensus: z.array(zodAnalysisOpinionItem),
+            controversial: z.array(zodAnalysisOpinionItem),
             clusters: zodPolisClusters,
         })
         .strict();
@@ -159,34 +160,6 @@ export class Dto {
         })
         .strict();
     static fetchHiddenOpinionsResponse = z.array(zodOpinionItem);
-    static fetchConsensusResponse = z.array(zodOpinionItem);
-    static fetchConsensusRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchMajorityResponse = z.array(zodOpinionItem);
-    static fetchMajorityRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchControversialResponse = z.array(zodOpinionItem);
-    static fetchControversialRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchRepresentativeResponse = z.record(
-        zodPolisKey,
-        z.array(zodOpinionItem),
-    );
-    static fetchRepresentativeRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-
     static createNewConversationRequest = z
         .object({
             conversationTitle: zodConversationTitle,

--- a/services/agora/src/shared/types/zod.ts
+++ b/services/agora/src/shared/types/zod.ts
@@ -134,10 +134,6 @@ export const zodCommentFeedFilter = z.enum([
     "moderated",
     "new",
     "discover",
-    "group-aware-consensus",
-    "majority",
-    "controversial",
-    "cluster",
 ]);
 export const usernameRegex = new RegExp(
     `^[a-z0-9_]*$`, // {${MIN_LENGTH_USERNAME.toString()},${MAX_LENGTH_USERNAME.toString()}
@@ -327,7 +323,6 @@ export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);
 export const zodVotingAction = z.enum(["agree", "disagree", "pass", "cancel"]);
 export const zodClusterStats = z.object({
     key: zodPolisKey,
-    aiLabel: z.string().optional(),
     isAuthorInCluster: z.boolean(),
     numUsers: z.number().int().nonnegative(),
     numAgrees: z.number().int().nonnegative(),
@@ -345,11 +340,13 @@ export const zodOpinionItem = z
         numDisagrees: z.number().int().nonnegative(),
         numPasses: z.number().int().nonnegative(),
         username: z.string(),
-        clustersStats: z.array(zodClusterStats),
         moderation: zodOpinionModerationProperties,
         isSeed: z.boolean(),
     })
     .strict();
+export const zodAnalysisOpinionItem = zodOpinionItem.extend({
+    clustersStats: z.array(zodClusterStats),
+});
 export const zodClusterMetadata = z
     .object({
         id: z.number().int().nonnegative(),
@@ -370,7 +367,7 @@ export const zodPolisClusters = z.record(
             aiLabel: z.string().optional(),
             aiSummary: z.string().optional(),
             isUserInCluster: z.boolean(),
-            representative: z.array(zodOpinionItem),
+            representative: z.array(zodAnalysisOpinionItem),
         })
         .strict(),
 );
@@ -380,6 +377,10 @@ export const zodPolisClustersMetadata = z.record(
 );
 
 export const zodOpinionItemPerSlugId = z.map(zodSlugId, zodOpinionItem);
+export const zodAnalysisOpinionItemPerSlugId = z.map(
+    zodSlugId,
+    zodAnalysisOpinionItem,
+);
 export const zodUserInteraction = z
     .object({
         hasVoted: z.boolean(),
@@ -931,7 +932,11 @@ export type ExtendedConversationPayload = z.infer<
 export type PollOptionWithResult = z.infer<typeof zodPollOptionWithResult>;
 export type CommentContent = z.infer<typeof zodOpinionContent>;
 export type OpinionItem = z.infer<typeof zodOpinionItem>;
+export type AnalysisOpinionItem = z.infer<typeof zodAnalysisOpinionItem>;
 export type OpinionItemPerSlugId = z.infer<typeof zodOpinionItemPerSlugId>;
+export type AnalysisOpinionItemPerSlugId = z.infer<
+    typeof zodAnalysisOpinionItemPerSlugId
+>;
 export type ExtendedOpinion = z.infer<typeof zodExtendedOpinionData>;
 export type ExtendedOpinionWithConvId = z.infer<
     typeof zodExtendedOpinionDataWithConvId

--- a/services/agora/src/utils/api/comment/comment.ts
+++ b/services/agora/src/utils/api/comment/comment.ts
@@ -7,6 +7,7 @@ import {
   type ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem,
   type ApiV1OpinionFetchAnalysisByConversationPost200Response,
   type ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0,
+  type ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner,
   DefaultApiAxiosParamCreator,
   DefaultApiFactory,
 } from "src/api";
@@ -14,6 +15,7 @@ import { useCommonApi } from "../common";
 import type {
   PolisKey,
   OpinionItem,
+  AnalysisOpinionItem,
   PolisClusters,
   moderationStatusOptionsType,
 } from "src/shared/types/zod";
@@ -56,7 +58,6 @@ export function useBackendCommentApi() {
           createdAt: new Date(item.moderation.createdAt),
           updatedAt: new Date(item.moderation.updatedAt),
         },
-        clustersStats: item.clustersStats,
       });
     });
 
@@ -215,8 +216,8 @@ export function useBackendCommentApi() {
   async function fetchAnalysisData(params: {
     conversationSlugId: string;
   }): Promise<{
-    consensus: OpinionItem[];
-    controversial: OpinionItem[];
+    consensus: AnalysisOpinionItem[];
+    controversial: AnalysisOpinionItem[];
     polisClusters: Partial<PolisClusters>;
   }> {
     let data: ApiV1OpinionFetchAnalysisByConversationPost200Response;
@@ -257,7 +258,7 @@ export function useBackendCommentApi() {
         PolisKey,
         ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0,
       ]) => {
-        const representative: Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem> =
+        const representative: Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner> =
           val.representative;
         const representativeItems = representative.map((item) => ({
           ...item,
@@ -271,15 +272,7 @@ export function useBackendCommentApi() {
       }
     );
 
-    const opinionConsensusItem: OpinionItem[] = data.consensus.map((val) => {
-      return {
-        ...val,
-        createdAt: new Date(val.createdAt),
-        updatedAt: new Date(val.updatedAt),
-      };
-    });
-
-    const opinionControversialItem: OpinionItem[] = data.controversial.map(
+    const opinionConsensusItem: AnalysisOpinionItem[] = data.consensus.map(
       (val) => {
         return {
           ...val,
@@ -288,6 +281,15 @@ export function useBackendCommentApi() {
         };
       }
     );
+
+    const opinionControversialItem: AnalysisOpinionItem[] =
+      data.controversial.map((val) => {
+        return {
+          ...val,
+          createdAt: new Date(val.createdAt),
+          updatedAt: new Date(val.updatedAt),
+        };
+      });
 
     return {
       consensus: opinionConsensusItem,

--- a/services/agora/src/utils/api/user.ts
+++ b/services/agora/src/utils/api/user.ts
@@ -146,7 +146,6 @@ export function useBackendUserApi() {
                 responseItem.opinionItem.moderation.updatedAt
               ),
             },
-            clustersStats: responseItem.opinionItem.clustersStats,
           },
         };
         extendedCommentList.push(extendedComment);

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -1935,56 +1935,6 @@
                                                     "username": {
                                                         "type": "string"
                                                     },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
                                                     "moderation": {
                                                         "anyOf": [
                                                             {
@@ -2068,7 +2018,6 @@
                                                     "numDisagrees",
                                                     "numPasses",
                                                     "username",
-                                                    "clustersStats",
                                                     "moderation",
                                                     "isSeed"
                                                 ],
@@ -2397,11 +2346,7 @@
                                             "hidden",
                                             "moderated",
                                             "new",
-                                            "discover",
-                                            "group-aware-consensus",
-                                            "majority",
-                                            "controversial",
-                                            "cluster"
+                                            "discover"
                                         ]
                                     },
                                     "clusterKey": {
@@ -2470,56 +2415,6 @@
                                             },
                                             "username": {
                                                 "type": "string"
-                                            },
-                                            "clustersStats": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "0",
-                                                                "1",
-                                                                "2",
-                                                                "3",
-                                                                "4",
-                                                                "5"
-                                                            ]
-                                                        },
-                                                        "aiLabel": {
-                                                            "type": "string"
-                                                        },
-                                                        "isAuthorInCluster": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "numUsers": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numAgrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numDisagrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numPasses": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "isAuthorInCluster",
-                                                        "numUsers",
-                                                        "numAgrees",
-                                                        "numDisagrees",
-                                                        "numPasses"
-                                                    ],
-                                                    "additionalProperties": false
-                                                }
                                             },
                                             "moderation": {
                                                 "anyOf": [
@@ -2604,7 +2499,6 @@
                                             "numDisagrees",
                                             "numPasses",
                                             "username",
-                                            "clustersStats",
                                             "moderation",
                                             "isSeed"
                                         ],
@@ -2691,56 +2585,6 @@
                                                     "username": {
                                                         "type": "string"
                                                     },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
                                                     "moderation": {
                                                         "anyOf": [
                                                             {
@@ -2812,6 +2656,53 @@
                                                     },
                                                     "isSeed": {
                                                         "type": "boolean"
+                                                    },
+                                                    "clustersStats": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "0",
+                                                                        "1",
+                                                                        "2",
+                                                                        "3",
+                                                                        "4",
+                                                                        "5"
+                                                                    ]
+                                                                },
+                                                                "isAuthorInCluster": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "numUsers": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0
+                                                                },
+                                                                "numAgrees": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0
+                                                                },
+                                                                "numDisagrees": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0
+                                                                },
+                                                                "numPasses": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "isAuthorInCluster",
+                                                                "numUsers",
+                                                                "numAgrees",
+                                                                "numDisagrees",
+                                                                "numPasses"
+                                                            ],
+                                                            "additionalProperties": false
+                                                        }
                                                     }
                                                 },
                                                 "required": [
@@ -2824,9 +2715,9 @@
                                                     "numDisagrees",
                                                     "numPasses",
                                                     "username",
-                                                    "clustersStats",
                                                     "moderation",
-                                                    "isSeed"
+                                                    "isSeed",
+                                                    "clustersStats"
                                                 ],
                                                 "additionalProperties": false
                                             }
@@ -2871,56 +2762,6 @@
                                                     "username": {
                                                         "type": "string"
                                                     },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
                                                     "moderation": {
                                                         "anyOf": [
                                                             {
@@ -2992,6 +2833,53 @@
                                                     },
                                                     "isSeed": {
                                                         "type": "boolean"
+                                                    },
+                                                    "clustersStats": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string",
+                                                                    "enum": [
+                                                                        "0",
+                                                                        "1",
+                                                                        "2",
+                                                                        "3",
+                                                                        "4",
+                                                                        "5"
+                                                                    ]
+                                                                },
+                                                                "isAuthorInCluster": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "numUsers": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0
+                                                                },
+                                                                "numAgrees": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0
+                                                                },
+                                                                "numDisagrees": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0
+                                                                },
+                                                                "numPasses": {
+                                                                    "type": "integer",
+                                                                    "minimum": 0
+                                                                }
+                                                            },
+                                                            "required": [
+                                                                "key",
+                                                                "isAuthorInCluster",
+                                                                "numUsers",
+                                                                "numAgrees",
+                                                                "numDisagrees",
+                                                                "numPasses"
+                                                            ],
+                                                            "additionalProperties": false
+                                                        }
                                                     }
                                                 },
                                                 "required": [
@@ -3004,9 +2892,9 @@
                                                     "numDisagrees",
                                                     "numPasses",
                                                     "username",
-                                                    "clustersStats",
                                                     "moderation",
-                                                    "isSeed"
+                                                    "isSeed",
+                                                    "clustersStats"
                                                 ],
                                                 "additionalProperties": false
                                             }
@@ -3089,56 +2977,6 @@
                                                                     "username": {
                                                                         "type": "string"
                                                                     },
-                                                                    "clustersStats": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "key": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "0",
-                                                                                        "1",
-                                                                                        "2",
-                                                                                        "3",
-                                                                                        "4",
-                                                                                        "5"
-                                                                                    ]
-                                                                                },
-                                                                                "aiLabel": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "isAuthorInCluster": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "numUsers": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numAgrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numDisagrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numPasses": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "key",
-                                                                                "isAuthorInCluster",
-                                                                                "numUsers",
-                                                                                "numAgrees",
-                                                                                "numDisagrees",
-                                                                                "numPasses"
-                                                                            ],
-                                                                            "additionalProperties": false
-                                                                        }
-                                                                    },
                                                                     "moderation": {
                                                                         "anyOf": [
                                                                             {
@@ -3210,6 +3048,53 @@
                                                                     },
                                                                     "isSeed": {
                                                                         "type": "boolean"
+                                                                    },
+                                                                    "clustersStats": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "0",
+                                                                                        "1",
+                                                                                        "2",
+                                                                                        "3",
+                                                                                        "4",
+                                                                                        "5"
+                                                                                    ]
+                                                                                },
+                                                                                "isAuthorInCluster": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "numUsers": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numAgrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numDisagrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numPasses": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "isAuthorInCluster",
+                                                                                "numUsers",
+                                                                                "numAgrees",
+                                                                                "numDisagrees",
+                                                                                "numPasses"
+                                                                            ],
+                                                                            "additionalProperties": false
+                                                                        }
                                                                     }
                                                                 },
                                                                 "required": [
@@ -3222,9 +3107,9 @@
                                                                     "numDisagrees",
                                                                     "numPasses",
                                                                     "username",
-                                                                    "clustersStats",
                                                                     "moderation",
-                                                                    "isSeed"
+                                                                    "isSeed",
+                                                                    "clustersStats"
                                                                 ],
                                                                 "additionalProperties": false
                                                             }
@@ -3305,56 +3190,6 @@
                                                                     "username": {
                                                                         "type": "string"
                                                                     },
-                                                                    "clustersStats": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "key": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "0",
-                                                                                        "1",
-                                                                                        "2",
-                                                                                        "3",
-                                                                                        "4",
-                                                                                        "5"
-                                                                                    ]
-                                                                                },
-                                                                                "aiLabel": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "isAuthorInCluster": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "numUsers": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numAgrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numDisagrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numPasses": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "key",
-                                                                                "isAuthorInCluster",
-                                                                                "numUsers",
-                                                                                "numAgrees",
-                                                                                "numDisagrees",
-                                                                                "numPasses"
-                                                                            ],
-                                                                            "additionalProperties": false
-                                                                        }
-                                                                    },
                                                                     "moderation": {
                                                                         "anyOf": [
                                                                             {
@@ -3426,6 +3261,53 @@
                                                                     },
                                                                     "isSeed": {
                                                                         "type": "boolean"
+                                                                    },
+                                                                    "clustersStats": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "0",
+                                                                                        "1",
+                                                                                        "2",
+                                                                                        "3",
+                                                                                        "4",
+                                                                                        "5"
+                                                                                    ]
+                                                                                },
+                                                                                "isAuthorInCluster": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "numUsers": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numAgrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numDisagrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numPasses": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "isAuthorInCluster",
+                                                                                "numUsers",
+                                                                                "numAgrees",
+                                                                                "numDisagrees",
+                                                                                "numPasses"
+                                                                            ],
+                                                                            "additionalProperties": false
+                                                                        }
                                                                     }
                                                                 },
                                                                 "required": [
@@ -3438,9 +3320,9 @@
                                                                     "numDisagrees",
                                                                     "numPasses",
                                                                     "username",
-                                                                    "clustersStats",
                                                                     "moderation",
-                                                                    "isSeed"
+                                                                    "isSeed",
+                                                                    "clustersStats"
                                                                 ],
                                                                 "additionalProperties": false
                                                             }
@@ -3521,56 +3403,6 @@
                                                                     "username": {
                                                                         "type": "string"
                                                                     },
-                                                                    "clustersStats": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "key": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "0",
-                                                                                        "1",
-                                                                                        "2",
-                                                                                        "3",
-                                                                                        "4",
-                                                                                        "5"
-                                                                                    ]
-                                                                                },
-                                                                                "aiLabel": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "isAuthorInCluster": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "numUsers": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numAgrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numDisagrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numPasses": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "key",
-                                                                                "isAuthorInCluster",
-                                                                                "numUsers",
-                                                                                "numAgrees",
-                                                                                "numDisagrees",
-                                                                                "numPasses"
-                                                                            ],
-                                                                            "additionalProperties": false
-                                                                        }
-                                                                    },
                                                                     "moderation": {
                                                                         "anyOf": [
                                                                             {
@@ -3642,6 +3474,53 @@
                                                                     },
                                                                     "isSeed": {
                                                                         "type": "boolean"
+                                                                    },
+                                                                    "clustersStats": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "0",
+                                                                                        "1",
+                                                                                        "2",
+                                                                                        "3",
+                                                                                        "4",
+                                                                                        "5"
+                                                                                    ]
+                                                                                },
+                                                                                "isAuthorInCluster": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "numUsers": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numAgrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numDisagrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numPasses": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "isAuthorInCluster",
+                                                                                "numUsers",
+                                                                                "numAgrees",
+                                                                                "numDisagrees",
+                                                                                "numPasses"
+                                                                            ],
+                                                                            "additionalProperties": false
+                                                                        }
                                                                     }
                                                                 },
                                                                 "required": [
@@ -3654,9 +3533,9 @@
                                                                     "numDisagrees",
                                                                     "numPasses",
                                                                     "username",
-                                                                    "clustersStats",
                                                                     "moderation",
-                                                                    "isSeed"
+                                                                    "isSeed",
+                                                                    "clustersStats"
                                                                 ],
                                                                 "additionalProperties": false
                                                             }
@@ -3737,56 +3616,6 @@
                                                                     "username": {
                                                                         "type": "string"
                                                                     },
-                                                                    "clustersStats": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "key": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "0",
-                                                                                        "1",
-                                                                                        "2",
-                                                                                        "3",
-                                                                                        "4",
-                                                                                        "5"
-                                                                                    ]
-                                                                                },
-                                                                                "aiLabel": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "isAuthorInCluster": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "numUsers": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numAgrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numDisagrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numPasses": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "key",
-                                                                                "isAuthorInCluster",
-                                                                                "numUsers",
-                                                                                "numAgrees",
-                                                                                "numDisagrees",
-                                                                                "numPasses"
-                                                                            ],
-                                                                            "additionalProperties": false
-                                                                        }
-                                                                    },
                                                                     "moderation": {
                                                                         "anyOf": [
                                                                             {
@@ -3858,6 +3687,53 @@
                                                                     },
                                                                     "isSeed": {
                                                                         "type": "boolean"
+                                                                    },
+                                                                    "clustersStats": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "0",
+                                                                                        "1",
+                                                                                        "2",
+                                                                                        "3",
+                                                                                        "4",
+                                                                                        "5"
+                                                                                    ]
+                                                                                },
+                                                                                "isAuthorInCluster": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "numUsers": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numAgrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numDisagrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numPasses": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "isAuthorInCluster",
+                                                                                "numUsers",
+                                                                                "numAgrees",
+                                                                                "numDisagrees",
+                                                                                "numPasses"
+                                                                            ],
+                                                                            "additionalProperties": false
+                                                                        }
                                                                     }
                                                                 },
                                                                 "required": [
@@ -3870,9 +3746,9 @@
                                                                     "numDisagrees",
                                                                     "numPasses",
                                                                     "username",
-                                                                    "clustersStats",
                                                                     "moderation",
-                                                                    "isSeed"
+                                                                    "isSeed",
+                                                                    "clustersStats"
                                                                 ],
                                                                 "additionalProperties": false
                                                             }
@@ -3953,56 +3829,6 @@
                                                                     "username": {
                                                                         "type": "string"
                                                                     },
-                                                                    "clustersStats": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "key": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "0",
-                                                                                        "1",
-                                                                                        "2",
-                                                                                        "3",
-                                                                                        "4",
-                                                                                        "5"
-                                                                                    ]
-                                                                                },
-                                                                                "aiLabel": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "isAuthorInCluster": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "numUsers": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numAgrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numDisagrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numPasses": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "key",
-                                                                                "isAuthorInCluster",
-                                                                                "numUsers",
-                                                                                "numAgrees",
-                                                                                "numDisagrees",
-                                                                                "numPasses"
-                                                                            ],
-                                                                            "additionalProperties": false
-                                                                        }
-                                                                    },
                                                                     "moderation": {
                                                                         "anyOf": [
                                                                             {
@@ -4074,6 +3900,53 @@
                                                                     },
                                                                     "isSeed": {
                                                                         "type": "boolean"
+                                                                    },
+                                                                    "clustersStats": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "0",
+                                                                                        "1",
+                                                                                        "2",
+                                                                                        "3",
+                                                                                        "4",
+                                                                                        "5"
+                                                                                    ]
+                                                                                },
+                                                                                "isAuthorInCluster": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "numUsers": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numAgrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numDisagrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numPasses": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "isAuthorInCluster",
+                                                                                "numUsers",
+                                                                                "numAgrees",
+                                                                                "numDisagrees",
+                                                                                "numPasses"
+                                                                            ],
+                                                                            "additionalProperties": false
+                                                                        }
                                                                     }
                                                                 },
                                                                 "required": [
@@ -4086,9 +3959,9 @@
                                                                     "numDisagrees",
                                                                     "numPasses",
                                                                     "username",
-                                                                    "clustersStats",
                                                                     "moderation",
-                                                                    "isSeed"
+                                                                    "isSeed",
+                                                                    "clustersStats"
                                                                 ],
                                                                 "additionalProperties": false
                                                             }
@@ -4169,56 +4042,6 @@
                                                                     "username": {
                                                                         "type": "string"
                                                                     },
-                                                                    "clustersStats": {
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "key": {
-                                                                                    "type": "string",
-                                                                                    "enum": [
-                                                                                        "0",
-                                                                                        "1",
-                                                                                        "2",
-                                                                                        "3",
-                                                                                        "4",
-                                                                                        "5"
-                                                                                    ]
-                                                                                },
-                                                                                "aiLabel": {
-                                                                                    "type": "string"
-                                                                                },
-                                                                                "isAuthorInCluster": {
-                                                                                    "type": "boolean"
-                                                                                },
-                                                                                "numUsers": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numAgrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numDisagrees": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                },
-                                                                                "numPasses": {
-                                                                                    "type": "integer",
-                                                                                    "minimum": 0
-                                                                                }
-                                                                            },
-                                                                            "required": [
-                                                                                "key",
-                                                                                "isAuthorInCluster",
-                                                                                "numUsers",
-                                                                                "numAgrees",
-                                                                                "numDisagrees",
-                                                                                "numPasses"
-                                                                            ],
-                                                                            "additionalProperties": false
-                                                                        }
-                                                                    },
                                                                     "moderation": {
                                                                         "anyOf": [
                                                                             {
@@ -4290,6 +4113,53 @@
                                                                     },
                                                                     "isSeed": {
                                                                         "type": "boolean"
+                                                                    },
+                                                                    "clustersStats": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "object",
+                                                                            "properties": {
+                                                                                "key": {
+                                                                                    "type": "string",
+                                                                                    "enum": [
+                                                                                        "0",
+                                                                                        "1",
+                                                                                        "2",
+                                                                                        "3",
+                                                                                        "4",
+                                                                                        "5"
+                                                                                    ]
+                                                                                },
+                                                                                "isAuthorInCluster": {
+                                                                                    "type": "boolean"
+                                                                                },
+                                                                                "numUsers": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numAgrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numDisagrees": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                },
+                                                                                "numPasses": {
+                                                                                    "type": "integer",
+                                                                                    "minimum": 0
+                                                                                }
+                                                                            },
+                                                                            "required": [
+                                                                                "key",
+                                                                                "isAuthorInCluster",
+                                                                                "numUsers",
+                                                                                "numAgrees",
+                                                                                "numDisagrees",
+                                                                                "numPasses"
+                                                                            ],
+                                                                            "additionalProperties": false
+                                                                        }
                                                                     }
                                                                 },
                                                                 "required": [
@@ -4302,9 +4172,9 @@
                                                                     "numDisagrees",
                                                                     "numPasses",
                                                                     "username",
-                                                                    "clustersStats",
                                                                     "moderation",
-                                                                    "isSeed"
+                                                                    "isSeed",
+                                                                    "clustersStats"
                                                                 ],
                                                                 "additionalProperties": false
                                                             }
@@ -4405,56 +4275,6 @@
                                             "username": {
                                                 "type": "string"
                                             },
-                                            "clustersStats": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "0",
-                                                                "1",
-                                                                "2",
-                                                                "3",
-                                                                "4",
-                                                                "5"
-                                                            ]
-                                                        },
-                                                        "aiLabel": {
-                                                            "type": "string"
-                                                        },
-                                                        "isAuthorInCluster": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "numUsers": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numAgrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numDisagrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numPasses": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "isAuthorInCluster",
-                                                        "numUsers",
-                                                        "numAgrees",
-                                                        "numDisagrees",
-                                                        "numPasses"
-                                                    ],
-                                                    "additionalProperties": false
-                                                }
-                                            },
                                             "moderation": {
                                                 "anyOf": [
                                                     {
@@ -4538,7 +4358,6 @@
                                             "numDisagrees",
                                             "numPasses",
                                             "username",
-                                            "clustersStats",
                                             "moderation",
                                             "isSeed"
                                         ],
@@ -4622,56 +4441,6 @@
                                             "username": {
                                                 "type": "string"
                                             },
-                                            "clustersStats": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "0",
-                                                                "1",
-                                                                "2",
-                                                                "3",
-                                                                "4",
-                                                                "5"
-                                                            ]
-                                                        },
-                                                        "aiLabel": {
-                                                            "type": "string"
-                                                        },
-                                                        "isAuthorInCluster": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "numUsers": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numAgrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numDisagrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numPasses": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "isAuthorInCluster",
-                                                        "numUsers",
-                                                        "numAgrees",
-                                                        "numDisagrees",
-                                                        "numPasses"
-                                                    ],
-                                                    "additionalProperties": false
-                                                }
-                                            },
                                             "moderation": {
                                                 "anyOf": [
                                                     {
@@ -4755,1778 +4524,11 @@
                                             "numDisagrees",
                                             "numPasses",
                                             "username",
-                                            "clustersStats",
                                             "moderation",
                                             "isSeed"
                                         ],
                                         "additionalProperties": false
                                     }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/opinion/fetch-consensus-by-conversation": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "conversationSlugId": {
-                                        "type": "string",
-                                        "maxLength": 10
-                                    }
-                                },
-                                "required": [
-                                    "conversationSlugId"
-                                ],
-                                "additionalProperties": false
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "opinionSlugId": {
-                                                "type": "string",
-                                                "maxLength": 10
-                                            },
-                                            "createdAt": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "updatedAt": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "opinion": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "numParticipants": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numAgrees": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numDisagrees": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numPasses": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "username": {
-                                                "type": "string"
-                                            },
-                                            "clustersStats": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "0",
-                                                                "1",
-                                                                "2",
-                                                                "3",
-                                                                "4",
-                                                                "5"
-                                                            ]
-                                                        },
-                                                        "aiLabel": {
-                                                            "type": "string"
-                                                        },
-                                                        "isAuthorInCluster": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "numUsers": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numAgrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numDisagrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numPasses": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "isAuthorInCluster",
-                                                        "numUsers",
-                                                        "numAgrees",
-                                                        "numDisagrees",
-                                                        "numPasses"
-                                                    ],
-                                                    "additionalProperties": false
-                                                }
-                                            },
-                                            "moderation": {
-                                                "anyOf": [
-                                                    {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "status": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "moderated"
-                                                                ]
-                                                            },
-                                                            "action": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "move",
-                                                                    "hide"
-                                                                ]
-                                                            },
-                                                            "reason": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "misleading",
-                                                                    "antisocial",
-                                                                    "illegal",
-                                                                    "doxing",
-                                                                    "sexual",
-                                                                    "spam"
-                                                                ]
-                                                            },
-                                                            "explanation": {
-                                                                "type": "string",
-                                                                "maxLength": 1000
-                                                            },
-                                                            "createdAt": {
-                                                                "type": "string",
-                                                                "format": "date-time"
-                                                            },
-                                                            "updatedAt": {
-                                                                "type": "string",
-                                                                "format": "date-time"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "status",
-                                                            "action",
-                                                            "reason",
-                                                            "explanation",
-                                                            "createdAt",
-                                                            "updatedAt"
-                                                        ],
-                                                        "additionalProperties": false
-                                                    },
-                                                    {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "status": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "unmoderated"
-                                                                ]
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "status"
-                                                        ],
-                                                        "additionalProperties": false
-                                                    }
-                                                ]
-                                            },
-                                            "isSeed": {
-                                                "type": "boolean"
-                                            }
-                                        },
-                                        "required": [
-                                            "opinionSlugId",
-                                            "createdAt",
-                                            "updatedAt",
-                                            "opinion",
-                                            "numParticipants",
-                                            "numAgrees",
-                                            "numDisagrees",
-                                            "numPasses",
-                                            "username",
-                                            "clustersStats",
-                                            "moderation",
-                                            "isSeed"
-                                        ],
-                                        "additionalProperties": false
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/opinion/fetch-majority-by-conversation": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "conversationSlugId": {
-                                        "type": "string",
-                                        "maxLength": 10
-                                    }
-                                },
-                                "required": [
-                                    "conversationSlugId"
-                                ],
-                                "additionalProperties": false
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "opinionSlugId": {
-                                                "type": "string",
-                                                "maxLength": 10
-                                            },
-                                            "createdAt": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "updatedAt": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "opinion": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "numParticipants": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numAgrees": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numDisagrees": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numPasses": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "username": {
-                                                "type": "string"
-                                            },
-                                            "clustersStats": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "0",
-                                                                "1",
-                                                                "2",
-                                                                "3",
-                                                                "4",
-                                                                "5"
-                                                            ]
-                                                        },
-                                                        "aiLabel": {
-                                                            "type": "string"
-                                                        },
-                                                        "isAuthorInCluster": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "numUsers": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numAgrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numDisagrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numPasses": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "isAuthorInCluster",
-                                                        "numUsers",
-                                                        "numAgrees",
-                                                        "numDisagrees",
-                                                        "numPasses"
-                                                    ],
-                                                    "additionalProperties": false
-                                                }
-                                            },
-                                            "moderation": {
-                                                "anyOf": [
-                                                    {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "status": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "moderated"
-                                                                ]
-                                                            },
-                                                            "action": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "move",
-                                                                    "hide"
-                                                                ]
-                                                            },
-                                                            "reason": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "misleading",
-                                                                    "antisocial",
-                                                                    "illegal",
-                                                                    "doxing",
-                                                                    "sexual",
-                                                                    "spam"
-                                                                ]
-                                                            },
-                                                            "explanation": {
-                                                                "type": "string",
-                                                                "maxLength": 1000
-                                                            },
-                                                            "createdAt": {
-                                                                "type": "string",
-                                                                "format": "date-time"
-                                                            },
-                                                            "updatedAt": {
-                                                                "type": "string",
-                                                                "format": "date-time"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "status",
-                                                            "action",
-                                                            "reason",
-                                                            "explanation",
-                                                            "createdAt",
-                                                            "updatedAt"
-                                                        ],
-                                                        "additionalProperties": false
-                                                    },
-                                                    {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "status": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "unmoderated"
-                                                                ]
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "status"
-                                                        ],
-                                                        "additionalProperties": false
-                                                    }
-                                                ]
-                                            },
-                                            "isSeed": {
-                                                "type": "boolean"
-                                            }
-                                        },
-                                        "required": [
-                                            "opinionSlugId",
-                                            "createdAt",
-                                            "updatedAt",
-                                            "opinion",
-                                            "numParticipants",
-                                            "numAgrees",
-                                            "numDisagrees",
-                                            "numPasses",
-                                            "username",
-                                            "clustersStats",
-                                            "moderation",
-                                            "isSeed"
-                                        ],
-                                        "additionalProperties": false
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/opinion/fetch-controversial-by-conversation": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "conversationSlugId": {
-                                        "type": "string",
-                                        "maxLength": 10
-                                    }
-                                },
-                                "required": [
-                                    "conversationSlugId"
-                                ],
-                                "additionalProperties": false
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "opinionSlugId": {
-                                                "type": "string",
-                                                "maxLength": 10
-                                            },
-                                            "createdAt": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "updatedAt": {
-                                                "type": "string",
-                                                "format": "date-time"
-                                            },
-                                            "opinion": {
-                                                "type": "string",
-                                                "minLength": 1
-                                            },
-                                            "numParticipants": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numAgrees": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numDisagrees": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "numPasses": {
-                                                "type": "integer",
-                                                "minimum": 0
-                                            },
-                                            "username": {
-                                                "type": "string"
-                                            },
-                                            "clustersStats": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "object",
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string",
-                                                            "enum": [
-                                                                "0",
-                                                                "1",
-                                                                "2",
-                                                                "3",
-                                                                "4",
-                                                                "5"
-                                                            ]
-                                                        },
-                                                        "aiLabel": {
-                                                            "type": "string"
-                                                        },
-                                                        "isAuthorInCluster": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "numUsers": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numAgrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numDisagrees": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        },
-                                                        "numPasses": {
-                                                            "type": "integer",
-                                                            "minimum": 0
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "isAuthorInCluster",
-                                                        "numUsers",
-                                                        "numAgrees",
-                                                        "numDisagrees",
-                                                        "numPasses"
-                                                    ],
-                                                    "additionalProperties": false
-                                                }
-                                            },
-                                            "moderation": {
-                                                "anyOf": [
-                                                    {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "status": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "moderated"
-                                                                ]
-                                                            },
-                                                            "action": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "move",
-                                                                    "hide"
-                                                                ]
-                                                            },
-                                                            "reason": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "misleading",
-                                                                    "antisocial",
-                                                                    "illegal",
-                                                                    "doxing",
-                                                                    "sexual",
-                                                                    "spam"
-                                                                ]
-                                                            },
-                                                            "explanation": {
-                                                                "type": "string",
-                                                                "maxLength": 1000
-                                                            },
-                                                            "createdAt": {
-                                                                "type": "string",
-                                                                "format": "date-time"
-                                                            },
-                                                            "updatedAt": {
-                                                                "type": "string",
-                                                                "format": "date-time"
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "status",
-                                                            "action",
-                                                            "reason",
-                                                            "explanation",
-                                                            "createdAt",
-                                                            "updatedAt"
-                                                        ],
-                                                        "additionalProperties": false
-                                                    },
-                                                    {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "status": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "unmoderated"
-                                                                ]
-                                                            }
-                                                        },
-                                                        "required": [
-                                                            "status"
-                                                        ],
-                                                        "additionalProperties": false
-                                                    }
-                                                ]
-                                            },
-                                            "isSeed": {
-                                                "type": "boolean"
-                                            }
-                                        },
-                                        "required": [
-                                            "opinionSlugId",
-                                            "createdAt",
-                                            "updatedAt",
-                                            "opinion",
-                                            "numParticipants",
-                                            "numAgrees",
-                                            "numDisagrees",
-                                            "numPasses",
-                                            "username",
-                                            "clustersStats",
-                                            "moderation",
-                                            "isSeed"
-                                        ],
-                                        "additionalProperties": false
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/opinion/fetch-representative-by-conversation": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "conversationSlugId": {
-                                        "type": "string",
-                                        "maxLength": 10
-                                    }
-                                },
-                                "required": [
-                                    "conversationSlugId"
-                                ],
-                                "additionalProperties": false
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "required": [
-                                        "0",
-                                        "1",
-                                        "2",
-                                        "3",
-                                        "4",
-                                        "5"
-                                    ],
-                                    "properties": {
-                                        "0": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "opinionSlugId": {
-                                                        "type": "string",
-                                                        "maxLength": 10
-                                                    },
-                                                    "createdAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "updatedAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "opinion": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                    },
-                                                    "numParticipants": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numAgrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numDisagrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numPasses": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "username": {
-                                                        "type": "string"
-                                                    },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
-                                                    "moderation": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "moderated"
-                                                                        ]
-                                                                    },
-                                                                    "action": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "move",
-                                                                            "hide"
-                                                                        ]
-                                                                    },
-                                                                    "reason": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "misleading",
-                                                                            "antisocial",
-                                                                            "illegal",
-                                                                            "doxing",
-                                                                            "sexual",
-                                                                            "spam"
-                                                                        ]
-                                                                    },
-                                                                    "explanation": {
-                                                                        "type": "string",
-                                                                        "maxLength": 1000
-                                                                    },
-                                                                    "createdAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    },
-                                                                    "updatedAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status",
-                                                                    "action",
-                                                                    "reason",
-                                                                    "explanation",
-                                                                    "createdAt",
-                                                                    "updatedAt"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            },
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "unmoderated"
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            }
-                                                        ]
-                                                    },
-                                                    "isSeed": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "opinionSlugId",
-                                                    "createdAt",
-                                                    "updatedAt",
-                                                    "opinion",
-                                                    "numParticipants",
-                                                    "numAgrees",
-                                                    "numDisagrees",
-                                                    "numPasses",
-                                                    "username",
-                                                    "clustersStats",
-                                                    "moderation",
-                                                    "isSeed"
-                                                ],
-                                                "additionalProperties": false
-                                            }
-                                        },
-                                        "1": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "opinionSlugId": {
-                                                        "type": "string",
-                                                        "maxLength": 10
-                                                    },
-                                                    "createdAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "updatedAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "opinion": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                    },
-                                                    "numParticipants": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numAgrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numDisagrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numPasses": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "username": {
-                                                        "type": "string"
-                                                    },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
-                                                    "moderation": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "moderated"
-                                                                        ]
-                                                                    },
-                                                                    "action": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "move",
-                                                                            "hide"
-                                                                        ]
-                                                                    },
-                                                                    "reason": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "misleading",
-                                                                            "antisocial",
-                                                                            "illegal",
-                                                                            "doxing",
-                                                                            "sexual",
-                                                                            "spam"
-                                                                        ]
-                                                                    },
-                                                                    "explanation": {
-                                                                        "type": "string",
-                                                                        "maxLength": 1000
-                                                                    },
-                                                                    "createdAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    },
-                                                                    "updatedAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status",
-                                                                    "action",
-                                                                    "reason",
-                                                                    "explanation",
-                                                                    "createdAt",
-                                                                    "updatedAt"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            },
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "unmoderated"
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            }
-                                                        ]
-                                                    },
-                                                    "isSeed": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "opinionSlugId",
-                                                    "createdAt",
-                                                    "updatedAt",
-                                                    "opinion",
-                                                    "numParticipants",
-                                                    "numAgrees",
-                                                    "numDisagrees",
-                                                    "numPasses",
-                                                    "username",
-                                                    "clustersStats",
-                                                    "moderation",
-                                                    "isSeed"
-                                                ],
-                                                "additionalProperties": false
-                                            }
-                                        },
-                                        "2": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "opinionSlugId": {
-                                                        "type": "string",
-                                                        "maxLength": 10
-                                                    },
-                                                    "createdAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "updatedAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "opinion": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                    },
-                                                    "numParticipants": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numAgrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numDisagrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numPasses": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "username": {
-                                                        "type": "string"
-                                                    },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
-                                                    "moderation": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "moderated"
-                                                                        ]
-                                                                    },
-                                                                    "action": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "move",
-                                                                            "hide"
-                                                                        ]
-                                                                    },
-                                                                    "reason": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "misleading",
-                                                                            "antisocial",
-                                                                            "illegal",
-                                                                            "doxing",
-                                                                            "sexual",
-                                                                            "spam"
-                                                                        ]
-                                                                    },
-                                                                    "explanation": {
-                                                                        "type": "string",
-                                                                        "maxLength": 1000
-                                                                    },
-                                                                    "createdAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    },
-                                                                    "updatedAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status",
-                                                                    "action",
-                                                                    "reason",
-                                                                    "explanation",
-                                                                    "createdAt",
-                                                                    "updatedAt"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            },
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "unmoderated"
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            }
-                                                        ]
-                                                    },
-                                                    "isSeed": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "opinionSlugId",
-                                                    "createdAt",
-                                                    "updatedAt",
-                                                    "opinion",
-                                                    "numParticipants",
-                                                    "numAgrees",
-                                                    "numDisagrees",
-                                                    "numPasses",
-                                                    "username",
-                                                    "clustersStats",
-                                                    "moderation",
-                                                    "isSeed"
-                                                ],
-                                                "additionalProperties": false
-                                            }
-                                        },
-                                        "3": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "opinionSlugId": {
-                                                        "type": "string",
-                                                        "maxLength": 10
-                                                    },
-                                                    "createdAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "updatedAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "opinion": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                    },
-                                                    "numParticipants": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numAgrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numDisagrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numPasses": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "username": {
-                                                        "type": "string"
-                                                    },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
-                                                    "moderation": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "moderated"
-                                                                        ]
-                                                                    },
-                                                                    "action": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "move",
-                                                                            "hide"
-                                                                        ]
-                                                                    },
-                                                                    "reason": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "misleading",
-                                                                            "antisocial",
-                                                                            "illegal",
-                                                                            "doxing",
-                                                                            "sexual",
-                                                                            "spam"
-                                                                        ]
-                                                                    },
-                                                                    "explanation": {
-                                                                        "type": "string",
-                                                                        "maxLength": 1000
-                                                                    },
-                                                                    "createdAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    },
-                                                                    "updatedAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status",
-                                                                    "action",
-                                                                    "reason",
-                                                                    "explanation",
-                                                                    "createdAt",
-                                                                    "updatedAt"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            },
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "unmoderated"
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            }
-                                                        ]
-                                                    },
-                                                    "isSeed": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "opinionSlugId",
-                                                    "createdAt",
-                                                    "updatedAt",
-                                                    "opinion",
-                                                    "numParticipants",
-                                                    "numAgrees",
-                                                    "numDisagrees",
-                                                    "numPasses",
-                                                    "username",
-                                                    "clustersStats",
-                                                    "moderation",
-                                                    "isSeed"
-                                                ],
-                                                "additionalProperties": false
-                                            }
-                                        },
-                                        "4": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "opinionSlugId": {
-                                                        "type": "string",
-                                                        "maxLength": 10
-                                                    },
-                                                    "createdAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "updatedAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "opinion": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                    },
-                                                    "numParticipants": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numAgrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numDisagrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numPasses": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "username": {
-                                                        "type": "string"
-                                                    },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
-                                                    "moderation": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "moderated"
-                                                                        ]
-                                                                    },
-                                                                    "action": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "move",
-                                                                            "hide"
-                                                                        ]
-                                                                    },
-                                                                    "reason": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "misleading",
-                                                                            "antisocial",
-                                                                            "illegal",
-                                                                            "doxing",
-                                                                            "sexual",
-                                                                            "spam"
-                                                                        ]
-                                                                    },
-                                                                    "explanation": {
-                                                                        "type": "string",
-                                                                        "maxLength": 1000
-                                                                    },
-                                                                    "createdAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    },
-                                                                    "updatedAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status",
-                                                                    "action",
-                                                                    "reason",
-                                                                    "explanation",
-                                                                    "createdAt",
-                                                                    "updatedAt"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            },
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "unmoderated"
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            }
-                                                        ]
-                                                    },
-                                                    "isSeed": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "opinionSlugId",
-                                                    "createdAt",
-                                                    "updatedAt",
-                                                    "opinion",
-                                                    "numParticipants",
-                                                    "numAgrees",
-                                                    "numDisagrees",
-                                                    "numPasses",
-                                                    "username",
-                                                    "clustersStats",
-                                                    "moderation",
-                                                    "isSeed"
-                                                ],
-                                                "additionalProperties": false
-                                            }
-                                        },
-                                        "5": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "object",
-                                                "properties": {
-                                                    "opinionSlugId": {
-                                                        "type": "string",
-                                                        "maxLength": 10
-                                                    },
-                                                    "createdAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "updatedAt": {
-                                                        "type": "string",
-                                                        "format": "date-time"
-                                                    },
-                                                    "opinion": {
-                                                        "type": "string",
-                                                        "minLength": 1
-                                                    },
-                                                    "numParticipants": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numAgrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numDisagrees": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "numPasses": {
-                                                        "type": "integer",
-                                                        "minimum": 0
-                                                    },
-                                                    "username": {
-                                                        "type": "string"
-                                                    },
-                                                    "clustersStats": {
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "properties": {
-                                                                "key": {
-                                                                    "type": "string",
-                                                                    "enum": [
-                                                                        "0",
-                                                                        "1",
-                                                                        "2",
-                                                                        "3",
-                                                                        "4",
-                                                                        "5"
-                                                                    ]
-                                                                },
-                                                                "aiLabel": {
-                                                                    "type": "string"
-                                                                },
-                                                                "isAuthorInCluster": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "numUsers": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numAgrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numDisagrees": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                },
-                                                                "numPasses": {
-                                                                    "type": "integer",
-                                                                    "minimum": 0
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "key",
-                                                                "isAuthorInCluster",
-                                                                "numUsers",
-                                                                "numAgrees",
-                                                                "numDisagrees",
-                                                                "numPasses"
-                                                            ],
-                                                            "additionalProperties": false
-                                                        }
-                                                    },
-                                                    "moderation": {
-                                                        "anyOf": [
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "moderated"
-                                                                        ]
-                                                                    },
-                                                                    "action": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "move",
-                                                                            "hide"
-                                                                        ]
-                                                                    },
-                                                                    "reason": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "misleading",
-                                                                            "antisocial",
-                                                                            "illegal",
-                                                                            "doxing",
-                                                                            "sexual",
-                                                                            "spam"
-                                                                        ]
-                                                                    },
-                                                                    "explanation": {
-                                                                        "type": "string",
-                                                                        "maxLength": 1000
-                                                                    },
-                                                                    "createdAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    },
-                                                                    "updatedAt": {
-                                                                        "type": "string",
-                                                                        "format": "date-time"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status",
-                                                                    "action",
-                                                                    "reason",
-                                                                    "explanation",
-                                                                    "createdAt",
-                                                                    "updatedAt"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            },
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "status": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "unmoderated"
-                                                                        ]
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "status"
-                                                                ],
-                                                                "additionalProperties": false
-                                                            }
-                                                        ]
-                                                    },
-                                                    "isSeed": {
-                                                        "type": "boolean"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "opinionSlugId",
-                                                    "createdAt",
-                                                    "updatedAt",
-                                                    "opinion",
-                                                    "numParticipants",
-                                                    "numAgrees",
-                                                    "numDisagrees",
-                                                    "numPasses",
-                                                    "username",
-                                                    "clustersStats",
-                                                    "moderation",
-                                                    "isSeed"
-                                                ],
-                                                "additionalProperties": false
-                                            }
-                                        }
-                                    },
-                                    "additionalProperties": false
                                 }
                             }
                         }

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -5,9 +5,6 @@ import {
     opinionModerationTable,
     conversationTable,
     userTable,
-    polisContentTable,
-    polisClusterTable,
-    polisClusterUserTable,
     voteTable,
 } from "@/shared-backend/schema.js";
 import type { GetUserProfileResponse } from "@/shared/types/dto.js";
@@ -15,7 +12,6 @@ import type {
     OpinionItem,
     ExtendedOpinion,
     ExtendedConversationPerSlugId,
-    ClusterStats,
     ExtendedOpinionWithConvId,
 } from "@/shared/types/zod.js";
 import { httpErrors } from "@fastify/sensible";
@@ -26,8 +22,6 @@ import { getPostSlugIdLastCreatedAt } from "./feed.js";
 import { getCommentSlugIdLastCreatedAt } from "./comment.js";
 import { fetchPostBySlugId } from "./post.js";
 import { createCommentModerationPropertyObject } from "./moderation.js";
-import { alias } from "drizzle-orm/pg-core";
-import { toUnionUndefined } from "@/shared/shared.js";
 import { getOrganizationsByUsername } from "./administrator/organization.js";
 import type { ImportPolisResults } from "@/shared/types/polis.js";
 import { generateUUID } from "@/crypto.js";
@@ -103,13 +97,6 @@ export async function getUserComments({
             db: db,
         });
 
-        const polisClusterTableAlias0 = alias(polisClusterTable, "cluster_0 ");
-        const polisClusterTableAlias1 = alias(polisClusterTable, "cluster_1 ");
-        const polisClusterTableAlias2 = alias(polisClusterTable, "cluster_2 ");
-        const polisClusterTableAlias3 = alias(polisClusterTable, "cluster_3 ");
-        const polisClusterTableAlias4 = alias(polisClusterTable, "cluster_4 ");
-        const polisClusterTableAlias5 = alias(polisClusterTable, "cluster_5 ");
-
         // Fetch a list of comment IDs first
         const preparedQuery = db
             .select({
@@ -131,56 +118,6 @@ export async function getUserComments({
                 moderationReason: opinionModerationTable.moderationReason,
                 moderationCreatedAt: opinionModerationTable.createdAt,
                 moderationUpdatedAt: opinionModerationTable.updatedAt,
-                polisCluster0Id: polisClusterTableAlias0.id,
-                polisCluster0Key: polisClusterTableAlias0.key,
-                polisCluster0AiLabel: polisClusterTableAlias0.aiLabel,
-                polisCluster0NumUsers: polisClusterTableAlias0.numUsers,
-                polisCluster0NumAgrees: opinionTable.polisCluster0NumAgrees,
-                polisCluster0NumDisagrees:
-                    opinionTable.polisCluster0NumDisagrees,
-                polisCluster0NumPasses: opinionTable.polisCluster0NumPasses,
-                polisCluster1Id: polisClusterTableAlias1.id,
-                polisCluster1Key: polisClusterTableAlias1.key,
-                polisCluster1AiLabel: polisClusterTableAlias1.aiLabel,
-                polisCluster1NumUsers: polisClusterTableAlias1.numUsers,
-                polisCluster1NumAgrees: opinionTable.polisCluster1NumAgrees,
-                polisCluster1NumDisagrees:
-                    opinionTable.polisCluster1NumDisagrees,
-                polisCluster1NumPasses: opinionTable.polisCluster1NumPasses,
-                polisCluster2Id: polisClusterTableAlias2.id,
-                polisCluster2Key: polisClusterTableAlias2.key,
-                polisCluster2AiLabel: polisClusterTableAlias2.aiLabel,
-                polisCluster2NumUsers: polisClusterTableAlias2.numUsers,
-                polisCluster2NumAgrees: opinionTable.polisCluster2NumAgrees,
-                polisCluster2NumDisagrees:
-                    opinionTable.polisCluster2NumDisagrees,
-                polisCluster2NumPasses: opinionTable.polisCluster2NumPasses,
-                polisCluster3Id: polisClusterTableAlias3.id,
-                polisCluster3Key: polisClusterTableAlias3.key,
-                polisCluster3AiLabel: polisClusterTableAlias3.aiLabel,
-                polisCluster3NumUsers: polisClusterTableAlias3.numUsers,
-                polisCluster3NumAgrees: opinionTable.polisCluster3NumAgrees,
-                polisCluster3NumDisagrees:
-                    opinionTable.polisCluster3NumDisagrees,
-                polisCluster3NumPasses: opinionTable.polisCluster3NumPasses,
-                polisCluster4Id: polisClusterTableAlias4.id,
-                polisCluster4Key: polisClusterTableAlias4.key,
-                polisCluster4AiLabel: polisClusterTableAlias4.aiLabel,
-                polisCluster4NumUsers: polisClusterTableAlias4.numUsers,
-                polisCluster4NumAgrees: opinionTable.polisCluster4NumAgrees,
-                polisCluster4NumDisagrees:
-                    opinionTable.polisCluster4NumDisagrees,
-                polisCluster4NumPasses: opinionTable.polisCluster4NumPasses,
-                polisCluster5Id: polisClusterTableAlias5.id,
-                polisCluster5Key: polisClusterTableAlias5.key,
-                polisCluster5AiLabel: polisClusterTableAlias5.aiLabel,
-                polisCluster5NumUsers: polisClusterTableAlias5.numUsers,
-                polisCluster5NumAgrees: opinionTable.polisCluster5NumAgrees,
-                polisCluster5NumDisagrees:
-                    opinionTable.polisCluster5NumDisagrees,
-                polisCluster5NumPasses: opinionTable.polisCluster5NumPasses,
-                opinionAuthorPolisClusterId:
-                    polisClusterUserTable.polisClusterId,
             })
             .from(opinionTable)
             .innerJoin(
@@ -191,47 +128,6 @@ export async function getUserComments({
             .innerJoin(
                 conversationTable,
                 eq(conversationTable.id, opinionTable.conversationId),
-            )
-            .leftJoin(
-                polisClusterTableAlias0,
-                eq(polisClusterTableAlias0.id, opinionTable.polisCluster0Id),
-            )
-            .leftJoin(
-                polisClusterTableAlias1,
-                eq(polisClusterTableAlias1.id, opinionTable.polisCluster1Id),
-            )
-            .leftJoin(
-                polisClusterTableAlias2,
-                eq(polisClusterTableAlias2.id, opinionTable.polisCluster2Id),
-            )
-            .leftJoin(
-                polisClusterTableAlias3,
-                eq(polisClusterTableAlias3.id, opinionTable.polisCluster3Id),
-            )
-            .leftJoin(
-                polisClusterTableAlias4,
-                eq(polisClusterTableAlias4.id, opinionTable.polisCluster4Id),
-            )
-            .leftJoin(
-                polisClusterTableAlias5,
-                eq(polisClusterTableAlias5.id, opinionTable.polisCluster5Id),
-            )
-            .leftJoin(
-                polisContentTable,
-                eq(
-                    polisContentTable.id,
-                    conversationTable.currentPolisContentId,
-                ),
-            )
-            .leftJoin(
-                polisClusterUserTable,
-                and(
-                    eq(
-                        polisClusterUserTable.polisContentId,
-                        polisContentTable.id,
-                    ),
-                    eq(polisClusterUserTable.userId, opinionTable.authorId),
-                ),
             )
             .leftJoin(
                 opinionModerationTable,
@@ -263,134 +159,6 @@ export async function getUserComments({
                 opinionResponse.moderationUpdatedAt,
             );
 
-            const clustersStats: ClusterStats[] = [];
-            if (
-                opinionResponse.polisCluster0Key !== null &&
-                opinionResponse.polisCluster0NumUsers !== null &&
-                opinionResponse.polisCluster0NumAgrees !== null &&
-                opinionResponse.polisCluster0NumDisagrees !== null &&
-                opinionResponse.polisCluster0NumPasses !== null
-            ) {
-                clustersStats.push({
-                    key: opinionResponse.polisCluster0Key,
-                    aiLabel: toUnionUndefined(
-                        opinionResponse.polisCluster0AiLabel,
-                    ),
-                    isAuthorInCluster:
-                        opinionResponse.opinionAuthorPolisClusterId ===
-                        opinionResponse.polisCluster0Id,
-                    numUsers: opinionResponse.polisCluster0NumUsers,
-                    numAgrees: opinionResponse.polisCluster0NumAgrees,
-                    numDisagrees: opinionResponse.polisCluster0NumDisagrees,
-                    numPasses: opinionResponse.polisCluster0NumPasses,
-                });
-            }
-            if (
-                opinionResponse.polisCluster1Key !== null &&
-                opinionResponse.polisCluster1NumUsers !== null &&
-                opinionResponse.polisCluster1NumAgrees !== null &&
-                opinionResponse.polisCluster1NumDisagrees !== null &&
-                opinionResponse.polisCluster1NumPasses !== null
-            ) {
-                clustersStats.push({
-                    key: opinionResponse.polisCluster1Key,
-                    aiLabel: toUnionUndefined(
-                        opinionResponse.polisCluster1AiLabel,
-                    ),
-                    isAuthorInCluster:
-                        opinionResponse.opinionAuthorPolisClusterId ===
-                        opinionResponse.polisCluster1Id,
-                    numUsers: opinionResponse.polisCluster1NumUsers,
-                    numAgrees: opinionResponse.polisCluster1NumAgrees,
-                    numDisagrees: opinionResponse.polisCluster1NumDisagrees,
-                    numPasses: opinionResponse.polisCluster1NumPasses,
-                });
-            }
-            if (
-                opinionResponse.polisCluster2Key !== null &&
-                opinionResponse.polisCluster2NumUsers !== null &&
-                opinionResponse.polisCluster2NumAgrees !== null &&
-                opinionResponse.polisCluster2NumDisagrees !== null &&
-                opinionResponse.polisCluster2NumPasses !== null
-            ) {
-                clustersStats.push({
-                    key: opinionResponse.polisCluster2Key,
-                    aiLabel: toUnionUndefined(
-                        opinionResponse.polisCluster2AiLabel,
-                    ),
-                    isAuthorInCluster:
-                        opinionResponse.opinionAuthorPolisClusterId ===
-                        opinionResponse.polisCluster2Id,
-                    numUsers: opinionResponse.polisCluster2NumUsers,
-                    numAgrees: opinionResponse.polisCluster2NumAgrees,
-                    numDisagrees: opinionResponse.polisCluster2NumDisagrees,
-                    numPasses: opinionResponse.polisCluster2NumPasses,
-                });
-            }
-            if (
-                opinionResponse.polisCluster3Key !== null &&
-                opinionResponse.polisCluster3NumUsers !== null &&
-                opinionResponse.polisCluster3NumAgrees !== null &&
-                opinionResponse.polisCluster3NumDisagrees !== null &&
-                opinionResponse.polisCluster3NumPasses !== null
-            ) {
-                clustersStats.push({
-                    key: opinionResponse.polisCluster3Key,
-                    aiLabel: toUnionUndefined(
-                        opinionResponse.polisCluster3AiLabel,
-                    ),
-                    isAuthorInCluster:
-                        opinionResponse.opinionAuthorPolisClusterId ===
-                        opinionResponse.polisCluster3Id,
-                    numUsers: opinionResponse.polisCluster3NumUsers,
-                    numAgrees: opinionResponse.polisCluster3NumAgrees,
-                    numDisagrees: opinionResponse.polisCluster3NumDisagrees,
-                    numPasses: opinionResponse.polisCluster3NumPasses,
-                });
-            }
-            if (
-                opinionResponse.polisCluster4Key !== null &&
-                opinionResponse.polisCluster4NumUsers !== null &&
-                opinionResponse.polisCluster4NumAgrees !== null &&
-                opinionResponse.polisCluster4NumDisagrees !== null &&
-                opinionResponse.polisCluster4NumPasses !== null
-            ) {
-                clustersStats.push({
-                    key: opinionResponse.polisCluster4Key,
-                    aiLabel: toUnionUndefined(
-                        opinionResponse.polisCluster4AiLabel,
-                    ),
-                    isAuthorInCluster:
-                        opinionResponse.opinionAuthorPolisClusterId ===
-                        opinionResponse.polisCluster4Id,
-                    numUsers: opinionResponse.polisCluster4NumUsers,
-                    numAgrees: opinionResponse.polisCluster4NumAgrees,
-                    numDisagrees: opinionResponse.polisCluster4NumDisagrees,
-                    numPasses: opinionResponse.polisCluster4NumPasses,
-                });
-            }
-            if (
-                opinionResponse.polisCluster5Key !== null &&
-                opinionResponse.polisCluster5NumUsers !== null &&
-                opinionResponse.polisCluster5NumAgrees !== null &&
-                opinionResponse.polisCluster5NumDisagrees !== null &&
-                opinionResponse.polisCluster5NumPasses !== null
-            ) {
-                clustersStats.push({
-                    key: opinionResponse.polisCluster5Key,
-                    aiLabel: toUnionUndefined(
-                        opinionResponse.polisCluster5AiLabel,
-                    ),
-                    isAuthorInCluster:
-                        opinionResponse.opinionAuthorPolisClusterId ===
-                        opinionResponse.polisCluster5Id,
-                    numUsers: opinionResponse.polisCluster5NumUsers,
-                    numAgrees: opinionResponse.polisCluster5NumAgrees,
-                    numDisagrees: opinionResponse.polisCluster5NumDisagrees,
-                    numPasses: opinionResponse.polisCluster5NumPasses,
-                });
-            }
-
             const commentItem: OpinionItem = {
                 opinion: opinionResponse.comment,
                 opinionSlugId: opinionResponse.commentSlugId,
@@ -403,7 +171,6 @@ export async function getUserComments({
                 username: opinionResponse.username,
                 moderation: moderationProperties,
                 isSeed: opinionResponse.isSeed,
-                clustersStats: clustersStats,
             };
 
             const postItem = await fetchPostBySlugId({

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -6,6 +6,7 @@ import {
     zodUserId,
     zodSlugId,
     zodOpinionItem,
+    zodAnalysisOpinionItem,
     zodPollOptionTitle,
     zodConversationTitle,
     zodConversationBody,
@@ -147,8 +148,8 @@ export class Dto {
     static fetchAnalysisResponse = z
         .object({
             polisContentId: z.number().int().nonnegative().optional(), // for logging/debugging purpose, undefined if no polis calculated
-            consensus: z.array(zodOpinionItem),
-            controversial: z.array(zodOpinionItem),
+            consensus: z.array(zodAnalysisOpinionItem),
+            controversial: z.array(zodAnalysisOpinionItem),
             clusters: zodPolisClusters,
         })
         .strict();
@@ -159,34 +160,6 @@ export class Dto {
         })
         .strict();
     static fetchHiddenOpinionsResponse = z.array(zodOpinionItem);
-    static fetchConsensusResponse = z.array(zodOpinionItem);
-    static fetchConsensusRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchMajorityResponse = z.array(zodOpinionItem);
-    static fetchMajorityRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchControversialResponse = z.array(zodOpinionItem);
-    static fetchControversialRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchRepresentativeResponse = z.record(
-        zodPolisKey,
-        z.array(zodOpinionItem),
-    );
-    static fetchRepresentativeRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-
     static createNewConversationRequest = z
         .object({
             conversationTitle: zodConversationTitle,

--- a/services/api/src/shared/types/zod.ts
+++ b/services/api/src/shared/types/zod.ts
@@ -134,10 +134,6 @@ export const zodCommentFeedFilter = z.enum([
     "moderated",
     "new",
     "discover",
-    "group-aware-consensus",
-    "majority",
-    "controversial",
-    "cluster",
 ]);
 export const usernameRegex = new RegExp(
     `^[a-z0-9_]*$`, // {${MIN_LENGTH_USERNAME.toString()},${MAX_LENGTH_USERNAME.toString()}
@@ -327,7 +323,6 @@ export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);
 export const zodVotingAction = z.enum(["agree", "disagree", "pass", "cancel"]);
 export const zodClusterStats = z.object({
     key: zodPolisKey,
-    aiLabel: z.string().optional(),
     isAuthorInCluster: z.boolean(),
     numUsers: z.number().int().nonnegative(),
     numAgrees: z.number().int().nonnegative(),
@@ -345,11 +340,13 @@ export const zodOpinionItem = z
         numDisagrees: z.number().int().nonnegative(),
         numPasses: z.number().int().nonnegative(),
         username: z.string(),
-        clustersStats: z.array(zodClusterStats),
         moderation: zodOpinionModerationProperties,
         isSeed: z.boolean(),
     })
     .strict();
+export const zodAnalysisOpinionItem = zodOpinionItem.extend({
+    clustersStats: z.array(zodClusterStats),
+});
 export const zodClusterMetadata = z
     .object({
         id: z.number().int().nonnegative(),
@@ -370,7 +367,7 @@ export const zodPolisClusters = z.record(
             aiLabel: z.string().optional(),
             aiSummary: z.string().optional(),
             isUserInCluster: z.boolean(),
-            representative: z.array(zodOpinionItem),
+            representative: z.array(zodAnalysisOpinionItem),
         })
         .strict(),
 );
@@ -380,6 +377,10 @@ export const zodPolisClustersMetadata = z.record(
 );
 
 export const zodOpinionItemPerSlugId = z.map(zodSlugId, zodOpinionItem);
+export const zodAnalysisOpinionItemPerSlugId = z.map(
+    zodSlugId,
+    zodAnalysisOpinionItem,
+);
 export const zodUserInteraction = z
     .object({
         hasVoted: z.boolean(),
@@ -931,7 +932,11 @@ export type ExtendedConversationPayload = z.infer<
 export type PollOptionWithResult = z.infer<typeof zodPollOptionWithResult>;
 export type CommentContent = z.infer<typeof zodOpinionContent>;
 export type OpinionItem = z.infer<typeof zodOpinionItem>;
+export type AnalysisOpinionItem = z.infer<typeof zodAnalysisOpinionItem>;
 export type OpinionItemPerSlugId = z.infer<typeof zodOpinionItemPerSlugId>;
+export type AnalysisOpinionItemPerSlugId = z.infer<
+    typeof zodAnalysisOpinionItemPerSlugId
+>;
 export type ExtendedOpinion = z.infer<typeof zodExtendedOpinionData>;
 export type ExtendedOpinionWithConvId = z.infer<
     typeof zodExtendedOpinionDataWithConvId

--- a/services/load-testing/src/api/api.ts
+++ b/services/load-testing/src/api/api.ts
@@ -2023,16 +2023,16 @@ export interface ApiV1OpinionFetchAnalysisByConversationPost200Response {
     'polisContentId'?: number;
     /**
      * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
+     * @type {Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>}
      * @memberof ApiV1OpinionFetchAnalysisByConversationPost200Response
      */
-    'consensus': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
+    'consensus': Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>;
     /**
      * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
+     * @type {Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>}
      * @memberof ApiV1OpinionFetchAnalysisByConversationPost200Response
      */
-    'controversial': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
+    'controversial': Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>;
     /**
      * 
      * @type {ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters}
@@ -2121,10 +2121,10 @@ export interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0
     'isUserInCluster': boolean;
     /**
      * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
+     * @type {Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>}
      * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0
      */
-    'representative': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
+    'representative': Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner>;
 }
 
 export const ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyEnum = {
@@ -2137,6 +2137,140 @@ export const ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyE
 } as const;
 
 export type ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyEnum = typeof ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyEnum[keyof typeof ApiV1OpinionFetchAnalysisByConversationPost200ResponseClusters0KeyEnum];
+
+/**
+ * 
+ * @export
+ * @interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+ */
+export interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner {
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'opinionSlugId': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'createdAt': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'updatedAt': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'opinion': string;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'numParticipants': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'numAgrees': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'numDisagrees': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'numPasses': number;
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'username': string;
+    /**
+     * 
+     * @type {ApiV1ModerationOpinionGetPost200Response}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'moderation': ApiV1ModerationOpinionGetPost200Response;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'isSeed': boolean;
+    /**
+     * 
+     * @type {Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner>}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInner
+     */
+    'clustersStats': Array<ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner>;
+}
+/**
+ * 
+ * @export
+ * @interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+ */
+export interface ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner {
+    /**
+     * 
+     * @type {string}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'key': ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'isAuthorInCluster': boolean;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'numUsers': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'numAgrees': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'numDisagrees': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInner
+     */
+    'numPasses': number;
+}
+
+export const ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum = {
+    _0: '0',
+    _1: '1',
+    _2: '2',
+    _3: '3',
+    _4: '4',
+    _5: '5'
+} as const;
+
+export type ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum = typeof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum[keyof typeof ApiV1OpinionFetchAnalysisByConversationPost200ResponseConsensusInnerClustersStatsInnerKeyEnum];
 
 /**
  * 
@@ -2168,11 +2302,7 @@ export const ApiV1OpinionFetchByConversationPostRequestFilterEnum = {
     Hidden: 'hidden',
     Moderated: 'moderated',
     New: 'new',
-    Discover: 'discover',
-    GroupAwareConsensus: 'group-aware-consensus',
-    Majority: 'majority',
-    Controversial: 'controversial',
-    Cluster: 'cluster'
+    Discover: 'discover'
 } as const;
 
 export type ApiV1OpinionFetchByConversationPostRequestFilterEnum = typeof ApiV1OpinionFetchByConversationPostRequestFilterEnum[keyof typeof ApiV1OpinionFetchByConversationPostRequestFilterEnum];
@@ -2218,49 +2348,6 @@ export interface ApiV1OpinionFetchHiddenByConversationPostRequest {
      * @memberof ApiV1OpinionFetchHiddenByConversationPostRequest
      */
     'createdAt'?: string;
-}
-/**
- * 
- * @export
- * @interface ApiV1OpinionFetchRepresentativeByConversationPost200Response
- */
-export interface ApiV1OpinionFetchRepresentativeByConversationPost200Response {
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '0': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '1': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '2': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '3': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '4': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
-    /**
-     * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>}
-     * @memberof ApiV1OpinionFetchRepresentativeByConversationPost200Response
-     */
-    '5': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>;
 }
 /**
  * 
@@ -2750,12 +2837,6 @@ export interface ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem {
     'username': string;
     /**
      * 
-     * @type {Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner>}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem
-     */
-    'clustersStats': Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner>;
-    /**
-     * 
      * @type {ApiV1ModerationOpinionGetPost200Response}
      * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem
      */
@@ -2767,67 +2848,6 @@ export interface ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem {
      */
     'isSeed': boolean;
 }
-/**
- * 
- * @export
- * @interface ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
- */
-export interface ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner {
-    /**
-     * 
-     * @type {string}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'key': ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum;
-    /**
-     * 
-     * @type {string}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'aiLabel'?: string;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'isAuthorInCluster': boolean;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'numUsers': number;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'numAgrees': number;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'numDisagrees': number;
-    /**
-     * 
-     * @type {number}
-     * @memberof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInner
-     */
-    'numPasses': number;
-}
-
-export const ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum = {
-    _0: '0',
-    _1: '1',
-    _2: '2',
-    _3: '3',
-    _4: '4',
-    _5: '5'
-} as const;
-
-export type ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum = typeof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum[keyof typeof ApiV1UserOpinionFetchPost200ResponseInnerOpinionItemClustersStatsInnerKeyEnum];
-
 /**
  * 
  * @export
@@ -4271,84 +4291,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchConsensusByConversationPost: async (apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1ModerationConversationWithdrawPostRequest' is not null or undefined
-            assertParamExists('apiV1OpinionFetchConsensusByConversationPost', 'apiV1ModerationConversationWithdrawPostRequest', apiV1ModerationConversationWithdrawPostRequest)
-            const localVarPath = `/api/v1/opinion/fetch-consensus-by-conversation`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationConversationWithdrawPostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchControversialByConversationPost: async (apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1ModerationConversationWithdrawPostRequest' is not null or undefined
-            assertParamExists('apiV1OpinionFetchControversialByConversationPost', 'apiV1ModerationConversationWithdrawPostRequest', apiV1ModerationConversationWithdrawPostRequest)
-            const localVarPath = `/api/v1/opinion/fetch-controversial-by-conversation`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationConversationWithdrawPostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
          * @param {ApiV1OpinionFetchHiddenByConversationPostRequest} apiV1OpinionFetchHiddenByConversationPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -4380,84 +4322,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(apiV1OpinionFetchHiddenByConversationPostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchMajorityByConversationPost: async (apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1ModerationConversationWithdrawPostRequest' is not null or undefined
-            assertParamExists('apiV1OpinionFetchMajorityByConversationPost', 'apiV1ModerationConversationWithdrawPostRequest', apiV1ModerationConversationWithdrawPostRequest)
-            const localVarPath = `/api/v1/opinion/fetch-majority-by-conversation`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationConversationWithdrawPostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchRepresentativeByConversationPost: async (apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1ModerationConversationWithdrawPostRequest' is not null or undefined
-            assertParamExists('apiV1OpinionFetchRepresentativeByConversationPost', 'apiV1ModerationConversationWithdrawPostRequest', apiV1ModerationConversationWithdrawPostRequest)
-            const localVarPath = `/api/v1/opinion/fetch-representative-by-conversation`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1ModerationConversationWithdrawPostRequest, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -5586,30 +5450,6 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchConsensusByConversationPost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchControversialByConversationPost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
          * @param {ApiV1OpinionFetchHiddenByConversationPostRequest} apiV1OpinionFetchHiddenByConversationPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -5618,30 +5458,6 @@ export const DefaultApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchHiddenByConversationPost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchMajorityByConversationPost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1OpinionFetchRepresentativeByConversationPost200Response>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1OpinionFetchRepresentativeByConversationPost']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
@@ -6179,48 +5995,12 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>> {
-            return localVarFp.apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>> {
-            return localVarFp.apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
          * @param {ApiV1OpinionFetchHiddenByConversationPostRequest} apiV1OpinionFetchHiddenByConversationPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest: ApiV1OpinionFetchHiddenByConversationPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>> {
             return localVarFp.apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<Array<ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem>> {
-            return localVarFp.apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
-         * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1OpinionFetchRepresentativeByConversationPost200Response> {
-            return localVarFp.apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -6768,28 +6548,6 @@ export class DefaultApi extends BaseAPI {
 
     /**
      * 
-     * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1OpinionFetchConsensusByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1OpinionFetchControversialByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
      * @param {ApiV1OpinionFetchHiddenByConversationPostRequest} apiV1OpinionFetchHiddenByConversationPostRequest 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -6797,28 +6555,6 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest: ApiV1OpinionFetchHiddenByConversationPostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1OpinionFetchHiddenByConversationPost(apiV1OpinionFetchHiddenByConversationPostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1OpinionFetchMajorityByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {ApiV1ModerationConversationWithdrawPostRequest} apiV1ModerationConversationWithdrawPostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof DefaultApi
-     */
-    public apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest: ApiV1ModerationConversationWithdrawPostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1OpinionFetchRepresentativeByConversationPost(apiV1ModerationConversationWithdrawPostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/services/load-testing/src/crypto/ucan/implementation/k6.ts
+++ b/services/load-testing/src/crypto/ucan/implementation/k6.ts
@@ -276,6 +276,25 @@ export async function implementation({
             getUcanAlgorithm: async (): Promise<string> => {
                 return "RS256";
             },
+            exportKeys: async (
+                writeName: string,
+                exchangeName: string,
+            ): Promise<{
+                write: { privateKey: JsonWebKey; publicKey: JsonWebKey };
+                exchange: { privateKey: JsonWebKey; publicKey: JsonWebKey };
+            }> => {
+                return await ks.exportKeys(writeName, exchangeName);
+            },
+            importKeys: async (
+                writeName: string,
+                exchangeName: string,
+                exportedKeys: {
+                    write: { privateKey: JsonWebKey; publicKey: JsonWebKey };
+                    exchange: { privateKey: JsonWebKey; publicKey: JsonWebKey };
+                }
+            ): Promise<any> => {
+                return await ks.importKeys(writeName, exchangeName, exportedKeys);
+            },
         },
     };
 }

--- a/services/load-testing/src/crypto/ucan/operation.ts
+++ b/services/load-testing/src/crypto/ucan/operation.ts
@@ -100,3 +100,22 @@ export function buildAuthorizationHeader(encodedUcan: string) {
     Authorization: `Bearer ${encodedUcan}`,
   };
 }
+
+export interface ExportedKeys {
+  write: { privateKey: JsonWebKey; publicKey: JsonWebKey };
+  exchange: { privateKey: JsonWebKey; publicKey: JsonWebKey };
+}
+
+export async function exportKeys(prefixedKey: string): Promise<ExportedKeys> {
+  const cryptoStore = await getNodeCryptoStore();
+  const writeName = `${prefixedKey}/write`;
+  const exchangeName = `${prefixedKey}/exchange`;
+  return await cryptoStore.keystore.exportKeys(writeName, exchangeName);
+}
+
+export async function importKeys(prefixedKey: string, exportedKeys: ExportedKeys): Promise<void> {
+  const cryptoStore = await getNodeCryptoStore();
+  const writeName = `${prefixedKey}/write`;
+  const exchangeName = `${prefixedKey}/exchange`;
+  await cryptoStore.keystore.importKeys(writeName, exchangeName, exportedKeys);
+}

--- a/services/load-testing/src/shared/types/dto.ts
+++ b/services/load-testing/src/shared/types/dto.ts
@@ -6,6 +6,7 @@ import {
     zodUserId,
     zodSlugId,
     zodOpinionItem,
+    zodAnalysisOpinionItem,
     zodPollOptionTitle,
     zodConversationTitle,
     zodConversationBody,
@@ -147,8 +148,8 @@ export class Dto {
     static fetchAnalysisResponse = z
         .object({
             polisContentId: z.number().int().nonnegative().optional(), // for logging/debugging purpose, undefined if no polis calculated
-            consensus: z.array(zodOpinionItem),
-            controversial: z.array(zodOpinionItem),
+            consensus: z.array(zodAnalysisOpinionItem),
+            controversial: z.array(zodAnalysisOpinionItem),
             clusters: zodPolisClusters,
         })
         .strict();
@@ -159,34 +160,6 @@ export class Dto {
         })
         .strict();
     static fetchHiddenOpinionsResponse = z.array(zodOpinionItem);
-    static fetchConsensusResponse = z.array(zodOpinionItem);
-    static fetchConsensusRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchMajorityResponse = z.array(zodOpinionItem);
-    static fetchMajorityRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchControversialResponse = z.array(zodOpinionItem);
-    static fetchControversialRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchRepresentativeResponse = z.record(
-        zodPolisKey,
-        z.array(zodOpinionItem),
-    );
-    static fetchRepresentativeRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-
     static createNewConversationRequest = z
         .object({
             conversationTitle: zodConversationTitle,

--- a/services/load-testing/src/shared/types/zod.ts
+++ b/services/load-testing/src/shared/types/zod.ts
@@ -134,10 +134,6 @@ export const zodCommentFeedFilter = z.enum([
     "moderated",
     "new",
     "discover",
-    "group-aware-consensus",
-    "majority",
-    "controversial",
-    "cluster",
 ]);
 export const usernameRegex = new RegExp(
     `^[a-z0-9_]*$`, // {${MIN_LENGTH_USERNAME.toString()},${MAX_LENGTH_USERNAME.toString()}
@@ -327,7 +323,6 @@ export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);
 export const zodVotingAction = z.enum(["agree", "disagree", "pass", "cancel"]);
 export const zodClusterStats = z.object({
     key: zodPolisKey,
-    aiLabel: z.string().optional(),
     isAuthorInCluster: z.boolean(),
     numUsers: z.number().int().nonnegative(),
     numAgrees: z.number().int().nonnegative(),
@@ -345,11 +340,13 @@ export const zodOpinionItem = z
         numDisagrees: z.number().int().nonnegative(),
         numPasses: z.number().int().nonnegative(),
         username: z.string(),
-        clustersStats: z.array(zodClusterStats),
         moderation: zodOpinionModerationProperties,
         isSeed: z.boolean(),
     })
     .strict();
+export const zodAnalysisOpinionItem = zodOpinionItem.extend({
+    clustersStats: z.array(zodClusterStats),
+});
 export const zodClusterMetadata = z
     .object({
         id: z.number().int().nonnegative(),
@@ -370,7 +367,7 @@ export const zodPolisClusters = z.record(
             aiLabel: z.string().optional(),
             aiSummary: z.string().optional(),
             isUserInCluster: z.boolean(),
-            representative: z.array(zodOpinionItem),
+            representative: z.array(zodAnalysisOpinionItem),
         })
         .strict(),
 );
@@ -380,6 +377,10 @@ export const zodPolisClustersMetadata = z.record(
 );
 
 export const zodOpinionItemPerSlugId = z.map(zodSlugId, zodOpinionItem);
+export const zodAnalysisOpinionItemPerSlugId = z.map(
+    zodSlugId,
+    zodAnalysisOpinionItem,
+);
 export const zodUserInteraction = z
     .object({
         hasVoted: z.boolean(),
@@ -931,7 +932,11 @@ export type ExtendedConversationPayload = z.infer<
 export type PollOptionWithResult = z.infer<typeof zodPollOptionWithResult>;
 export type CommentContent = z.infer<typeof zodOpinionContent>;
 export type OpinionItem = z.infer<typeof zodOpinionItem>;
+export type AnalysisOpinionItem = z.infer<typeof zodAnalysisOpinionItem>;
 export type OpinionItemPerSlugId = z.infer<typeof zodOpinionItemPerSlugId>;
+export type AnalysisOpinionItemPerSlugId = z.infer<
+    typeof zodAnalysisOpinionItemPerSlugId
+>;
 export type ExtendedOpinion = z.infer<typeof zodExtendedOpinionData>;
 export type ExtendedOpinionWithConvId = z.infer<
     typeof zodExtendedOpinionDataWithConvId

--- a/services/math-updater/src/shared/types/dto.ts
+++ b/services/math-updater/src/shared/types/dto.ts
@@ -6,6 +6,7 @@ import {
     zodUserId,
     zodSlugId,
     zodOpinionItem,
+    zodAnalysisOpinionItem,
     zodPollOptionTitle,
     zodConversationTitle,
     zodConversationBody,
@@ -147,8 +148,8 @@ export class Dto {
     static fetchAnalysisResponse = z
         .object({
             polisContentId: z.number().int().nonnegative().optional(), // for logging/debugging purpose, undefined if no polis calculated
-            consensus: z.array(zodOpinionItem),
-            controversial: z.array(zodOpinionItem),
+            consensus: z.array(zodAnalysisOpinionItem),
+            controversial: z.array(zodAnalysisOpinionItem),
             clusters: zodPolisClusters,
         })
         .strict();
@@ -159,34 +160,6 @@ export class Dto {
         })
         .strict();
     static fetchHiddenOpinionsResponse = z.array(zodOpinionItem);
-    static fetchConsensusResponse = z.array(zodOpinionItem);
-    static fetchConsensusRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchMajorityResponse = z.array(zodOpinionItem);
-    static fetchMajorityRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchControversialResponse = z.array(zodOpinionItem);
-    static fetchControversialRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchRepresentativeResponse = z.record(
-        zodPolisKey,
-        z.array(zodOpinionItem),
-    );
-    static fetchRepresentativeRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-
     static createNewConversationRequest = z
         .object({
             conversationTitle: zodConversationTitle,

--- a/services/math-updater/src/shared/types/zod.ts
+++ b/services/math-updater/src/shared/types/zod.ts
@@ -134,10 +134,6 @@ export const zodCommentFeedFilter = z.enum([
     "moderated",
     "new",
     "discover",
-    "group-aware-consensus",
-    "majority",
-    "controversial",
-    "cluster",
 ]);
 export const usernameRegex = new RegExp(
     `^[a-z0-9_]*$`, // {${MIN_LENGTH_USERNAME.toString()},${MAX_LENGTH_USERNAME.toString()}
@@ -327,7 +323,6 @@ export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);
 export const zodVotingAction = z.enum(["agree", "disagree", "pass", "cancel"]);
 export const zodClusterStats = z.object({
     key: zodPolisKey,
-    aiLabel: z.string().optional(),
     isAuthorInCluster: z.boolean(),
     numUsers: z.number().int().nonnegative(),
     numAgrees: z.number().int().nonnegative(),
@@ -345,11 +340,13 @@ export const zodOpinionItem = z
         numDisagrees: z.number().int().nonnegative(),
         numPasses: z.number().int().nonnegative(),
         username: z.string(),
-        clustersStats: z.array(zodClusterStats),
         moderation: zodOpinionModerationProperties,
         isSeed: z.boolean(),
     })
     .strict();
+export const zodAnalysisOpinionItem = zodOpinionItem.extend({
+    clustersStats: z.array(zodClusterStats),
+});
 export const zodClusterMetadata = z
     .object({
         id: z.number().int().nonnegative(),
@@ -370,7 +367,7 @@ export const zodPolisClusters = z.record(
             aiLabel: z.string().optional(),
             aiSummary: z.string().optional(),
             isUserInCluster: z.boolean(),
-            representative: z.array(zodOpinionItem),
+            representative: z.array(zodAnalysisOpinionItem),
         })
         .strict(),
 );
@@ -380,6 +377,10 @@ export const zodPolisClustersMetadata = z.record(
 );
 
 export const zodOpinionItemPerSlugId = z.map(zodSlugId, zodOpinionItem);
+export const zodAnalysisOpinionItemPerSlugId = z.map(
+    zodSlugId,
+    zodAnalysisOpinionItem,
+);
 export const zodUserInteraction = z
     .object({
         hasVoted: z.boolean(),
@@ -931,7 +932,11 @@ export type ExtendedConversationPayload = z.infer<
 export type PollOptionWithResult = z.infer<typeof zodPollOptionWithResult>;
 export type CommentContent = z.infer<typeof zodOpinionContent>;
 export type OpinionItem = z.infer<typeof zodOpinionItem>;
+export type AnalysisOpinionItem = z.infer<typeof zodAnalysisOpinionItem>;
 export type OpinionItemPerSlugId = z.infer<typeof zodOpinionItemPerSlugId>;
+export type AnalysisOpinionItemPerSlugId = z.infer<
+    typeof zodAnalysisOpinionItemPerSlugId
+>;
 export type ExtendedOpinion = z.infer<typeof zodExtendedOpinionData>;
 export type ExtendedOpinionWithConvId = z.infer<
     typeof zodExtendedOpinionDataWithConvId

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -5,6 +5,7 @@ import {
     zodUserId,
     zodSlugId,
     zodOpinionItem,
+    zodAnalysisOpinionItem,
     zodPollOptionTitle,
     zodConversationTitle,
     zodConversationBody,
@@ -146,8 +147,8 @@ export class Dto {
     static fetchAnalysisResponse = z
         .object({
             polisContentId: z.number().int().nonnegative().optional(), // for logging/debugging purpose, undefined if no polis calculated
-            consensus: z.array(zodOpinionItem),
-            controversial: z.array(zodOpinionItem),
+            consensus: z.array(zodAnalysisOpinionItem),
+            controversial: z.array(zodAnalysisOpinionItem),
             clusters: zodPolisClusters,
         })
         .strict();
@@ -158,34 +159,6 @@ export class Dto {
         })
         .strict();
     static fetchHiddenOpinionsResponse = z.array(zodOpinionItem);
-    static fetchConsensusResponse = z.array(zodOpinionItem);
-    static fetchConsensusRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchMajorityResponse = z.array(zodOpinionItem);
-    static fetchMajorityRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchControversialResponse = z.array(zodOpinionItem);
-    static fetchControversialRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-    static fetchRepresentativeResponse = z.record(
-        zodPolisKey,
-        z.array(zodOpinionItem),
-    );
-    static fetchRepresentativeRequest = z
-        .object({
-            conversationSlugId: zodSlugId,
-        })
-        .strict();
-
     static createNewConversationRequest = z
         .object({
             conversationTitle: zodConversationTitle,

--- a/services/shared/src/types/zod.ts
+++ b/services/shared/src/types/zod.ts
@@ -133,10 +133,6 @@ export const zodCommentFeedFilter = z.enum([
     "moderated",
     "new",
     "discover",
-    "group-aware-consensus",
-    "majority",
-    "controversial",
-    "cluster",
 ]);
 export const usernameRegex = new RegExp(
     `^[a-z0-9_]*$`, // {${MIN_LENGTH_USERNAME.toString()},${MAX_LENGTH_USERNAME.toString()}
@@ -326,7 +322,6 @@ export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);
 export const zodVotingAction = z.enum(["agree", "disagree", "pass", "cancel"]);
 export const zodClusterStats = z.object({
     key: zodPolisKey,
-    aiLabel: z.string().optional(),
     isAuthorInCluster: z.boolean(),
     numUsers: z.number().int().nonnegative(),
     numAgrees: z.number().int().nonnegative(),
@@ -344,11 +339,13 @@ export const zodOpinionItem = z
         numDisagrees: z.number().int().nonnegative(),
         numPasses: z.number().int().nonnegative(),
         username: z.string(),
-        clustersStats: z.array(zodClusterStats),
         moderation: zodOpinionModerationProperties,
         isSeed: z.boolean(),
     })
     .strict();
+export const zodAnalysisOpinionItem = zodOpinionItem.extend({
+    clustersStats: z.array(zodClusterStats),
+});
 export const zodClusterMetadata = z
     .object({
         id: z.number().int().nonnegative(),
@@ -369,7 +366,7 @@ export const zodPolisClusters = z.record(
             aiLabel: z.string().optional(),
             aiSummary: z.string().optional(),
             isUserInCluster: z.boolean(),
-            representative: z.array(zodOpinionItem),
+            representative: z.array(zodAnalysisOpinionItem),
         })
         .strict(),
 );
@@ -379,6 +376,10 @@ export const zodPolisClustersMetadata = z.record(
 );
 
 export const zodOpinionItemPerSlugId = z.map(zodSlugId, zodOpinionItem);
+export const zodAnalysisOpinionItemPerSlugId = z.map(
+    zodSlugId,
+    zodAnalysisOpinionItem,
+);
 export const zodUserInteraction = z
     .object({
         hasVoted: z.boolean(),
@@ -930,7 +931,11 @@ export type ExtendedConversationPayload = z.infer<
 export type PollOptionWithResult = z.infer<typeof zodPollOptionWithResult>;
 export type CommentContent = z.infer<typeof zodOpinionContent>;
 export type OpinionItem = z.infer<typeof zodOpinionItem>;
+export type AnalysisOpinionItem = z.infer<typeof zodAnalysisOpinionItem>;
 export type OpinionItemPerSlugId = z.infer<typeof zodOpinionItemPerSlugId>;
+export type AnalysisOpinionItemPerSlugId = z.infer<
+    typeof zodAnalysisOpinionItemPerSlugId
+>;
 export type ExtendedOpinion = z.infer<typeof zodExtendedOpinionData>;
 export type ExtendedOpinionWithConvId = z.infer<
     typeof zodExtendedOpinionDataWithConvId


### PR DESCRIPTION
Fixed AI label bug on analysis details page by separating analysis opinion fetching from regular opinion fetching, ensuring cluster statistics are always included in analysis views.

**Analysis API refactoring:**
- Split opinion fetching into two distinct code paths:
  * fetchOpinionsByPostSlugId: for regular opinion lists without cluster stats (new/moderated/hidden/discover feeds)
  * fetchAnalysisOpinionsByPostSlugId: for analysis views with cluster stats (consensus/controversial/representative opinions)
- Fixed AI label bug: analysis opinions now always include cluster statistics because they use the dedicated analysis fetch path
- Simplified filterTarget parameter (removed unused filter types)

**Type safety improvements:**
- Added AnalysisOpinionItem type that extends OpinionItem with required clustersStats array
- Ensures analysis opinions always have cluster statistics attached
- Prevents runtime errors from missing cluster data in UI components

**Load testing fixes:**
- Fixed 401 authentication errors during teardown phase
- Root cause: MemoryKeyStore keys were not shared between VUs and teardown environment in k6
- Solution: Added exportKeys/importKeys methods to MemoryKeyStore
- Keys now generated in setup(), exported as JSON, and imported into each VU and teardown phase
- Eliminates need to regenerate keys in teardown (which was failing)

**Code cleanup:**
- Removed 4 unused API endpoints (fetch-consensus, fetch-majority, fetch-controversial, fetch-representative)
- Removed ~3000 lines from OpenAPI spec (unused endpoint definitions)
- Removed unused imports and SQL query builder functions
- Simplified frontend query hooks with better cache management
- Removed dead cluster stats fetching code from user service
- Removed redundant SQL queries in user profile fetching

Net result: 33 files changed, 1536 insertions(+), 4479 deletions(-)