### PR TITLE
refactor(api,agora): rename EXPORT config vars to EXPORT_CONVOS prefix

### DIFF
--- a/services/agora/env.example
+++ b/services/agora/env.example
@@ -20,4 +20,4 @@ VITE_IS_ORG_IMPORT_ONLY="false"
 # Optional variables
 # VITE_DEV_AUTHORIZED_PHONES="+33612345678,+12345678910"  # Dev/staging only - must not be in production
 # VITE_DISCORD_LINK="https://discord.gg/example"  # Discord invite link for support
-# VITE_CONVERSATION_EXPORT_ENABLED="true"  # Enable/disable conversation export feature (must match backend)
+# VITE_EXPORT_CONVOS_ENABLED="true"  # Enable/disable conversation export feature (must match backend)

--- a/services/agora/src/utils/actions/definitions/posts.ts
+++ b/services/agora/src/utils/actions/definitions/posts.ts
@@ -101,7 +101,7 @@ export function getPostActions(
       isVisible: (context: ContentActionContext) =>
         context.isLoggedIn &&
         !context.isEmbeddedMode &&
-        processEnv.VITE_CONVERSATION_EXPORT_ENABLED === "true",
+        processEnv.VITE_EXPORT_CONVOS_ENABLED === "true",
     },
   ];
 }

--- a/services/agora/src/utils/processEnv.ts
+++ b/services/agora/src/utils/processEnv.ts
@@ -36,7 +36,7 @@ export const envSchema = z.object({
   // Note: We use z.enum instead of transform because import.meta.env contains raw strings at runtime.
   // The processEnv object is just a type cast of import.meta.env, so transforms don't run at runtime.
   // Compare with string "true"/"false" when using this value.
-  VITE_CONVERSATION_EXPORT_ENABLED: z.enum(["true", "false"]).default("true"), // Enable/disable conversation export feature (must match backend)
+  VITE_EXPORT_CONVOS_ENABLED: z.enum(["true", "false"]).default("true"), // Enable/disable conversation export feature (must match backend)
 });
 
 export type ProcessEnv = z.infer<typeof envSchema>;

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -85,14 +85,14 @@ The API provides a conversation export feature that allows users to download con
 
 ```bash
 # S3 bucket configuration
-AWS_S3_REGION=us-east-1                                    # AWS region for S3 bucket
-AWS_S3_BUCKET_NAME=agora-conversation-exports              # S3 bucket name
+EXPORT_CONVOS_AWS_S3_REGION=us-east-1                      # AWS region for S3 bucket
+EXPORT_CONVOS_AWS_S3_BUCKET_NAME=agora-conversation-exports # S3 bucket name
 
 # Optional configuration (with defaults)
-CONVERSATION_EXPORT_EXPIRY_DAYS=30                         # Days until exports auto-delete (default: 30)
-CONVERSATION_EXPORT_COOLDOWN_SECONDS=300                   # Cooldown between exports for same conversation (default: 300s/5min)
-S3_PRESIGNED_URL_EXPIRY_SECONDS=3600                       # Presigned URL validity (default: 3600s/1 hour)
-CONVERSATION_EXPORT_ENABLED=true                           # Enable/disable export feature (default: true)
+EXPORT_CONVOS_EXPIRY_DAYS=30                               # Days until exports auto-delete (default: 30)
+EXPORT_CONVOS_COOLDOWN_SECONDS=300                         # Cooldown between exports for same conversation (default: 300s/5min)
+EXPORT_CONVOS_S3_PRESIGNED_URL_EXPIRY_SECONDS=3600         # Presigned URL validity (default: 3600s/1 hour)
+EXPORT_CONVOS_ENABLED=true                                 # Enable/disable export feature (default: true)
 
 # Optional: Valkey for export queue persistence across instances
 VALKEY_URL=redis://localhost:6379                          # If not set, uses in-memory storage (lost on restart)
@@ -168,7 +168,7 @@ aws s3api put-public-access-block --bucket agora-conversation-exports \
   --public-access-block-configuration \
   "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
 
-# Set lifecycle policy (auto-delete after 30 days - should match CONVERSATION_EXPORT_EXPIRY_DAYS)
+# Set lifecycle policy (auto-delete after 30 days - should match EXPORT_CONVOS_EXPIRY_DAYS)
 aws s3api put-bucket-lifecycle-configuration --bucket agora-conversation-exports \
   --lifecycle-configuration '{
     "Rules": [{
@@ -196,7 +196,7 @@ aws s3api put-bucket-lifecycle-configuration --bucket agora-conversation-exports
 To disable the CSV export feature entirely:
 
 ```bash
