### PR TITLE
feat(agora): add frontend config for conversation export toggle

### DIFF
--- a/services/agora/env.example
+++ b/services/agora/env.example
@@ -20,3 +20,4 @@ VITE_IS_ORG_IMPORT_ONLY="false"
 # Optional variables
 # VITE_DEV_AUTHORIZED_PHONES="+33612345678,+12345678910"  # Dev/staging only - must not be in production
 # VITE_DISCORD_LINK="https://discord.gg/example"  # Discord invite link for support
+# VITE_CONVERSATION_EXPORT_ENABLED="true"  # Enable/disable conversation export feature (must match backend)

--- a/services/agora/src/pages/conversation/[conversationSlugId]/export.[exportId].i18n.ts
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/export.[exportId].i18n.ts
@@ -2,6 +2,7 @@ import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
 
 export interface ExportStatusPageTranslations {
   pageTitle: string;
+  exportFeatureDisabled: string;
 }
 
 export const exportStatusPageTranslations: Record<
@@ -10,23 +11,30 @@ export const exportStatusPageTranslations: Record<
 > = {
   en: {
     pageTitle: "Export Status",
+    exportFeatureDisabled: "Export feature is disabled",
   },
   ar: {
     pageTitle: "حالة التصدير",
+    exportFeatureDisabled: "ميزة التصدير معطلة",
   },
   es: {
     pageTitle: "Estado de Exportación",
+    exportFeatureDisabled: "La función de exportación está deshabilitada",
   },
   fr: {
     pageTitle: "État de l'Exportation",
+    exportFeatureDisabled: "La fonction d'exportation est désactivée",
   },
   "zh-Hans": {
     pageTitle: "导出状态",
+    exportFeatureDisabled: "导出功能已禁用",
   },
   "zh-Hant": {
     pageTitle: "匯出狀態",
+    exportFeatureDisabled: "匯出功能已停用",
   },
   ja: {
     pageTitle: "エクスポートステータス",
+    exportFeatureDisabled: "エクスポート機能は無効です",
   },
 };

--- a/services/agora/src/pages/conversation/[conversationSlugId]/export.[exportId].vue
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/export.[exportId].vue
@@ -22,7 +22,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { StandardMenuBar } from "src/components/navigation/header/variants";
 import WidthWrapper from "src/components/navigation/WidthWrapper.vue";
 import DrawerLayout from "src/layouts/DrawerLayout.vue";
@@ -32,12 +32,25 @@ import {
   exportStatusPageTranslations,
   type ExportStatusPageTranslations,
 } from "./export.[exportId].i18n";
+import { useNotify } from "src/utils/ui/notify";
+import { processEnv } from "src/utils/processEnv";
 
 const { t } = useComponentI18n<ExportStatusPageTranslations>(
   exportStatusPageTranslations
 );
+const router = useRouter();
+const { showNotifyMessage } = useNotify();
 
 const route = useRoute("/conversation/[conversationSlugId]/export.[exportId]");
