### PR TITLE
feat: enable vote modification with race condition handling

### DIFF
--- a/services/agora/src/components/post/comments/group/item/CommentActionBar.i18n.ts
+++ b/services/agora/src/components/post/comments/group/item/CommentActionBar.i18n.ts
@@ -4,7 +4,6 @@ export interface CommentActionBarTranslations {
   disagree: string;
   pass: string;
   agree: string;
-  voteChangeDisabled: string;
   voteFailed: string;
   disagreeAriaLabel: string;
   passAriaLabel: string;
@@ -19,7 +18,6 @@ export const commentActionBarTranslations: Record<
     disagree: "Disagree",
     pass: "Unsure",
     agree: "Agree",
-    voteChangeDisabled: "Vote change temporarily disabled",
     voteFailed: "Failed to submit vote. Please try again.",
     disagreeAriaLabel: "Disagree with comment. Current disagrees:",
     passAriaLabel: "Unsure about this comment. Current count:",
@@ -29,7 +27,6 @@ export const commentActionBarTranslations: Record<
     disagree: "أرفض",
     pass: "غير متأكد",
     agree: "أوافق",
-    voteChangeDisabled: "تغيير التصويت معطل مؤقتاً",
     voteFailed: "فشل في إرسال التصويت. يرجى المحاولة مرة أخرى.",
     disagreeAriaLabel: "أرفض التعليق. عدد الرفض الحالي:",
     passAriaLabel: "لست متأكداً من هذا الرأي. العدد الحالي:",
@@ -39,7 +36,6 @@ export const commentActionBarTranslations: Record<
     disagree: "En desacuerdo",
     pass: "No seguro",
     agree: "De acuerdo",
-    voteChangeDisabled: "Cambio de voto temporalmente deshabilitado",
     voteFailed: "Error al enviar el voto. Por favor, inténtelo de nuevo.",
     disagreeAriaLabel: "En desacuerdo con el comentario. Desacuerdos actuales:",
     passAriaLabel: "Inseguro sobre esta opinión. Recuento actual:",
@@ -49,7 +45,6 @@ export const commentActionBarTranslations: Record<
     disagree: "Pas d'accord",
     pass: "Incertain",
     agree: "D'accord",
-    voteChangeDisabled: "Changement de vote temporairement désactivé",
     voteFailed: "Échec de l'envoi du vote. Veuillez réessayer.",
     disagreeAriaLabel: "Pas d'accord avec le commentaire. Désaccords actuels:",
     passAriaLabel: "Incertain à propos de cet avis. Nombre actuel :",
@@ -59,7 +54,6 @@ export const commentActionBarTranslations: Record<
     disagree: "不同意",
     pass: "不确定",
     agree: "同意",
-    voteChangeDisabled: "投票更改暂时禁用",
     voteFailed: "投票提交失败。请重试。",
     disagreeAriaLabel: "不同意此评论。当前不同意数：",
     passAriaLabel: "对该观点不确定。当前不确定数：",
@@ -69,7 +63,6 @@ export const commentActionBarTranslations: Record<
     disagree: "不同意",
     pass: "不確定",
     agree: "同意",
-    voteChangeDisabled: "投票更改暫時禁用",
     voteFailed: "投票提交失敗。請重試。",
     disagreeAriaLabel: "不同意此評論。當前不同意數：",
     passAriaLabel: "對該觀點不確定。當前不確定數：",
@@ -79,7 +72,6 @@ export const commentActionBarTranslations: Record<
     disagree: "不同意",
     pass: "わからない",
     agree: "同意",
-    voteChangeDisabled: "投票変更が一時的に無効化されています",
     voteFailed: "投票の送信に失敗しました。もう一度お試しください。",
     disagreeAriaLabel: "コメントに不同意。現在の不同意数：",
     passAriaLabel: "この意見について不確かです。現在の数：",


### PR DESCRIPTION
Changes:
- Add ON CONFLICT DO NOTHING to vote buffer bulk INSERT
- Skip conflicted votes instead of failing entire batch
- Log warnings when race conditions occur for monitoring
- Enable vote changes in frontend (remove temporary block)
- Add vote cancellation by re-clicking same vote button
- Refactor optimistic update logic to eliminate code repetition

Race condition handling:
When concurrent batches try to insert the same vote, the conflict is now handled gracefully. Conflicted votes are skipped and logged, preventing one user's rapid clicking from blocking other users' votes in the same batch. This is an acceptable trade-off for the rare case where a user votes twice within ~20ms across batch boundaries.

Vote modification:
Users can now change their votes (agree → disagree) and cancel votes by clicking the same button again. The optimistic UI updates correctly handle all cases: new votes, vote changes, and cancellations.

Deploy: api, agora