-CONVERSATION_EXPORT_ENABLED=false
+EXPORT_CONVOS_ENABLED=false
 ```
 
 When disabled, export API endpoints will return 404 Not Found.

--- a/services/api/env.example
+++ b/services/api/env.example
@@ -21,14 +21,14 @@ PORT=8084
 SERVER_DID_DEV=did:web:localhost%3A8084
 
 # S3 configuration for conversation CSV exports
-AWS_S3_REGION="us-east-1"
-AWS_S3_BUCKET_NAME="your-bucket-name"
-CONVERSATION_EXPORT_EXPIRY_DAYS=30
-CONVERSATION_EXPORT_COOLDOWN_SECONDS=300
-S3_PRESIGNED_URL_EXPIRY_SECONDS=3600
+EXPORT_CONVOS_AWS_S3_REGION="us-east-1"
+EXPORT_CONVOS_AWS_S3_BUCKET_NAME="your-bucket-name"
+EXPORT_CONVOS_EXPIRY_DAYS=30
+EXPORT_CONVOS_COOLDOWN_SECONDS=300
+EXPORT_CONVOS_S3_PRESIGNED_URL_EXPIRY_SECONDS=3600
 
 # Conversation export feature toggle
-CONVERSATION_EXPORT_ENABLED=true
+EXPORT_CONVOS_ENABLED=true
 
 # Import restriction configuration
 # If true, only organization accounts can import conversations (Polis URL & CSV)

--- a/services/api/src/app.ts
+++ b/services/api/src/app.ts
@@ -86,20 +86,16 @@ const configSchema = sharedConfigSchema.extend({
             "1, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100000, 250000, 500000, 1000000, 2500000, 5000000, 10000000",
         ),
     // S3 configuration for conversation CSV exports
-    AWS_S3_REGION: z.string().optional(),
-    AWS_S3_BUCKET_NAME: z.string().optional(),
-    CONVERSATION_EXPORT_EXPIRY_DAYS: z.coerce.number().int().min(1).default(30), // Export file expiry
-    CONVERSATION_EXPORT_COOLDOWN_SECONDS: z.coerce
-        .number()
-        .int()
-        .min(0)
-        .default(300), // Cooldown between exports for same conversation (default: 5 minutes)
-    S3_PRESIGNED_URL_EXPIRY_SECONDS: z.coerce
+    EXPORT_CONVOS_AWS_S3_REGION: z.string().optional(),
+    EXPORT_CONVOS_AWS_S3_BUCKET_NAME: z.string().optional(),
+    EXPORT_CONVOS_EXPIRY_DAYS: z.coerce.number().int().min(1).default(30), // Export file expiry
+    EXPORT_CONVOS_COOLDOWN_SECONDS: z.coerce.number().int().min(0).default(300), // Cooldown between exports for same conversation (default: 5 minutes)
+    EXPORT_CONVOS_S3_PRESIGNED_URL_EXPIRY_SECONDS: z.coerce
         .number()
         .int()
         .min(60)
         .default(3600), // Presigned URL expiry (default: 1 hour)
-    CONVERSATION_EXPORT_ENABLED: z
+    EXPORT_CONVOS_ENABLED: z
         .string()
         .transform((value, ctx) => {
             if (value.toLowerCase().trim() === "true") {
@@ -115,10 +111,26 @@ const configSchema = sharedConfigSchema.extend({
             }
         })
         .default("true"),
-    EXPORT_BUFFER_MAX_BATCH_SIZE: z.coerce.number().int().min(1).default(100), // Max exports to take from queue per flush
-    EXPORT_BUFFER_MAX_CONCURRENCY: z.coerce.number().int().min(1).default(5), // Max exports to process in parallel (exports are I/O-bound: CSV generation + S3 upload)
-    EXPORT_BUFFER_STALE_THRESHOLD_MS: z.coerce.number().int().min(30000).default(300000), // 5 minutes - mark "processing" exports as failed after this
-    EXPORT_BUFFER_STALE_CLEANUP_EVERY_N_FLUSHES: z.coerce.number().int().min(1).default(60), // Run stale cleanup every N flushes (~1 minute at 1s flush)
+    EXPORT_CONVOS_BUFFER_MAX_BATCH_SIZE: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .default(100), // Max exports to take from queue per flush
+    EXPORT_CONVOS_BUFFER_MAX_CONCURRENCY: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .default(5), // Max exports to process in parallel (exports are I/O-bound: CSV generation + S3 upload)
+    EXPORT_CONVOS_BUFFER_STALE_THRESHOLD_MS: z.coerce
+        .number()
+        .int()
+        .min(30000)
+        .default(300000), // 5 minutes - mark "processing" exports as failed after this
+    EXPORT_CONVOS_BUFFER_STALE_CLEANUP_EVERY_N_FLUSHES: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .default(60), // Run stale cleanup every N flushes (~1 minute at 1s flush)
     IS_ORG_IMPORT_ONLY: z
         .string()
         .transform((value, ctx) => {
@@ -136,14 +148,38 @@ const configSchema = sharedConfigSchema.extend({
         })
         .default("false"),
     // CSV Import buffer configuration
-    IMPORT_BUFFER_MAX_BATCH_SIZE: z.coerce.number().int().nonnegative().default(4), // Max imports to take from queue per flush (0 = disable imports)
+    IMPORT_BUFFER_MAX_BATCH_SIZE: z.coerce
+        .number()
+        .int()
+        .nonnegative()
+        .default(4), // Max imports to take from queue per flush (0 = disable imports)
     IMPORT_BUFFER_MAX_CONCURRENCY: z.coerce.number().int().min(1).default(2), // Max imports to process in parallel
-    IMPORT_BUFFER_FLUSH_INTERVAL_MS: z.coerce.number().int().min(100).default(1000), // Flush interval in ms
-    IMPORT_BUFFER_STALE_THRESHOLD_MS: z.coerce.number().int().min(30000).default(300000), // 5 minutes - mark "processing" imports as failed after this
-    IMPORT_BUFFER_STALE_CLEANUP_EVERY_N_FLUSHES: z.coerce.number().int().min(1).default(60), // Run stale cleanup every N flushes (~1 minute at 1s flush)
+    IMPORT_BUFFER_FLUSH_INTERVAL_MS: z.coerce
+        .number()
+        .int()
+        .min(100)
+        .default(1000), // Flush interval in ms
+    IMPORT_BUFFER_STALE_THRESHOLD_MS: z.coerce
+        .number()
+        .int()
+        .min(30000)
+        .default(300000), // 5 minutes - mark "processing" imports as failed after this
+    IMPORT_BUFFER_STALE_CLEANUP_EVERY_N_FLUSHES: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .default(60), // Run stale cleanup every N flushes (~1 minute at 1s flush)
     // Vote buffer configuration (batches votes to reduce DB contention)
-    VOTE_BUFFER_FLUSH_INTERVAL_MS: z.coerce.number().int().min(100).default(1000), // Flush interval in ms
-    VOTE_BUFFER_VALKEY_BATCH_LIMIT: z.coerce.number().int().min(1).default(5000), // Max votes to fetch from Valkey per flush
+    VOTE_BUFFER_FLUSH_INTERVAL_MS: z.coerce
+        .number()
+        .int()
+        .min(100)
+        .default(1000), // Flush interval in ms
+    VOTE_BUFFER_VALKEY_BATCH_LIMIT: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .default(5000), // Max votes to fetch from Valkey per flush
 });
 
 export const config = configSchema.parse(process.env);

--- a/services/api/src/service/conversationExport/core.ts
+++ b/services/api/src/service/conversationExport/core.ts
@@ -149,7 +149,10 @@ export async function processConversationExport({
         const generators = factory.getAllGenerators();
 
         // Validate S3 configuration
-        if (!config.AWS_S3_BUCKET_NAME || !config.AWS_S3_REGION) {
+        if (
+            !config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME ||
+            !config.EXPORT_CONVOS_AWS_S3_REGION
+        ) {
             throw new Error("S3 configuration is missing");
         }
 
@@ -191,7 +194,7 @@ export async function processConversationExport({
                 await uploadToS3({
                     s3Key,
                     buffer: csvBuffer,
-                    bucketName: config.AWS_S3_BUCKET_NAME,
+                    bucketName: config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME,
                     fileName: downloadFileName,
                 });
 
@@ -233,7 +236,7 @@ export async function processConversationExport({
                 try {
                     await deleteFromS3({
                         s3Key,
-                        bucketName: config.AWS_S3_BUCKET_NAME,
+                        bucketName: config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME,
                     });
                     log.info(`Rolled back S3 file: ${s3Key}`);
                 } catch (deleteError: unknown) {
@@ -421,11 +424,11 @@ export async function getConversationExportStatus({
     let filesWithUrls: ExportFileInfo[] | undefined = undefined;
 
     if (fileRecords.length > 0) {
-        if (!config.AWS_S3_BUCKET_NAME) {
+        if (!config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME) {
             throw new Error("S3 configuration is missing");
         }
 
-        const bucketName = config.AWS_S3_BUCKET_NAME;
+        const bucketName = config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME;
 
         filesWithUrls = await Promise.all(
             fileRecords.map(async (file) => {
@@ -433,7 +436,8 @@ export async function getConversationExportStatus({
                 const { url, expiresAt } = await generatePresignedUrl({
                     s3Key: file.s3Key,
                     bucketName,
-                    expiresIn: config.S3_PRESIGNED_URL_EXPIRY_SECONDS,
+                    expiresIn:
+                        config.EXPORT_CONVOS_S3_PRESIGNED_URL_EXPIRY_SECONDS,
                 });
 
                 return {
@@ -657,10 +661,10 @@ export async function deleteConversationExport({
 
         // Delete from S3
         for (const file of fileRecords) {
-            if (file.s3Key && config.AWS_S3_BUCKET_NAME) {
+            if (file.s3Key && config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME) {
                 await deleteFromS3({
                     s3Key: file.s3Key,
-                    bucketName: config.AWS_S3_BUCKET_NAME,
+                    bucketName: config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME,
                 });
             }
         }
@@ -829,10 +833,10 @@ export async function cleanupExpiredExports({
 
             // Delete from S3
             for (const file of fileRecords) {
-                if (file.s3Key && config.AWS_S3_BUCKET_NAME) {
+                if (file.s3Key && config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME) {
                     await deleteFromS3({
                         s3Key: file.s3Key,
-                        bucketName: config.AWS_S3_BUCKET_NAME,
+                        bucketName: config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME,
                     });
                 }
             }
@@ -921,11 +925,12 @@ export async function deleteAllConversationExports({
 
                 // Delete from S3
                 for (const file of fileRecords) {
-                    if (file.s3Key && config.AWS_S3_BUCKET_NAME) {
+                    if (file.s3Key && config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME) {
                         try {
                             await deleteFromS3({
                                 s3Key: file.s3Key,
-                                bucketName: config.AWS_S3_BUCKET_NAME,
+                                bucketName:
+                                    config.EXPORT_CONVOS_AWS_S3_BUCKET_NAME,
                             });
                         } catch (s3Error: unknown) {
                             log.error(

--- a/services/api/src/service/s3.ts
+++ b/services/api/src/service/s3.ts
@@ -11,7 +11,7 @@ import { config, log } from "@/app.js";
 // Initialize S3 client following the same pattern as SecretsManagerClient in index.ts
 // Credentials are automatically loaded from IAM role or environment variables
 export const s3Client = new S3Client({
-    region: config.AWS_S3_REGION,
+    region: config.EXPORT_CONVOS_AWS_S3_REGION,
 });
 
 /**


### PR DESCRIPTION
Standardize environment variable naming for conversation export feature to use consistent EXPORT_CONVOS_ prefix, making it clearer these are specifically for conversation exports (vs future export features).

Renames:
- AWS_S3_REGION -> EXPORT_CONVOS_AWS_S3_REGION
- AWS_S3_BUCKET_NAME -> EXPORT_CONVOS_AWS_S3_BUCKET_NAME
- CONVERSATION_EXPORT_* -> EXPORT_CONVOS_*
- S3_PRESIGNED_URL_EXPIRY_SECONDS -> EXPORT_CONVOS_S3_PRESIGNED_URL_EXPIRY_SECONDS
- EXPORT_BUFFER_* -> EXPORT_CONVOS_BUFFER_*
- VITE_CONVERSATION_EXPORT_ENABLED -> VITE_EXPORT_CONVOS_ENABLED

Updated all usages in code, documentation, and env.example files.

Deploy: api, agora