+
+const conversationSlugId = computed(() => {
+  const value = route.params.conversationSlugId;
+  if (Array.isArray(value)) {
+    return value[0] || "";
+  }
+  return value || "";
+});
+
 const exportSlugId = computed(() => {
   const value = route.params.exportId;
   if (Array.isArray(value)) {
@@ -45,6 +58,15 @@ const exportSlugId = computed(() => {
   }
   return value || "";
 });
+
+// Redirect if export feature is disabled
+if (processEnv.VITE_CONVERSATION_EXPORT_ENABLED === "false") {
+  showNotifyMessage(t("exportFeatureDisabled"));
+  void router.replace({
+    name: "/conversation/[postSlugId]",
+    params: { postSlugId: conversationSlugId.value },
+  });
+}
 </script>
 
 <style scoped lang="scss">

--- a/services/agora/src/pages/conversation/[conversationSlugId]/export.i18n.ts
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/export.i18n.ts
@@ -14,6 +14,7 @@ export interface ExportPageTranslations {
   errorActiveExportInProgress: string;
   errorConversationNotFound: string;
   errorNoOpinions: string;
+  exportFeatureDisabled: string;
 }
 
 export const exportPageTranslations: Record<
@@ -39,6 +40,7 @@ export const exportPageTranslations: Record<
     errorConversationNotFound: "Conversation not found.",
     errorNoOpinions:
       "This conversation has no opinions to export. Add some opinions first.",
+    exportFeatureDisabled: "Export feature is disabled",
   },
   ar: {
     pageTitle: "تصدير المحادثة",
@@ -57,6 +59,7 @@ export const exportPageTranslations: Record<
     errorConversationNotFound: "المحادثة غير موجودة.",
     errorNoOpinions:
       "لا توجد آراء في هذه المحادثة للتصدير. أضف بعض الآراء أولاً.",
+    exportFeatureDisabled: "ميزة التصدير معطلة",
   },
   es: {
     pageTitle: "Exportar Conversación",
@@ -78,6 +81,7 @@ export const exportPageTranslations: Record<
     errorConversationNotFound: "Conversación no encontrada.",
     errorNoOpinions:
       "Esta conversación no tiene opiniones para exportar. Añade algunas opiniones primero.",
+    exportFeatureDisabled: "La función de exportación está deshabilitada",
   },
   fr: {
     pageTitle: "Exporter la Conversation",
@@ -100,6 +104,7 @@ export const exportPageTranslations: Record<
     errorConversationNotFound: "Conversation introuvable.",
     errorNoOpinions:
       "Cette conversation n'a pas d'opinions à exporter. Ajoutez d'abord quelques opinions.",
+    exportFeatureDisabled: "La fonction d'exportation est désactivée",
   },
   "zh-Hans": {
     pageTitle: "导出对话",
@@ -115,6 +120,7 @@ export const exportPageTranslations: Record<
     errorActiveExportInProgress: "导出正在进行中。请等待完成。",
     errorConversationNotFound: "未找到对话。",
     errorNoOpinions: "此对话没有可导出的意见。请先添加一些意见。",
+    exportFeatureDisabled: "导出功能已禁用",
   },
   "zh-Hant": {
     pageTitle: "匯出對話",
@@ -130,6 +136,7 @@ export const exportPageTranslations: Record<
     errorActiveExportInProgress: "匯出正在進行中。請等待完成。",
     errorConversationNotFound: "未找到對話。",
     errorNoOpinions: "此對話沒有可匯出的意見。請先新增一些意見。",
+    exportFeatureDisabled: "匯出功能已停用",
   },
   ja: {
     pageTitle: "会話をエクスポート",
@@ -151,5 +158,6 @@ export const exportPageTranslations: Record<
     errorConversationNotFound: "会話が見つかりません。",
     errorNoOpinions:
       "この会話にはエクスポートする意見がありません。まず意見を追加してください。",
+    exportFeatureDisabled: "エクスポート機能は無効です",
   },
 };

--- a/services/agora/src/pages/conversation/[conversationSlugId]/export.vue
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/export.vue
@@ -112,6 +112,7 @@ import {
 } from "./export.i18n";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useNotify } from "src/utils/ui/notify";
+import { processEnv } from "src/utils/processEnv";
 
 const { t } = useComponentI18n<ExportPageTranslations>(exportPageTranslations);
 const router = useRouter();
@@ -128,6 +129,15 @@ const conversationSlugId = computed(() => {
   }
   return value || "";
 });
