### PR TITLE
feat(frontend): add login intention dialogs for Zupass-gated actions

### DIFF
--- a/services/agora/src/App.vue
+++ b/services/agora/src/App.vue
@@ -2,6 +2,10 @@
   <router-view />
   <PostSignupPreferencesDialog />
   <EmbeddedBrowserWarningDialog />
+
+  <!-- Global Zupass iframe container - shared by all components -->
+  <!-- Parcnet creates its own dialog with overlay, positioned fixed -->
+  <div ref="zupassIframeContainer" class="zupass-iframe-container"></div>
 </template>
 
 <script setup lang="ts">
@@ -11,6 +15,7 @@ import * as swiperElement from "swiper/element/bundle";
 import { onMounted } from "vue";
 import { useBackendAuthApi } from "./utils/api/auth";
 import { useHtmlNodeCssPatch } from "./utils/css/htmlNodeCssPatch";
+import { useZupassVerification } from "./composables/zupass/useZupassVerification";
 import "primeicons/primeicons.css";
 
 swiperElement.register();
@@ -18,6 +23,9 @@ swiperElement.register();
 const authenticationStore = useBackendAuthApi();
 
 useHtmlNodeCssPatch();
+
+// Initialize global Zupass iframe container
+const { zupassIframeContainer } = useZupassVerification();
 
 onMounted(async () => {
   try {
@@ -30,4 +38,9 @@ onMounted(async () => {
 });
 </script>
 
-<style lang="scss"></style>
+<style lang="scss">
+.zupass-iframe-container {
+  // Empty container - Parcnet will inject iframe and dialog
+  // Dialog is positioned fixed with its own backdrop, doesn't need special styling here
+}
+</style>

--- a/services/agora/src/components/authentication/intention/DialogContainer.vue
+++ b/services/agora/src/components/authentication/intention/DialogContainer.vue
@@ -32,6 +32,8 @@
             button-type="largeButton"
             :label="labelOk"
             color="primary"
+            :loading="okLoading"
+            :disable="okLoading"
             @click="clickedOkButton()"
           />
         </div>
@@ -51,6 +53,7 @@ const props = defineProps<{
   okCallback: () => void;
   labelOk: string;
   labelCancel: string;
+  okLoading: boolean;
 }>();
 
 const showDialog = defineModel<boolean>({ required: true });

--- a/services/agora/src/components/authentication/intention/PreLoginIntentionDialog.i18n.ts
+++ b/services/agora/src/components/authentication/intention/PreLoginIntentionDialog.i18n.ts
@@ -2,8 +2,12 @@ import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
 
 export interface PreLoginIntentionDialogTranslations {
   title: string;
+  titleZupassOnly: string;
   message: string;
+  messageBothRequired: string;
+  messageZupassOnly: string;
   labelOk: string;
+  labelOkZupass: string;
   labelCancel: string;
 }
 
@@ -13,44 +17,72 @@ export const preLoginIntentionDialogTranslations: Record<
 > = {
   en: {
     title: "Log in to Agora",
+    titleZupassOnly: "Verify Event Ticket",
     message: "Log in to participate in the discussions",
+    messageBothRequired: "This conversation requires login and event ticket verification to participate",
+    messageZupassOnly: "This conversation requires event ticket verification to participate",
     labelOk: "Log In",
+    labelOkZupass: "Verify Ticket",
     labelCancel: "Cancel",
   },
   ar: {
     title: "تسجيل الدخول إلى أغورا",
+    titleZupassOnly: "التحقق من تذكرة الحدث",
     message: "سجّل دخولك للمشاركة في النقاشات",
+    messageBothRequired: "تتطلب هذه المحادثة تسجيل الدخول والتحقق من تذكرة الحدث للمشاركة",
+    messageZupassOnly: "تتطلب هذه المحادثة التحقق من تذكرة الحدث للمشاركة",
     labelOk: "تسجيل الدخول",
+    labelOkZupass: "التحقق من التذكرة",
     labelCancel: "إلغاء",
   },
   es: {
     title: "Iniciar sesión en Ágora",
+    titleZupassOnly: "Verificar Boleto del Evento",
     message: "Inicia sesión para participar en las discusiones",
+    messageBothRequired: "Esta conversación requiere inicio de sesión y verificación de boleto del evento para participar",
+    messageZupassOnly: "Esta conversación requiere verificación de boleto del evento para participar",
     labelOk: "Iniciar Sesión",
+    labelOkZupass: "Verificar Boleto",
     labelCancel: "Cancelar",
   },
   fr: {
     title: "Se connecter à Agora",
+    titleZupassOnly: "Vérifier le Billet d'Événement",
     message: "Connectez-vous pour participer aux discussions",
+    messageBothRequired: "Cette conversation nécessite une connexion et une vérification de billet d'événement pour participer",
+    messageZupassOnly: "Cette conversation nécessite une vérification de billet d'événement pour participer",
     labelOk: "Se Connecter",
+    labelOkZupass: "Vérifier le Billet",
     labelCancel: "Annuler",
   },
   "zh-Hans": {
     title: "登录 Agora",
+    titleZupassOnly: "验证活动门票",
     message: "登录以参与讨论",
+    messageBothRequired: "此对话需要登录和活动门票验证才能参与",
+    messageZupassOnly: "此对话需要活动门票验证才能参与",
     labelOk: "登录",
+    labelOkZupass: "验证门票",
     labelCancel: "取消",
   },
   "zh-Hant": {
     title: "登入 Agora",
+    titleZupassOnly: "驗證活動門票",
     message: "登入以參與討論",
+    messageBothRequired: "此對話需要登入和活動門票驗證才能參與",
+    messageZupassOnly: "此對話需要活動門票驗證才能參與",
     labelOk: "登入",
+    labelOkZupass: "驗證門票",
     labelCancel: "取消",
   },
   ja: {
     title: "Agora にログイン",
+    titleZupassOnly: "イベントチケットの確認",
     message: "ログインして議論に参加",
+    messageBothRequired: "この会話に参加するにはログインとイベントチケットの確認が必要です",
+    messageZupassOnly: "この会話に参加するにはイベントチケットの確認が必要です",
     labelOk: "ログイン",
+    labelOkZupass: "チケット確認",
     labelCancel: "キャンセル",
   },
 };

--- a/services/agora/src/components/authentication/intention/PreLoginIntentionDialog.vue
+++ b/services/agora/src/components/authentication/intention/PreLoginIntentionDialog.vue
@@ -2,13 +2,14 @@
   <div>
     <DialogContainer
       v-model="showDialog"
-      :title="t('title')"
-      :message="t('message')"
+      :title="getTitle()"
+      :message="getMessage()"
       :show-cancel-dialog="true"
       :ok-callback="okButtonClicked"
       :cancel-callback="() => {}"
-      :label-ok="t('labelOk')"
+      :label-ok="getLabelOk()"
       :label-cancel="t('labelCancel')"
+      :ok-loading="isVerifyingZupass"
     >
       <template #body>
         <div v-if="subMessage" class="shadowBoxStyle">
@@ -29,26 +30,37 @@ import { ref } from "vue";
 import type { PossibleIntentions } from "src/stores/loginIntention";
 import { useLoginIntentionStore } from "src/stores/loginIntention";
 import { useRouter } from "vue-router";
+import { useAuthenticationStore } from "src/stores/authentication";
+import { storeToRefs } from "pinia";
 import DialogContainer from "./DialogContainer.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import {
   preLoginIntentionDialogTranslations,
   type PreLoginIntentionDialogTranslations,
 } from "./PreLoginIntentionDialog.i18n";
+import type { EventSlug } from "src/shared/types/zod";
+import { useZupassVerification } from "src/composables/zupass/useZupassVerification";
 
 const showDialog = defineModel<boolean>({ required: true });
 
 const props = defineProps<{
   okCallback: () => void;
   activeIntention: PossibleIntentions;
+  requiresZupassEventSlug?: EventSlug;
+  loginRequiredToParticipate?: boolean;
 }>();
 
 const { t } = useComponentI18n<PreLoginIntentionDialogTranslations>(
   preLoginIntentionDialogTranslations
 );
 
+const authStore = useAuthenticationStore();
+const { isLoggedIn } = storeToRefs(authStore);
+
 const { composeLoginIntentionDialogMessage, setActiveUserIntention } =
   useLoginIntentionStore();
+
+const { isVerifying: isVerifyingZupass } = useZupassVerification();
 
 const subMessage = ref(
   composeLoginIntentionDialogMessage(props.activeIntention)
@@ -56,10 +68,89 @@ const subMessage = ref(
 
 const router = useRouter();
 
+function getTitle(): string {
+  const hasZupassRequirement = props.requiresZupassEventSlug !== undefined;
+  const needsLogin = props.loginRequiredToParticipate === true && !isLoggedIn.value;
+
+  console.log('[PreLoginIntentionDialog] getTitle()', {
+    loginRequiredToParticipate: props.loginRequiredToParticipate,
+    requiresZupassEventSlug: props.requiresZupassEventSlug,
+    isLoggedIn: isLoggedIn.value,
+    hasZupassRequirement,
+    needsLogin,
+  });
+
+  if (hasZupassRequirement && !needsLogin) {
+    return t("titleZupassOnly");
+  } else {
+    return t("title");
+  }
+}
+
+function getMessage(): string {
+  const hasZupassRequirement = props.requiresZupassEventSlug !== undefined;
+  const needsLogin = props.loginRequiredToParticipate === true && !isLoggedIn.value;
+
+  console.log('[PreLoginIntentionDialog] getMessage()', {
+    loginRequiredToParticipate: props.loginRequiredToParticipate,
+    requiresZupassEventSlug: props.requiresZupassEventSlug,
+    isLoggedIn: isLoggedIn.value,
+    hasZupassRequirement,
+    needsLogin,
+  });
+
+  if (hasZupassRequirement && needsLogin) {
+    return t("messageBothRequired");
+  } else if (hasZupassRequirement && !needsLogin) {
+    return t("messageZupassOnly");
+  } else {
+    return t("message");
+  }
+}
+
+function getLabelOk(): string {
+  const hasZupassRequirement = props.requiresZupassEventSlug !== undefined;
+  const needsLogin = props.loginRequiredToParticipate === true && !isLoggedIn.value;
+
+  if (hasZupassRequirement && !needsLogin) {
+    return t("labelOkZupass");
+  } else {
+    return t("labelOk");
+  }
+}
+
 async function okButtonClicked() {
-  props.okCallback();
-  setActiveUserIntention(props.activeIntention);
-  await router.push({ name: "/welcome/" });
+  const hasZupassRequirement = props.requiresZupassEventSlug !== undefined;
+  const needsLogin = props.loginRequiredToParticipate === true && !isLoggedIn.value;
+
+  console.log('[PreLoginIntentionDialog] okButtonClicked()', {
+    loginRequiredToParticipate: props.loginRequiredToParticipate,
+    requiresZupassEventSlug: props.requiresZupassEventSlug,
+    isLoggedIn: isLoggedIn.value,
+    hasZupassRequirement,
+    needsLogin,
+    willRouteToWelcome: needsLogin,
+    willTriggerInlineVerification: !needsLogin && hasZupassRequirement,
+  });
+
+  if (needsLogin) {
+    // Need to login first - use existing login flow
+    console.log('[PreLoginIntentionDialog] Routing to /welcome/ for login');
+    props.okCallback();
+    setActiveUserIntention(props.activeIntention);
+    await router.push({ name: "/welcome/" });
+  } else if (hasZupassRequirement) {
+    // Zupass verification needed (either logged in or guest)
+    // Trigger the verification flow inline via callback
+    console.log('[PreLoginIntentionDialog] Triggering inline Zupass verification');
+    props.okCallback();
+  } else {
+    // Standard login-only flow (no Zupass required)
+    console.log('[PreLoginIntentionDialog] Standard login flow');
+    props.okCallback();
+    setActiveUserIntention(props.activeIntention);
+    await router.push({ name: "/welcome/" });
+  }
 }
 </script>
 

--- a/services/agora/src/components/post/PostDetails.vue
+++ b/services/agora/src/components/post/PostDetails.vue
@@ -43,10 +43,8 @@
             ref="opinionSectionRef"
             :post-slug-id="conversationData.metadata.conversationSlugId"
             :is-post-locked="isPostLocked"
-            :login-required-to-participate="
-              conversationData.metadata.isIndexed ||
-              conversationData.metadata.isLoginRequired
-            "
+            :login-required-to-participate="conversationData.metadata.isLoginRequired"
+            :requires-event-ticket="conversationData.metadata.requiresEventTicket"
             :preloaded-queries="{
               commentsDiscoverQuery,
               commentsNewQuery,
@@ -57,20 +55,19 @@
             @participant-count-delta="
               (delta: number) => (participantCountLocal += delta)
             "
+            @ticket-verified="(payload) => handleTicketVerified(payload)"
           />
         </div>
       </div>
     </ZKHoverEffect>
 
-    <FloatingBottomContainer v-if="!compactMode && !isPostLocked">
+    <FloatingBottomContainer v-if="!compactMode">
       <CommentComposer
         :post-slug-id="conversationData.metadata.conversationSlugId"
-        :login-required-to-participate="
-          conversationData.metadata.isIndexed ||
-          conversationData.metadata.isLoginRequired
-        "
+        :login-required-to-participate="conversationData.metadata.isLoginRequired"
         :requires-event-ticket="conversationData.metadata.requiresEventTicket"
         @submitted-comment="submittedComment"
+        @ticket-verified="(payload) => handleTicketVerified(payload)"
       />
     </FloatingBottomContainer>
 

--- a/services/agora/src/components/post/comments/CommentSection.vue
+++ b/services/agora/src/components/post/comments/CommentSection.vue
@@ -36,8 +36,10 @@
             }"
             :is-post-locked="isPostLocked"
             :login-required-to-participate="props.loginRequiredToParticipate"
+            :requires-event-ticket="props.requiresEventTicket"
             @deleted="handleOpinionDeleted()"
             @muted-comment="handleOpinionMuted()"
+            @ticket-verified="(payload) => emit('ticketVerified', payload)"
           />
         </AsyncStateHandler>
       </div>
@@ -65,12 +67,22 @@ import { useOpinionPagination } from "src/composables/opinion/useOpinionPaginati
 import type { UseQueryReturnType } from "@tanstack/vue-query";
 import type { OpinionItem } from "src/shared/types/zod";
 
-const emit = defineEmits(["deleted", "participantCountDelta", "voteCast"]);
+const emit = defineEmits<{
+  deleted: [];
+  participantCountDelta: [delta: number];
+  voteCast: [];
+  ticketVerified: [
+    payload: { userIdChanged: boolean; needsCacheRefresh: boolean }
+  ];
+}>();
+
+import type { EventSlug } from "src/shared/types/zod";
 
 const props = defineProps<{
   postSlugId: string;
   isPostLocked: boolean;
   loginRequiredToParticipate: boolean;
+  requiresEventTicket?: EventSlug;
   preloadedQueries: {
     commentsDiscoverQuery: UseQueryReturnType<OpinionItem[], Error>;
     commentsNewQuery: UseQueryReturnType<OpinionItem[], Error>;

--- a/services/agora/src/components/post/comments/group/CommentGroup.vue
+++ b/services/agora/src/components/post/comments/group/CommentGroup.vue
@@ -46,11 +46,14 @@
         :voting-utilities="votingUtilities"
         :is-post-locked="isPostLocked"
         :login-required-to-participate="loginRequiredToParticipate"
+        :requires-event-ticket="props.requiresEventTicket"
         @deleted="deletedComment()"
         @muted-comment="mutedComment()"
         @change-vote="
           (vote: VotingAction, opinionSlugId: string) =>
             changeVote(vote, opinionSlugId)
+        "
+        @ticket-verified="(payload) => emit('ticketVerified', payload)
         "
       />
     </ZKCard>
@@ -64,7 +67,16 @@ import type { OpinionVotingUtilities } from "src/composables/opinion/types";
 import CommentItem from "./item/CommentItem.vue";
 import ZKCard from "src/components/ui-library/ZKCard.vue";
 
-const emit = defineEmits(["deleted", "mutedComment", "changeVote"]);
+const emit = defineEmits<{
+  deleted: [];
+  mutedComment: [];
+  changeVote: [vote: VotingAction, opinionSlugId: string];
+  ticketVerified: [
+    payload: { userIdChanged: boolean; needsCacheRefresh: boolean }
+  ];
+}>();
+
+import type { EventSlug } from "src/shared/types/zod";
 
 const props = defineProps<{
   commentItemList: OpinionItem[];
@@ -73,6 +85,7 @@ const props = defineProps<{
   votingUtilities: OpinionVotingUtilities;
   isPostLocked: boolean;
   loginRequiredToParticipate: boolean;
+  requiresEventTicket?: EventSlug;
 }>();
 
 const finalCommentList = computed((): OpinionItem[] => {

--- a/services/agora/src/components/post/comments/group/item/CommentItem.vue
+++ b/services/agora/src/components/post/comments/group/item/CommentItem.vue
@@ -42,7 +42,9 @@
             :voting-utilities="votingUtilities"
             :is-post-locked="isPostLocked"
             :login-required-to-participate="loginRequiredToParticipate"
+            :requires-event-ticket="props.requiresEventTicket"
             @change-vote="(vote: VotingAction) => changeVote(vote)"
+            @ticket-verified="(payload) => emit('ticketVerified', payload)"
           />
         </div>
       </div>
@@ -59,7 +61,16 @@ import CommentActionBar from "./CommentActionBar.vue";
 import ZKHtmlContent from "../../../../ui-library/ZKHtmlContent.vue";
 import OpinionIdentityCard from "src/components/post/comments/OpinionIdentityCard.vue";
 
-const emit = defineEmits(["deleted", "mutedComment", "changeVote"]);
+const emit = defineEmits<{
+  deleted: [];
+  mutedComment: [];
+  changeVote: [vote: VotingAction, opinionSlugId: string];
+  ticketVerified: [
+    payload: { userIdChanged: boolean; needsCacheRefresh: boolean }
+  ];
+}>();
+
+import type { EventSlug } from "src/shared/types/zod";
 
 const props = defineProps<{
   commentItem: OpinionItem;
@@ -67,6 +78,7 @@ const props = defineProps<{
   votingUtilities: OpinionVotingUtilities;
   isPostLocked: boolean;
   loginRequiredToParticipate: boolean;
+  requiresEventTicket?: EventSlug;
 }>();
 
 function changeVote(vote: VotingAction) {

--- a/services/agora/src/components/post/display/PostContent.vue
+++ b/services/agora/src/components/post/display/PostContent.vue
@@ -42,14 +42,12 @@
 
       <div v-if="extendedPostData.payload.poll" class="pollContainer">
         <PollWrapper
-          :login-required-to-participate="
-            extendedPostData.metadata.isIndexed ||
-            extendedPostData.metadata.isLoginRequired
-          "
+          :login-required-to-participate="extendedPostData.metadata.isLoginRequired"
           :poll-options="extendedPostData.payload.poll"
           :post-slug-id="extendedPostData.metadata.conversationSlugId"
           :user-response="extendedPostData.interaction"
           :requires-event-ticket="extendedPostData.metadata.requiresEventTicket"
+          @ticket-verified="(payload) => $emit('verified', payload)"
         />
       </div>
 

--- a/services/agora/src/components/routeGuard/ExitRoutePrompt.vue
+++ b/services/agora/src/components/routeGuard/ExitRoutePrompt.vue
@@ -9,6 +9,7 @@
       :ok-callback="saveDraft"
       :label-ok="t('saveAsDraft')"
       :label-cancel="t('discard')"
+      :ok-loading="false"
     >
     </DialogContainer>
   </div>

--- a/services/agora/src/composables/auth/useConversationLoginIntentions.ts
+++ b/services/agora/src/composables/auth/useConversationLoginIntentions.ts
@@ -1,6 +1,7 @@
 import { useLoginIntentionStore } from "src/stores/loginIntention";
 import { useRoute } from "vue-router";
 import { useEmbedMode } from "src/utils/ui/embedMode";
+import type { EventSlug } from "src/shared/types/zod";
 
 export function useConversationLoginIntentions() {
   const route = useRoute();
@@ -13,38 +14,38 @@ export function useConversationLoginIntentions() {
     setActiveUserIntention,
   } = useLoginIntentionStore();
 
-  function setVotingIntention() {
+  function setVotingIntention(eventSlug?: EventSlug) {
     if (
       route.name === "/conversation/[postSlugId]" ||
       route.name === "/conversation/[postSlugId].embed"
     ) {
       const isEmbedView = isEmbeddedMode();
       const postSlugId = route.params.postSlugId;
-      createVotingIntention(postSlugId, isEmbedView);
+      createVotingIntention(postSlugId, isEmbedView, eventSlug);
       setActiveUserIntention("voting");
     }
   }
 
-  function setOpinionAgreementIntention(opinionSlugId: string) {
+  function setOpinionAgreementIntention(opinionSlugId: string, eventSlug?: EventSlug) {
     if (
       route.name === "/conversation/[postSlugId]" ||
       route.name === "/conversation/[postSlugId].embed"
     ) {
       const isEmbedView = isEmbeddedMode();
       const postSlugId = route.params.postSlugId;
-      createOpinionAgreementIntention(postSlugId, opinionSlugId, isEmbedView);
+      createOpinionAgreementIntention(postSlugId, opinionSlugId, isEmbedView, eventSlug);
       setActiveUserIntention("agreement");
     }
   }
 
-  function setReportIntention(opinionSlugId: string) {
+  function setReportIntention(opinionSlugId: string, eventSlug?: EventSlug) {
     if (
       route.name === "/conversation/[postSlugId]" ||
       route.name === "/conversation/[postSlugId].embed"
     ) {
       const isEmbedView = isEmbeddedMode();
       const postSlugId = route.params.postSlugId;
-      createReportUserContentIntention(postSlugId, opinionSlugId, isEmbedView);
+      createReportUserContentIntention(postSlugId, opinionSlugId, isEmbedView, eventSlug);
       setActiveUserIntention("reportUserContent");
     }
   }

--- a/services/agora/src/composables/zupass/useTicketVerificationFlow.ts
+++ b/services/agora/src/composables/zupass/useTicketVerificationFlow.ts
@@ -1,0 +1,182 @@
+import { useZupassVerification } from "./useZupassVerification";
+import { useBackendZupassApi } from "src/utils/api/zupass";
+import { useBackendAuthApi } from "src/utils/api/auth";
+import { useAuthenticationStore } from "src/stores/authentication";
+import { useUserStore } from "src/stores/user";
+import { useNotify } from "src/utils/ui/notify";
+import { useQuasar } from "quasar";
+import { getPlatform } from "src/utils/common";
+import type { EventSlug } from "src/shared/types/zod";
+import { useComponentI18n } from "src/composables/ui/useComponentI18n";
+import {
+  eventTicketRequirementBannerTranslations,
+  type EventTicketRequirementBannerTranslations,
+} from "src/components/post/EventTicketRequirementBanner.i18n";
+
+export type TicketVerificationResult =
+  | {
+      success: true;
+      userIdChanged: boolean;
+      needsCacheRefresh: boolean;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+export interface TicketVerificationOptions {
+  eventSlug: EventSlug;
+  successMessage?: string;
+  onSuccess?: (result: TicketVerificationResult) => void | Promise<void>;
+  onIframeReady?: () => void;
+}
+
+/**
+ * Composable that provides a reusable ticket verification flow
+ * Handles the full flow: request proof -> verify backend -> update state
+ */
+export function useTicketVerificationFlow() {
+  const { requestTicketProof, setOnIframeReady, isVerifying } = useZupassVerification();
+  const { verifyEventTicket } = useBackendZupassApi();
+  const { updateAuthState } = useBackendAuthApi();
+  const { showNotifyMessage } = useNotify();
+  const authStore = useAuthenticationStore();
+  const userStore = useUserStore();
+
+  // Get platform at setup level (can't call useQuasar in async functions)
+  const $q = useQuasar();
+  const platform = getPlatform($q.platform);
+
+  // Translations for error messages
+  const { t } = useComponentI18n<EventTicketRequirementBannerTranslations>(
+    eventTicketRequirementBannerTranslations
+  );
+
+  // Map error codes to user-friendly messages
+  function getErrorMessage(errorCode: string): string {
+    const errorMessages: Record<string, string> = {
+      deserialization_error: t("errorDeserialization"),
+      invalid_proof: t("errorInvalidProof"),
+      invalid_signer: t("errorInvalidSigner"),
+      wrong_event: t("errorWrongEvent"),
+      ticket_already_used: t("errorTicketAlreadyUsed"),
+      unknown: t("errorUnknown"),
+    };
+    return errorMessages[errorCode] || errorMessages.unknown;
+  }
+
+  async function verifyTicket({
+    eventSlug,
+    successMessage,
+    onSuccess,
+    onIframeReady,
+  }: TicketVerificationOptions): Promise<TicketVerificationResult> {
+    // Set verifying state in store immediately
+    userStore.setTicketVerifying(eventSlug);
+    isVerifying.value = true;
+
+    try {
+
+      // Set callback to close dialog when iframe is ready
+      if (onIframeReady) {
+        setOnIframeReady(onIframeReady);
+      }
+
+      // Request proof from Zupass (Parcnet creates its own dialog)
+      const proofResult = await requestTicketProof({
+        eventSlug,
+        platform,
+      });
+
+      if (!proofResult.success) {
+        // Handle cancellation gracefully - don't show error
+        if (proofResult.error === "cancelled") {
+          userStore.clearTicketState(eventSlug);
+          return { success: false, error: "cancelled" };
+        }
+
+        const errorReason = proofResult.error || "unknown";
+        const errorMessage = getErrorMessage(errorReason);
+        userStore.setTicketError(eventSlug, errorMessage);
+        showNotifyMessage(errorMessage);
+        return { success: false, error: errorReason };
+      }
+
+      // Send GPC proof to backend for verification
+      console.log("[TicketVerificationFlow] Sending proof to backend...");
+      let verifyResult;
+      try {
+        verifyResult = await verifyEventTicket({
+          proof: proofResult.proof!,
+          eventSlug,
+        });
+        console.log("[TicketVerificationFlow] Backend response:", verifyResult);
+      } catch (backendError) {
+        console.error("[TicketVerificationFlow] Backend call threw exception:", backendError);
+        throw backendError;
+      }
+
+      if (!verifyResult.success) {
+        const errorReason = verifyResult.reason || "unknown";
+        console.log("[TicketVerificationFlow] Verification failed with reason:", errorReason);
+        const errorMessage = getErrorMessage(errorReason);
+        userStore.setTicketError(eventSlug, errorMessage);
+        showNotifyMessage(errorMessage);
+        return { success: false, error: errorReason };
+      }
+
+      // Check if userId changed (account merge)
+      const currentUserId = authStore.userId;
+      const newUserId = verifyResult.userId;
+      const userIdChanged = currentUserId !== newUserId;
+
+      // Update auth state with deferred cache operations
+      const { needsCacheRefresh } = await updateAuthState({
+        partialLoginStatus: { isKnown: true, userId: newUserId },
+        deferCacheOperations: true,
+      });
+
+      // Add verified ticket to user store immediately to unlock gated content
+      // This also clears the transient "verifying" state since getTicketVerificationState
+      // will now return "verified"
+      userStore.addVerifiedTicket(eventSlug);
+      userStore.clearTicketState(eventSlug);
+      console.log("[TicketVerificationFlow] Ticket verified and state cleared for", eventSlug);
+
+      // Show success message
+      if (successMessage !== undefined) {
+        showNotifyMessage(successMessage);
+      } else if (verifyResult.accountMerged) {
+        showNotifyMessage("Account merged successfully");
+      } else {
+        showNotifyMessage("Event ticket verified successfully");
+      }
+
+      const result: TicketVerificationResult = {
+        success: true,
+        userIdChanged,
+        needsCacheRefresh,
+      };
+
+      // Call success callback if provided
+      if (onSuccess !== undefined) {
+        await onSuccess(result);
+      }
+
+      return result;
+    } catch (err) {
+      console.error("[TicketVerificationFlow] Error:", err);
+      const errorMessage = getErrorMessage("unknown");
+      userStore.setTicketError(eventSlug, errorMessage);
+      showNotifyMessage(errorMessage);
+      return { success: false, error: "unknown" };
+    } finally {
+      // Reset loading state after entire verification flow completes
+      isVerifying.value = false;
+    }
+  }
+
+  return {
+    verifyTicket,
+  };
+}

--- a/services/agora/src/pages/conversation/new/create/index.vue
+++ b/services/agora/src/pages/conversation/new/create/index.vue
@@ -189,6 +189,9 @@ const { handleAxiosErrorStatusCodes } = useCommonApi();
 const showLoginDialog = ref(false);
 
 function onLoginCallback() {
+  // Unlock route to prevent ExitRoutePrompt from showing
+  // The user already saw "Your draft will be restored" in the login dialog
+  routeGuardRef.value?.unlockRoute();
   createNewConversationIntention();
 }
 

--- a/services/agora/src/stores/loginIntention.ts
+++ b/services/agora/src/stores/loginIntention.ts
@@ -3,11 +3,13 @@ import { ref } from "vue";
 import { useRouter } from "vue-router";
 import { useOnboardingPreferencesStore } from "./onboarding/preferences";
 import { onboardingFlowStore } from "./onboarding/flow";
+import type { EventSlug } from "src/shared/types/zod";
 
 interface VotingIntention {
   enabled: boolean;
   conversationSlugId: string;
   isEmbedView: boolean;
+  eventSlug?: EventSlug;
 }
 
 interface OpinionAgreementIntention {
@@ -15,6 +17,7 @@ interface OpinionAgreementIntention {
   conversationSlugId: string;
   opinionSlugId: string;
   isEmbedView: boolean;
+  eventSlug?: EventSlug;
 }
 
 interface NewConversationIntention {
@@ -25,6 +28,7 @@ interface NewOpinionIntention {
   enabled: boolean;
   conversationSlugId: string;
   opinionBody: string;
+  eventSlug?: EventSlug;
 }
 
 interface ReportUserContentIntention {
@@ -32,6 +36,7 @@ interface ReportUserContentIntention {
   conversationSlugId: string;
   opinionSlugId: string;
   isEmbedView: boolean;
+  eventSlug?: EventSlug;
 }
 
 export type PossibleIntentions =
@@ -54,6 +59,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
     enabled: false,
     conversationSlugId: "",
     isEmbedView: false,
+    eventSlug: undefined,
   };
 
   let opinionAgreementIntention: OpinionAgreementIntention = {
@@ -61,6 +67,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
     conversationSlugId: "",
     opinionSlugId: "",
     isEmbedView: false,
+    eventSlug: undefined,
   };
 
   let newConversationIntention: NewConversationIntention = {
@@ -71,6 +78,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
     enabled: false,
     conversationSlugId: "",
     opinionBody: "",
+    eventSlug: undefined,
   };
 
   let reportUserContentIntention: ReportUserContentIntention = {
@@ -78,29 +86,34 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
     conversationSlugId: "",
     opinionSlugId: "",
     isEmbedView: false,
+    eventSlug: undefined,
   };
 
   function createVotingIntention(
     conversationSlugId: string,
-    isEmbedView: boolean
+    isEmbedView: boolean,
+    eventSlug?: EventSlug
   ) {
     votingIntention = {
       enabled: true,
       conversationSlugId: conversationSlugId,
       isEmbedView: isEmbedView,
+      eventSlug: eventSlug,
     };
   }
 
   function createOpinionAgreementIntention(
     conversationSlugId: string,
     opinionSlugId: string,
-    isEmbedView: boolean
+    isEmbedView: boolean,
+    eventSlug?: EventSlug
   ) {
     opinionAgreementIntention = {
       enabled: true,
       conversationSlugId: conversationSlugId,
       opinionSlugId: opinionSlugId,
       isEmbedView: isEmbedView,
+      eventSlug: eventSlug,
     };
   }
 
@@ -112,25 +125,29 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
 
   function createNewOpinionIntention(
     conversationSlugId: string,
-    opinionBody: string
+    opinionBody: string,
+    eventSlug?: EventSlug
   ) {
     newOpinionIntention = {
       enabled: true,
       conversationSlugId: conversationSlugId,
       opinionBody: opinionBody,
+      eventSlug: eventSlug,
     };
   }
 
   function createReportUserContentIntention(
     conversationSlugId: string,
     opinionSlugId: string,
-    isEmbedView: boolean
+    isEmbedView: boolean,
+    eventSlug?: EventSlug
   ) {
     reportUserContentIntention = {
       enabled: true,
       conversationSlugId: conversationSlugId,
       opinionSlugId: opinionSlugId,
       isEmbedView: isEmbedView,
+      eventSlug: eventSlug,
     };
   }
 
@@ -237,6 +254,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
         enabled: false,
         conversationSlugId: "",
         opinionBody: "",
+        eventSlug: undefined,
       };
     }
   }
@@ -270,6 +288,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
         conversationSlugId: "",
         opinionSlugId: "",
         isEmbedView: false,
+        eventSlug: undefined,
       };
     }
   }
@@ -285,6 +304,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
         enabled: false,
         conversationSlugId: "",
         isEmbedView: false,
+        eventSlug: undefined,
       };
     }
   }
@@ -303,6 +323,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
         conversationSlugId: "",
         opinionSlugId: "",
         isEmbedView: false,
+        eventSlug: undefined,
       };
     }
   }


### PR DESCRIPTION
Implement intention dialogs that allow users to login or verify Zupass tickets inline when attempting to participate in gated conversations. This prevents users from losing their drafted content and provides a smoother UX by keeping them in context.

Changes:
- Add PreLoginIntentionDialog with Zupass inline verification support
- Create useTicketVerificationFlow composable to centralize verification logic
- Refactor EventTicketRequirementBanner to use shared verification flow
- Add transient ticket verification states to user store (verifying, error)
- Implement inline Zupass verification for comments, polls, and opinions
- Fix guest participation logic to only check isLoginRequired
- Restore critical POD statistics logging for debugging proof failures
- Unlock route when navigating to login to prevent duplicate draft prompts

The intention dialogs:
- Show when non-logged-in or non-verified users attempt gated actions
- Display appropriate messages based on login and Zupass requirements
- Support inline Zupass verification without navigation
- Preserve user drafts and restore them after authentication

Technical improvements:
- Centralized verification logic eliminates ~100 lines of duplication
- Discriminated union types for type-safe result handling
- Callback pattern for iframe-ready coordination
- Reactive store-based state management for verification status
- Deep error context for production debugging (POD stats, container info)

Deploy: agora