### PR TITLE
fix(api): fix TS18048 undefined error in llmLabelSummary

### DIFF
--- a/services/api/src/service/llmLabelSummary.ts
+++ b/services/api/src/service/llmLabelSummary.ts
@@ -168,6 +168,11 @@ async function updateClustersLabelsAndSummaries({
         aiClustersLabelsAndSummaries,
     ) as (keyof typeof aiClustersLabelsAndSummaries)[] /* necessary otherwise the fine-grained type of `key` is lost */) {
         const aiClusterLabelAndSummary = aiClustersLabelsAndSummaries[key];
+        
+        if (!aiClusterLabelAndSummary) {
+            continue;
+        }
+
         // we use raw sql because update ... from with multiple join doesn't work properly in drizzle
         // WARN: this is not typesafe
         await db.execute(sql`


### PR DESCRIPTION
## Summary
Fixes a TypeScript build error (TS18048) in `src/service/llmLabelSummary.ts`.

## Description
When iterating over `aiClustersLabelsAndSummaries`, TypeScript correctly identifies that the object is a partial record, so accessing properties by key might return `undefined`. Although `Object.keys` at runtime ensures the key exists, the compiler requires a guard. This PR adds a check `if (!aiClusterLabelAndSummary) { continue; }` to satisfy the type checker.

## Changes
- Add null check for `aiClusterLabelAndSummary` in `updateClustersLabelsAndSummaries`

Deploy: api