### PR TITLE
feat(api): make URL imports async with improved error handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,4 @@ dev-math-updater:
 	cd services/math-updater && pnpm start:dev
 
 dev-polis:
-	cd services/python-bridge && source .venv/bin/activate && gunicorn -c gunicorn.conf.py main:app
+	cd services/python-bridge && source .venv/bin/activate && make dev

--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -2276,13 +2276,13 @@ export interface ApiV1ConversationImportActiveGet200ResponseAnyOf1 {
 /**
  * 
  * @export
- * @interface ApiV1ConversationImportCsvPost200Response
+ * @interface ApiV1ConversationImportPost200Response
  */
-export interface ApiV1ConversationImportCsvPost200Response {
+export interface ApiV1ConversationImportPost200Response {
     /**
      * 
      * @type {string}
-     * @memberof ApiV1ConversationImportCsvPost200Response
+     * @memberof ApiV1ConversationImportPost200Response
      */
     'importSlugId': string;
 }
@@ -7462,7 +7462,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiV1ConversationImportCsvPost(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationImportCsvPost200Response>> {
+        async apiV1ConversationImportCsvPost(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationImportPost200Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ConversationImportCsvPost(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1ConversationImportCsvPost']?.[localVarOperationServerIndex]?.url;
@@ -7474,7 +7474,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiV1ConversationImportPost(apiV1ConversationImportPostRequest: ApiV1ConversationImportPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationCreatePost200Response>> {
+        async apiV1ConversationImportPost(apiV1ConversationImportPostRequest: ApiV1ConversationImportPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationImportPost200Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ConversationImportPost(apiV1ConversationImportPostRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1ConversationImportPost']?.[localVarOperationServerIndex]?.url;
@@ -8163,7 +8163,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1ConversationImportCsvPost(options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationImportCsvPost200Response> {
+        apiV1ConversationImportCsvPost(options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationImportPost200Response> {
             return localVarFp.apiV1ConversationImportCsvPost(options).then((request) => request(axios, basePath));
         },
         /**
@@ -8172,7 +8172,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1ConversationImportPost(apiV1ConversationImportPostRequest: ApiV1ConversationImportPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationCreatePost200Response> {
+        apiV1ConversationImportPost(apiV1ConversationImportPostRequest: ApiV1ConversationImportPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationImportPost200Response> {
             return localVarFp.apiV1ConversationImportPost(apiV1ConversationImportPostRequest, options).then((request) => request(axios, basePath));
         },
         /**

--- a/services/agora/src/components/conversation/import/ImportStatusView.i18n.ts
+++ b/services/agora/src/components/conversation/import/ImportStatusView.i18n.ts
@@ -29,7 +29,7 @@ export const importStatusViewTranslations: Record<
     status_completed: "Completed",
     status_failed: "Failed",
     processingMessage:
-      "Your import is being processed. This may take a few moments...",
+      "Your import is being processed. This may take a few seconds to a few minutes depending on the size of your import.",
     completedMessage: "Your import has completed successfully!",
     failedMessage: "Import failed. Please try again or contact support.",
     viewConversation: "View Conversation",
@@ -43,7 +43,8 @@ export const importStatusViewTranslations: Record<
     status_processing: "قيد المعالجة",
     status_completed: "مكتمل",
     status_failed: "فشل",
-    processingMessage: "جاري معالجة الاستيراد. قد يستغرق ذلك بعض الوقت...",
+    processingMessage:
+      "جاري معالجة الاستيراد. قد يستغرق ذلك من بضع ثوانٍ إلى بضع دقائق حسب حجم الاستيراد.",
     completedMessage: "اكتمل الاستيراد بنجاح!",
     failedMessage: "فشل الاستيراد. يرجى المحاولة مرة أخرى أو الاتصال بالدعم.",
     viewConversation: "عرض المحادثة",
@@ -58,7 +59,7 @@ export const importStatusViewTranslations: Record<
     status_completed: "Completado",
     status_failed: "Fallido",
     processingMessage:
-      "Su importación se está procesando. Esto puede tomar unos momentos...",
+      "Su importación se está procesando. Esto puede tomar desde unos segundos hasta varios minutos dependiendo del tamaño de su importación.",
     completedMessage: "¡Su importación se completó exitosamente!",
     failedMessage:
       "La importación falló. Intente nuevamente o contacte con soporte.",
@@ -74,7 +75,7 @@ export const importStatusViewTranslations: Record<
     status_completed: "Terminé",
     status_failed: "Échoué",
     processingMessage:
-      "Votre importation est en cours de traitement. Cela peut prendre quelques instants...",
+      "Votre import est en cours de traitement. Cela peut prendre de quelques secondes à quelques minutes selon la taille de votre import.",
     completedMessage: "Votre importation s'est terminée avec succès !",
     failedMessage:
       "L'importation a échoué. Veuillez réessayer ou contacter le support.",
@@ -89,7 +90,8 @@ export const importStatusViewTranslations: Record<
     status_processing: "处理中",
     status_completed: "已完成",
     status_failed: "失败",
-    processingMessage: "您的导入正在处理中。这可能需要一些时间...",
+    processingMessage:
+      "您的导入正在处理中。根据导入大小，这可能需要几秒到几分钟的时间。",
     completedMessage: "您的导入已成功完成！",
     failedMessage: "导入失败。请重试或联系支持。",
     viewConversation: "查看对话",
@@ -103,7 +105,8 @@ export const importStatusViewTranslations: Record<
     status_processing: "處理中",
     status_completed: "已完成",
     status_failed: "失敗",
-    processingMessage: "您的匯入正在處理中。這可能需要一些時間...",
+    processingMessage:
+      "您的匯入正在處理中。根據匯入大小，這可能需要幾秒到幾分鐘的時間。",
     completedMessage: "您的匯入已成功完成！",
     failedMessage: "匯入失敗。請重試或聯絡支援。",
     viewConversation: "查看對話",
@@ -117,7 +120,8 @@ export const importStatusViewTranslations: Record<
     status_processing: "処理中",
     status_completed: "完了",
     status_failed: "失敗",
-    processingMessage: "インポートを処理中です。しばらくお待ちください...",
+    processingMessage:
+      "インポートを処理中です。インポートのサイズによって、数秒から数分かかる場合があります。",
     completedMessage: "インポートが正常に完了しました！",
     failedMessage:
       "インポートに失敗しました。再試行するか、サポートにお問い合わせください。",

--- a/services/agora/src/pages/conversation/new/create/index.vue
+++ b/services/agora/src/pages/conversation/new/create/index.vue
@@ -9,16 +9,15 @@
         button-type="largeButton"
         color="primary"
         :label="
-          conversationDraft.importSettings.importType !== null
+          isSubmitButtonLoading
             ? t('importButton')
-            : t('nextButton')
+            : conversationDraft.importSettings.importType !== null
+              ? t('importButton')
+              : t('nextButton')
         "
         size="0.8rem"
         :loading="isSubmitButtonLoading"
-        :disabled="
-          hasActiveImport &&
-          conversationDraft.importSettings.importType === 'csv-import'
-        "
+        :disabled="isSubmitButtonLoading || hasActiveImport"
         @click="onSubmit()"
       />
     </TopMenuWrapper>
@@ -388,9 +387,10 @@ async function handleImportSubmission(): Promise<void> {
 
     if (response.status === "success") {
       conversationDraft.value = createEmptyDraft();
+      // URL import is now async - redirect to import status page to poll for completion
       await router.replace({
-        name: "/conversation/[postSlugId]",
-        params: { postSlugId: response.data.conversationSlugId },
+        name: "/conversation/import/[importSlugId]",
+        params: { importSlugId: response.data.importSlugId },
       });
     } else {
       handleAxiosErrorStatusCodes({

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -194,7 +194,7 @@ export class Dto {
         .strict();
     static importConversationResponse = z
         .object({
-            conversationSlugId: z.string(),
+            importSlugId: z.string(),
         })
         .strict();
     static importCsvConversationRequest = z

--- a/services/agora/src/utils/api/post/post.ts
+++ b/services/agora/src/utils/api/post/post.ts
@@ -3,6 +3,7 @@ import { buildAuthorizationHeader } from "../../crypto/ucan/operation";
 import type {
   ApiV1ConversationFetchRecentPost200ResponseConversationDataListInner,
   ApiV1ConversationCreatePost200Response,
+  ApiV1ConversationImportPost200Response,
   ApiV1ConversationImportPostRequest,
 } from "src/api";
 import type { ImportCsvConversationResponse } from "src/shared/types/dto";
@@ -200,7 +201,7 @@ export function useBackendPostApi() {
   }
 
   type ImportConversationSuccessResponse =
-    AxiosSuccessResponse<ApiV1ConversationCreatePost200Response>;
+    AxiosSuccessResponse<ApiV1ConversationImportPost200Response>;
   type ImportConversationResponse =
     | ImportConversationSuccessResponse
     | AxiosErrorResponse;

--- a/services/api/database/flyway/V0030__prevent_empty_conversation_title.sql
+++ b/services/api/database/flyway/V0030__prevent_empty_conversation_title.sql
@@ -1,0 +1,9 @@
+-- Fix any existing empty titles before adding the constraint
+UPDATE conversation_content
+SET title = '[No title] Imported conversation'
+WHERE title = '';
+
+-- Add CHECK constraint to prevent empty titles
+ALTER TABLE conversation_content
+ADD CONSTRAINT conversation_content_title_not_empty
+CHECK (length(trim(title)) > 0);

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -4781,12 +4781,12 @@
                                 "schema": {
                                     "type": "object",
                                     "properties": {
-                                        "conversationSlugId": {
+                                        "importSlugId": {
                                             "type": "string"
                                         }
                                     },
                                     "required": [
-                                        "conversationSlugId"
+                                        "importSlugId"
                                     ],
                                     "additionalProperties": false
                                 }

--- a/services/api/src/service/urlImport.ts
+++ b/services/api/src/service/urlImport.ts
@@ -1,0 +1,60 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import type { AxiosInstance } from "axios";
+import * as polisService from "./polis.js";
+import * as importService from "./import.js";
+import type { VoteBuffer } from "./voteBuffer.js";
+import type { EventSlug } from "@/shared/types/zod.js";
+
+interface ProcessUrlImportProps {
+    db: PostgresJsDatabase;
+    voteBuffer: VoteBuffer;
+    axiosPolis: AxiosInstance;
+    polisUrl: string;
+    proof: string;
+    didWrite: string;
+    authorId: string;
+    postAsOrganization: string | undefined;
+    indexConversationAt?: string;
+    isLoginRequired: boolean;
+    isIndexed: boolean;
+    requiresEventTicket?: EventSlug;
+}
+
+/**
+ * Process URL import - fetch from Polis API and import conversation
+ * Returns conversationId for status tracking
+ */
+export async function processUrlImport(
+    props: ProcessUrlImportProps,
+): Promise<{ conversationId: number }> {
+    // 1. Fetch conversation data from Polis API
+    const { importedPolisConversation, polisUrlType } =
+        await polisService.importExternalPolisConversation({
+            polisUrl: props.polisUrl,
+            axiosPolis: props.axiosPolis,
+        });
+
+    // 2. Load the conversation using shared import logic
+    const { conversationId } = await importService.loadImportedPolisConversation(
+        {
+            db: props.db,
+            voteBuffer: props.voteBuffer,
+            importedPolisConversation,
+            importConfig: {
+                method: "url",
+                polisUrl: props.polisUrl,
+                polisUrlType,
+            },
+            proof: props.proof,
+            didWrite: props.didWrite,
+            authorId: props.authorId,
+            postAsOrganization: props.postAsOrganization,
+            indexConversationAt: props.indexConversationAt,
+            isLoginRequired: props.isLoginRequired,
+            isIndexed: props.isIndexed,
+            requiresEventTicket: props.requiresEventTicket,
+        },
+    );
+
+    return { conversationId };
+}

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -194,7 +194,7 @@ export class Dto {
         .strict();
     static importConversationResponse = z
         .object({
-            conversationSlugId: z.string(),
+            importSlugId: z.string(),
         })
         .strict();
     static importCsvConversationRequest = z

--- a/services/load-testing/src/api/api.ts
+++ b/services/load-testing/src/api/api.ts
@@ -2276,13 +2276,13 @@ export interface ApiV1ConversationImportActiveGet200ResponseAnyOf1 {
 /**
  * 
  * @export
- * @interface ApiV1ConversationImportCsvPost200Response
+ * @interface ApiV1ConversationImportPost200Response
  */
-export interface ApiV1ConversationImportCsvPost200Response {
+export interface ApiV1ConversationImportPost200Response {
     /**
      * 
      * @type {string}
-     * @memberof ApiV1ConversationImportCsvPost200Response
+     * @memberof ApiV1ConversationImportPost200Response
      */
     'importSlugId': string;
 }
@@ -7462,7 +7462,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiV1ConversationImportCsvPost(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationImportCsvPost200Response>> {
+        async apiV1ConversationImportCsvPost(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationImportPost200Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ConversationImportCsvPost(options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1ConversationImportCsvPost']?.[localVarOperationServerIndex]?.url;
@@ -7474,7 +7474,7 @@ export const DefaultApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async apiV1ConversationImportPost(apiV1ConversationImportPostRequest: ApiV1ConversationImportPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationCreatePost200Response>> {
+        async apiV1ConversationImportPost(apiV1ConversationImportPostRequest: ApiV1ConversationImportPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ConversationImportPost200Response>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ConversationImportPost(apiV1ConversationImportPostRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1ConversationImportPost']?.[localVarOperationServerIndex]?.url;
@@ -8163,7 +8163,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1ConversationImportCsvPost(options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationImportCsvPost200Response> {
+        apiV1ConversationImportCsvPost(options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationImportPost200Response> {
             return localVarFp.apiV1ConversationImportCsvPost(options).then((request) => request(axios, basePath));
         },
         /**
@@ -8172,7 +8172,7 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        apiV1ConversationImportPost(apiV1ConversationImportPostRequest: ApiV1ConversationImportPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationCreatePost200Response> {
+        apiV1ConversationImportPost(apiV1ConversationImportPostRequest: ApiV1ConversationImportPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ConversationImportPost200Response> {
             return localVarFp.apiV1ConversationImportPost(apiV1ConversationImportPostRequest, options).then((request) => request(axios, basePath));
         },
         /**

--- a/services/load-testing/src/shared/types/dto.ts
+++ b/services/load-testing/src/shared/types/dto.ts
@@ -194,7 +194,7 @@ export class Dto {
         .strict();
     static importConversationResponse = z
         .object({
-            conversationSlugId: z.string(),
+            importSlugId: z.string(),
         })
         .strict();
     static importCsvConversationRequest = z

--- a/services/math-updater/src/jobs/scanConversations.ts
+++ b/services/math-updater/src/jobs/scanConversations.ts
@@ -66,6 +66,9 @@ export async function scanConversationsJob(
             )
             .where(
                 and(
+                    // Condition 0: Exclude conversations still being imported
+                    // These have isImporting=true until all data is inserted
+                    eq(conversationTable.isImporting, false),
                     // Condition 1: New data arrived since last math update
                     // (or never processed)
                     or(

--- a/services/math-updater/src/shared/types/dto.ts
+++ b/services/math-updater/src/shared/types/dto.ts
@@ -194,7 +194,7 @@ export class Dto {
         .strict();
     static importConversationResponse = z
         .object({
-            conversationSlugId: z.string(),
+            importSlugId: z.string(),
         })
         .strict();
     static importCsvConversationRequest = z

--- a/services/python-bridge/Makefile
+++ b/services/python-bridge/Makefile
@@ -4,7 +4,7 @@ all: dev
 dev-simple:
 	flask --app main run
 
-# Run with Gunicorn (multi-worker, production-like, handles concurrent requests)
+# Run with Gunicorn (multi-worker, production-like, handles concurrent requests) -- caution on macOS doesnt' work
 dev:
 	gunicorn -c gunicorn.conf.py main:app
 image-buildx:

--- a/services/python-bridge/gunicorn.conf.py
+++ b/services/python-bridge/gunicorn.conf.py
@@ -5,6 +5,7 @@ Enables concurrent request handling with multiple worker processes
 
 import multiprocessing
 import os
+import platform
 
 # Bind to all interfaces on port 5001
 bind = "0.0.0.0:5001"
@@ -52,7 +53,8 @@ max_requests_jitter = 50
 
 # Pre-load the application in the master process
 # This shares memory between workers (reduces memory footprint)
-preload_app = True
+# Disabled on macOS due to fork() + Objective-C runtime conflict (SIGKILL on worker spawn)
+preload_app = platform.system() != "Darwin"
 
 # Number of pending connections (queued when all workers busy)
 # Set to 2048 (Gunicorn default), but actual limit depends on system's net.core.somaxconn:

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -193,7 +193,7 @@ export class Dto {
         .strict();
     static importConversationResponse = z
         .object({
-            conversationSlugId: z.string(),
+            importSlugId: z.string(),
         })
         .strict();
     static importCsvConversationRequest = z


### PR DESCRIPTION
URL imports now use the same async queue mechanism as CSV imports, providing consistent behavior and better user experience with progress tracking via SSE notifications.

Changes:
- Add urlImport.ts service for URL import processing
- Integrate URL imports into ImportBuffer with discriminated union types
- Make both import types set isImporting=true until complete
- Add fallback title "[No title] Imported conversation" for empty Polis topics
- Add DB CHECK constraint to prevent empty conversation titles
- Soft-delete imported users on import failure (via joins, not username pattern)
- Filter out importing conversations from user profile posts
- Update DTOs to return importSlugId instead of conversationSlugId
- Fix gunicorn config and python-bridge Makefile

The import error cleanup now properly soft-deletes both the conversation and all imported users who participated (via opinions or votes), using database joins rather than relying on username conventions.

Deploy: api, agora, python-bridge