+
+// Redirect if export feature is disabled
+if (processEnv.VITE_CONVERSATION_EXPORT_ENABLED === "false") {
+  showNotifyMessage(t("exportFeatureDisabled"));
+  void router.replace({
+    name: "/conversation/[postSlugId]",
+    params: { postSlugId: conversationSlugId.value },
+  });
+}
 
 const conversationQuery = useConversationQuery({
   conversationSlugId: conversationSlugId,

--- a/services/agora/src/utils/actions/definitions/posts.ts
+++ b/services/agora/src/utils/actions/definitions/posts.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ContentAction, ContentActionContext } from "../core/types";
+import { processEnv } from "src/utils/processEnv";
 
 /**
  * Translation keys for post actions
@@ -97,7 +98,9 @@ export function getPostActions(
       icon: "mdi-download",
       handler: exportConversationCallback,
       isVisible: (context: ContentActionContext) =>
-        context.isLoggedIn && !context.isEmbeddedMode,
+        context.isLoggedIn &&
+        !context.isEmbeddedMode &&
+        processEnv.VITE_CONVERSATION_EXPORT_ENABLED === "true",
     },
   ];
 }

--- a/services/agora/src/utils/processEnv.ts
+++ b/services/agora/src/utils/processEnv.ts
@@ -21,6 +21,9 @@ export const envSchema = z.object({
   NODE_ENV: z.string(), // Node environment: "development" | "production"
   VITE_API_BASE_URL: z.string(), // Backend API endpoint (e.g., "http://localhost:8084")
   VITE_BACK_DID: z.string(), // Backend DID, must match backend config (e.g., "did:web:localhost%3A8084")
+  // Note: We use z.enum instead of transform because import.meta.env contains raw strings at runtime.
+  // The processEnv object is just a type cast of import.meta.env, so transforms don't run at runtime.
+  // Compare with string "true"/"false" when using this value.
   VITE_IS_ORG_IMPORT_ONLY: z.enum(["true", "false"]), // If "true", only organizations can import conversations
 
   // Optional environment variables
@@ -30,6 +33,10 @@ export const envSchema = z.object({
   VITE_DEV_AUTHORIZED_PHONES: z.string().optional(), // Comma-separated list of phone numbers for dev/staging testing (must match backend). Must not be set in production (safety check enforced)
   VITE_SENTRY_AUTH_TOKEN: z.string().optional(), // Sentry auth token for production builds
   VITE_DISCORD_LINK: z.string().optional(), // Discord invite link for support
+  // Note: We use z.enum instead of transform because import.meta.env contains raw strings at runtime.
+  // The processEnv object is just a type cast of import.meta.env, so transforms don't run at runtime.
+  // Compare with string "true"/"false" when using this value.
+  VITE_CONVERSATION_EXPORT_ENABLED: z.enum(["true", "false"]).default("true"), // Enable/disable conversation export feature (must match backend)
 });
 
 export type ProcessEnv = z.infer<typeof envSchema>;
@@ -93,6 +100,6 @@ export function validateEnv(
  * Note: In Node.js build context (quasar.config.ts), import.meta.env doesn't exist.
  * The actual values are only needed at browser runtime, not during config evaluation.
  */
-export const processEnv = (typeof import.meta !== 'undefined' && import.meta.env
-  ? import.meta.env
-  : {}) as ProcessEnv;
+export const processEnv = (
+  typeof import.meta !== "undefined" && import.meta.env ? import.meta.env : {}
+) as ProcessEnv;

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -108,7 +108,7 @@ const configSchema = sharedConfigSchema.extend({
                 return false;
             } else {
                 ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
+                    code: "custom",
                     message: "Value must be true or false",
                 });
                 return z.NEVER;
@@ -128,7 +128,7 @@ const configSchema = sharedConfigSchema.extend({
                 return false;
             } else {
                 ctx.addIssue({
-                    code: z.ZodIssueCode.custom,
+                    code: "custom",
                     message: "Value must be true or false",
                 });
                 return z.NEVER;


### PR DESCRIPTION
Add VITE_CONVERSATION_EXPORT_ENABLED env variable to control the conversation export feature from the frontend, mirroring the backend's CONVERSATION_EXPORT_ENABLED setting.

Changes:
- Add VITE_CONVERSATION_EXPORT_ENABLED to processEnv.ts with z.enum validation and "true" default
- Hide "Export conversation" action button when feature is disabled
- Redirect export pages to conversation page with notification when feature is disabled
- Add exportFeatureDisabled i18n translations for all supported languages (en, ar, es, fr, zh-Hans, zh-Hant, ja)
- Update backend app.ts to use string literal "custom" instead of deprecated z.ZodIssueCode.custom for Zod v4 compatibility
- Add explanatory comments about why z.enum is used instead of transform (import.meta.env contains raw strings at runtime)

Deploy: agora, api