### PR TITLE
Frontend optimizations

### DIFF
--- a/services/agora/package.json
+++ b/services/agora/package.json
@@ -66,6 +66,7 @@
     "inapp-spy": "^5.0.7",
     "libphonenumber-js": "^1.12.17",
     "linkify-html": "^4.3.2",
+    "localforage": "^1.10.0",
     "linkifyjs": "^4.3.2",
     "localforage": "^1.10.0",
     "maz-ui": "3.50.1",

--- a/services/agora/quasar.config.ts
+++ b/services/agora/quasar.config.ts
@@ -28,15 +28,7 @@ export default defineConfig((ctx) => {
     boot.push("sentry");
   }
   boot.push(
-    ...[
-      "polyfills",
-      "i18n",
-      "axios",
-      "primevue",
-      "maz-ui",
-      "vue-query",
-      "embeddedBrowserGuard",
-    ]
+    ...["i18n", "axios", "primevue", "vue-query", "embeddedBrowserGuard"]
   );
 
   if (process.env.NODE_ENV) {
@@ -147,111 +139,6 @@ export default defineConfig((ctx) => {
             })
           );
         }
-
-        // Configure manual chunks for better code splitting
-        if (!viteConf.build) {
-          viteConf.build = {};
-        }
-        if (!viteConf.build.rollupOptions) {
-          viteConf.build.rollupOptions = {};
-        }
-
-        // Ensure output is an object (not an array) and add manual chunks configuration
-        const outputOptions = Array.isArray(viteConf.build.rollupOptions.output)
-          ? viteConf.build.rollupOptions.output[0] || {}
-          : viteConf.build.rollupOptions.output || {};
-
-        outputOptions.manualChunks = (id: string) => {
-          // Core Vue ecosystem
-          if (
-            id.includes("node_modules/vue/") ||
-            id.includes("node_modules/@vue/") ||
-            id.includes("node_modules/vue-router/") ||
-            id.includes("node_modules/pinia/") ||
-            id.includes("node_modules/vue-i18n/")
-          ) {
-            return "vue-vendor";
-          }
-
-          // PrimeVue
-          if (
-            id.includes("node_modules/primevue/") ||
-            id.includes("node_modules/@primeuix/") ||
-            id.includes("node_modules/primeicons/")
-          ) {
-            return "primevue";
-          }
-
-          // Quasar
-          if (id.includes("node_modules/quasar/")) {
-            return "quasar";
-          }
-
-          // Sentry
-          if (id.includes("node_modules/@sentry/")) {
-            return "sentry";
-          }
-
-          // Tiptap (Editor)
-          if (
-            id.includes("node_modules/@tiptap/") ||
-            id.includes("node_modules/prosemirror-")
-          ) {
-            return "editor";
-          }
-
-          // Crypto & IPFS
-          if (
-            id.includes("node_modules/@ucans/") ||
-            id.includes("node_modules/cborg/") ||
-            id.includes("node_modules/multiformats/") ||
-            id.includes("node_modules/tweetnacl/") ||
-            id.includes("node_modules/uint8arrays/")
-          ) {
-            return "crypto";
-          }
-
-          // UI utilities
-          // if (id.includes("node_modules/@dicebear/")) {
-          //   return "ui-utils";
-          // }
-
-          // Data & API utilities
-          if (
-            id.includes("node_modules/@tanstack/vue-query") ||
-            id.includes("node_modules/axios/") ||
-            id.includes("node_modules/zod/")
-          ) {
-            return "data-utils";
-          }
-
-          // VueUse composables
-          if (id.includes("node_modules/@vueuse/")) {
-            return "vueuse";
-          }
-
-          // Text processing utilities
-          if (
-            id.includes("node_modules/linkifyjs/") ||
-            id.includes("node_modules/linkify-html/") ||
-            id.includes("node_modules/sanitize-html/")
-          ) {
-            return "text-utils";
-          }
-
-          // Phone number utilities
-          if (id.includes("node_modules/libphonenumber-js/")) {
-            return "phone-utils";
-          }
-
-          // QR code generation
-          if (id.includes("node_modules/qrcode/")) {
-            return "qrcode";
-          }
-        };
-
-        // Set the output back to the configuration
-        viteConf.build.rollupOptions.output = outputOptions;
 
         // viteConf.base = ""; // @see https://github.com/quasarframework/quasar/issues/8513#issuecomment-1127654470 - otherwise the browser doesn't find index.html!
       },

--- a/services/agora/src/boot/i18n.ts
+++ b/services/agora/src/boot/i18n.ts
@@ -1,12 +1,16 @@
-import messages from "src/i18n";
+// Import only English translations for initial load
+import en from "src/i18n/en";
+import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
 import { parseDisplayLanguage } from "src/shared/languages";
+import { nextTick } from "vue";
+import type { I18n } from "vue-i18n";
 import { createI18n } from "vue-i18n";
 
 import { defineBoot } from "#q-app/wrappers";
 
-export type MessageLanguages = keyof typeof messages;
-// Type-define 'en-US' as the master schema for the resource
-export type MessageSchema = (typeof messages)["en"];
+export type MessageLanguages = SupportedDisplayLanguageCodes;
+// Type-define 'en' as the master schema for the resource
+export type MessageSchema = typeof en;
 
 // See https://vue-i18n.intlify.dev/guide/advanced/typescript.html#global-resource-schema-type-definition
 /* eslint-disable @typescript-eslint/no-empty-object-type */
@@ -29,6 +33,78 @@ function detectBrowserLanguage(): MessageLanguages {
   return displayLanguage;
 }
 
+// Global i18n instance reference
+let i18nInstance: I18n<
+  { message: MessageSchema },
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  {},
+  MessageLanguages,
+  false
+> | null = null;
+
+/**
+ * Set the i18n language and update HTML lang attribute
+ */
+export function setI18nLanguage(locale: MessageLanguages): void {
+  if (!i18nInstance) return;
+
+  // @ts-expect-error: locale type issue with lazy loading
+  i18nInstance.global.locale.value = locale;
+
+  /**
+   * NOTE:
+   * If you need to specify the language setting for headers, such as the `fetch` API, set it here.
+   * The following is an example for axios.
+   *
+   * axios.defaults.headers.common['Accept-Language'] = locale
+   */
+  document.querySelector("html")?.setAttribute("lang", locale);
+}
+
+/**
+ * Load locale messages dynamically using dynamic imports
+ */
+export async function loadLocaleMessages(
+  locale: MessageLanguages
+): Promise<void> {
+  if (!i18nInstance) return;
+
+  // Check if already loaded
+  // @ts-expect-error: availableLocales type issue with lazy loading
+  if (i18nInstance.global.availableLocales.includes(locale)) {
+    return;
+  }
+
+  // Load locale messages with dynamic import for code splitting
+  const messages = await import(
+    /* webpackChunkName: "locale-[request]" */
+    /* vite-chunk-name: "locale-[request]" */
+    `../i18n/${locale}/index.ts`
+  );
+
+  // Set locale message
+  i18nInstance.global.setLocaleMessage(locale, messages.default);
+
+  return nextTick();
+}
+
+/**
+ * Get the i18n instance (for use in stores and composables)
+ */
+export function getI18nInstance(): I18n<
+  { message: MessageSchema },
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  {},
+  MessageLanguages,
+  false
+> | null {
+  return i18nInstance;
+}
+
 export default defineBoot(({ app }) => {
   // Get stored language preference or detect from browser
   const storedLocale = localStorage.getItem("displayLanguage");
@@ -41,12 +117,29 @@ export default defineBoot(({ app }) => {
     default: ["en"],
   };
 
+  // Create i18n instance with only English loaded initially
   const i18n = createI18n<{ message: MessageSchema }, MessageLanguages>({
     locale: defaultLocale,
     fallbackLocale,
     legacy: false,
-    messages,
+    // @ts-expect-error: Only English loaded initially, others loaded lazily
+    messages: {
+      en, // Only English is loaded initially
+    },
   });
+
+  // Store reference for helper functions
+  // @ts-expect-error: Type inference issue with lazy loading
+  i18nInstance = i18n;
+
+  // Load the initial locale if it's not English
+  if (defaultLocale !== "en") {
+    void loadLocaleMessages(defaultLocale).then(() => {
+      setI18nLanguage(defaultLocale);
+    });
+  } else {
+    setI18nLanguage(defaultLocale);
+  }
 
   // Set i18n instance on app
   app.use(i18n);

--- a/services/agora/src/boot/maz-ui.ts
+++ b/services/agora/src/boot/maz-ui.ts
@@ -1,1 +1,0 @@
-import "maz-ui/css/main.css";

--- a/services/agora/src/boot/primevue.ts
+++ b/services/agora/src/boot/primevue.ts
@@ -1,20 +1,6 @@
 import { definePreset } from "@primeuix/themes";
 import Aura from "@primeuix/themes/aura";
-import Button from "primevue/button";
-import Card from "primevue/card";
-import Chip from "primevue/chip";
 import PrimeVue from "primevue/config";
-import DatePicker from "primevue/datepicker";
-import Divider from "primevue/divider";
-import FileUpload from "primevue/fileupload";
-import IconField from "primevue/iconfield";
-import InputIcon from "primevue/inputicon";
-import InputOtp from "primevue/inputotp";
-import InputText from "primevue/inputtext";
-import Message from "primevue/message";
-import ProgressSpinner from "primevue/progressspinner";
-import Select from "primevue/select";
-import Tag from "primevue/tag";
 
 import { defineBoot } from "#q-app/wrappers";
 
@@ -71,19 +57,4 @@ export default defineBoot(({ app }) => {
       overlay: 2000,
     },
   });
-
-  app.component("PrimeButton", Button);
-  app.component("PrimeCard", Card);
-  app.component("PrimeChip", Chip);
-  app.component("PrimeDatePicker", DatePicker);
-  app.component("PrimeSelect", Select);
-  app.component("PrimeInputOtp", InputOtp);
-  app.component("PrimeInputText", InputText);
-  app.component("PrimeIconField", IconField);
-  app.component("PrimeInputIcon", InputIcon);
-  app.component("PrimeFileUpload", FileUpload);
-  app.component("PrimeProgressSpinner", ProgressSpinner);
-  app.component("PrimeMessage", Message);
-  app.component("PrimeTag", Tag);
-  app.component("PrimeDivider", Divider);
 });

--- a/services/agora/src/components/account/EmbedAccountWidget.vue
+++ b/services/agora/src/components/account/EmbedAccountWidget.vue
@@ -30,6 +30,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import Button from "primevue/button";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useUserStore } from "src/stores/user";
@@ -40,6 +41,12 @@ import {
   embedAccountWidgetTranslations,
 } from "./EmbedAccountWidget.i18n";
 import UserAvatar from "./UserAvatar.vue";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 const { t } = useComponentI18n<EmbedAccountWidgetTranslations>(
   embedAccountWidgetTranslations

--- a/services/agora/src/components/conversation/export/ExportStatusView.vue
+++ b/services/agora/src/components/conversation/export/ExportStatusView.vue
@@ -219,10 +219,26 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import Button from "primevue/button";
+import ProgressSpinner from "primevue/progressspinner";
 import { useQuasar } from "quasar";
 import AsyncStateHandler from "src/components/ui/AsyncStateHandler.vue";
 import ZKIcon from "src/components/ui-library/ZKIcon.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
+
+import {
+  type ExportStatusViewTranslations,
+  exportStatusViewTranslations,
+} from "./ExportStatusView.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+    PrimeProgressSpinner: ProgressSpinner,
+  },
+});
+
+const props = defineProps<Props>();
 import type { ExportFailureReason } from "src/shared/types/zod";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useUserStore } from "src/stores/user";
@@ -235,16 +251,9 @@ import { useNotify } from "src/utils/ui/notify";
 import { computed } from "vue";
 import { useRouter } from "vue-router";
 
-import {
-  type ExportStatusViewTranslations,
-  exportStatusViewTranslations,
-} from "./ExportStatusView.i18n";
-
 interface Props {
   exportSlugId: string;
 }
-
-const props = defineProps<Props>();
 
 const { t } = useComponentI18n<ExportStatusViewTranslations>(
   exportStatusViewTranslations

--- a/services/agora/src/components/conversation/export/RequestExportButton.vue
+++ b/services/agora/src/components/conversation/export/RequestExportButton.vue
@@ -10,6 +10,7 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 
 import {
@@ -17,9 +18,11 @@ import {
   requestExportButtonTranslations,
 } from "./RequestExportButton.i18n";
 
-interface Props {
-  disabled?: boolean;
-}
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 withDefaults(defineProps<Props>(), {
   disabled: false,
@@ -28,6 +31,10 @@ withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   request: [];
 }>();
+
+interface Props {
+  disabled?: boolean;
+}
 
 const { t } = useComponentI18n<RequestExportButtonTranslations>(
   requestExportButtonTranslations

--- a/services/agora/src/components/editor/Editor.vue
+++ b/services/agora/src/components/editor/Editor.vue
@@ -110,12 +110,19 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
 import { EditorContent, useEditor } from "@tiptap/vue-3";
 import { BubbleMenu } from "@tiptap/vue-3/menus";
+import Divider from "primevue/divider";
 import { useQuasar } from "quasar";
 import sanitizeHtml from "sanitize-html";
 import { htmlToCountedText } from "src/shared/shared";
 import { computed, onUnmounted, watch } from "vue";
 
 import EditorToolbarButton from "./EditorToolbarButton.vue";
+
+defineOptions({
+  components: {
+    PrimeDivider: Divider,
+  },
+});
 
 const props = defineProps<{
   showToolbar: boolean;

--- a/services/agora/src/components/editor/EditorToolbarButton.vue
+++ b/services/agora/src/components/editor/EditorToolbarButton.vue
@@ -22,12 +22,13 @@
 
 <script setup lang="ts">
 import { Icon } from "@iconify/vue";
+import Button from "primevue/button";
 
-interface Props {
-  icon: string;
-  isActive?: boolean;
-  disabled?: boolean;
-}
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 withDefaults(defineProps<Props>(), {
   isActive: false,
@@ -38,6 +39,12 @@ withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   click: [];
 }>();
+
+interface Props {
+  icon: string;
+  isActive?: boolean;
+  disabled?: boolean;
+}
 
 function handleClick() {
   emit("click");

--- a/services/agora/src/components/embeddedBrowser/EmbeddedBrowserWarningDialog.vue
+++ b/services/agora/src/components/embeddedBrowser/EmbeddedBrowserWarningDialog.vue
@@ -115,6 +115,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import Button from "primevue/button";
 import { Platform } from "quasar";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { useEmbeddedBrowserWarningStore } from "src/stores/embeddedBrowserWarning";
@@ -122,6 +123,12 @@ import { useNotify } from "src/utils/ui/notify";
 import { computed, ref } from "vue";
 
 import { embeddedBrowserWarningTranslations } from "./EmbeddedBrowserWarningDialog.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 const { t } = useComponentI18n(embeddedBrowserWarningTranslations);
 const { showNotifyMessage } = useNotify();

--- a/services/agora/src/components/newConversation/SeedOpinionItem.vue
+++ b/services/agora/src/components/newConversation/SeedOpinionItem.vue
@@ -46,6 +46,8 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
+import Card from "primevue/card";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { MAX_LENGTH_OPINION } from "src/shared/shared";
 import { defineAsyncComponent, ref } from "vue";
@@ -54,6 +56,13 @@ import {
   type SeedOpinionItemTranslations,
   seedOpinionItemTranslations,
 } from "./SeedOpinionItem.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+    PrimeCard: Card,
+  },
+});
 
 const props = defineProps<{
   modelValue: string;
@@ -68,7 +77,9 @@ defineEmits<{
   (e: "blur"): void;
 }>();
 
-const Editor = defineAsyncComponent(() => import("src/components/editor/Editor.vue"));
+const Editor = defineAsyncComponent(
+  () => import("src/components/editor/Editor.vue")
+);
 
 const { t } = useComponentI18n<SeedOpinionItemTranslations>(
   seedOpinionItemTranslations

--- a/services/agora/src/components/newConversation/dialog/CustomTimerDialog.vue
+++ b/services/agora/src/components/newConversation/dialog/CustomTimerDialog.vue
@@ -39,6 +39,7 @@
 </template>
 
 <script setup lang="ts">
+import DatePicker from "primevue/datepicker";
 import ZKBottomDialogContainer from "src/components/ui-library/ZKBottomDialogContainer.vue";
 import type { PrivateConversationSettings } from "src/composables/conversation/draft";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
@@ -48,6 +49,12 @@ import {
   type CustomTimerDialogTranslations,
   customTimerDialogTranslations,
 } from "./CustomTimerDialog.i18n";
+
+defineOptions({
+  components: {
+    PrimeDatePicker: DatePicker,
+  },
+});
 
 const emit = defineEmits<{
   goBack: [];

--- a/services/agora/src/components/newConversation/import/csv/CsvDropZone.vue
+++ b/services/agora/src/components/newConversation/import/csv/CsvDropZone.vue
@@ -130,6 +130,7 @@
 <script setup lang="ts">
 import { useDropZone } from "@vueuse/core";
 import Badge from "primevue/badge";
+import Button from "primevue/button";
 import ZKIcon from "src/components/ui-library/ZKIcon.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { computed, ref } from "vue";
@@ -140,6 +141,12 @@ import {
   csvDropZoneTranslations,
 } from "./CsvDropZone.i18n";
 import CsvErrorDetailsDialog from "./CsvErrorDetailsDialog.vue";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 const props = defineProps<Props>();
 

--- a/services/agora/src/components/newConversation/import/csv/CsvErrorDetailsDialog.vue
+++ b/services/agora/src/components/newConversation/import/csv/CsvErrorDetailsDialog.vue
@@ -58,6 +58,7 @@
 
 <script setup lang="ts">
 import { useClipboard } from "@vueuse/core";
+import Button from "primevue/button";
 import ZKBottomDialogContainer from "src/components/ui-library/ZKBottomDialogContainer.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { processEnv } from "src/utils/processEnv";
@@ -68,11 +69,17 @@ import {
   csvErrorDetailsDialogTranslations,
 } from "./CsvErrorDetailsDialog.i18n";
 
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
+
+const props = defineProps<Props>();
+
 interface Props {
   errorMessage: string;
 }
-
-const props = defineProps<Props>();
 
 const showDialog = defineModel<boolean>({ required: true });
 

--- a/services/agora/src/components/newConversation/poll/PollComponent.vue
+++ b/services/agora/src/components/newConversation/poll/PollComponent.vue
@@ -78,6 +78,7 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
 import ZKCard from "src/components/ui-library/ZKCard.vue";
 import ZKIcon from "src/components/ui-library/ZKIcon.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
@@ -88,7 +89,11 @@ import {
   pollComponentTranslations,
 } from "./PollComponent.i18n";
 
-// Define props
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 const props = defineProps<{
   readonly?: boolean; // When true, poll options cannot be edited (but poll can still be removed)
 }>();

--- a/services/agora/src/components/onboarding/steps/SpokenLanguageStep.vue
+++ b/services/agora/src/components/onboarding/steps/SpokenLanguageStep.vue
@@ -13,6 +13,7 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
 import SpokenLanguageSelector from "src/components/language/SpokenLanguageSelector.vue";
 import DialogStepLayout from "src/components/onboarding/layouts/DialogStepLayout.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
@@ -22,12 +23,17 @@ import {
   spokenLanguageStepTranslations,
 } from "./SpokenLanguageStep.i18n";
 
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
+
 const emit = defineEmits<{ (e: "next"): void }>();
 
 const { t } = useComponentI18n<SpokenLanguageStepTranslations>(
   spokenLanguageStepTranslations
 );
-
 </script>
 
 <style scoped lang="scss">

--- a/services/agora/src/components/onboarding/steps/TopicSelectionStep.vue
+++ b/services/agora/src/components/onboarding/steps/TopicSelectionStep.vue
@@ -48,16 +48,25 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import Button from "primevue/button";
+import Chip from "primevue/chip";
 import DialogStepLayout from "src/components/onboarding/layouts/DialogStepLayout.vue";
 import ZKIcon from "src/components/ui-library/ZKIcon.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { useTopicStore } from "src/stores/topic";
-import { computed,onMounted } from "vue";
+import { computed, onMounted } from "vue";
 
 import {
   type TopicSelectionStepTranslations,
   topicSelectionStepTranslations,
 } from "./TopicSelectionStep.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+    PrimeChip: Chip,
+  },
+});
 
 const emit = defineEmits<{
   (e: "close"): void;

--- a/services/agora/src/components/post/analysis/shortcutBar/ShortcutButton.vue
+++ b/services/agora/src/components/post/analysis/shortcutBar/ShortcutButton.vue
@@ -13,6 +13,14 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
+
 const props = defineProps<{
   isSelected: boolean;
   label: string;

--- a/services/agora/src/components/post/comments/CommentComposer.vue
+++ b/services/agora/src/components/post/comments/CommentComposer.vue
@@ -2,6 +2,7 @@
   <div ref="target">
     <div class="container borderStyle" :class="{ focused: innerFocus }">
       <Editor
+        v-if="isEditorMounted"
         ref="editorRef"
         v-model="opinionBody"
         :placeholder="innerFocus ? t('placeholderExpanded') : t('placeholder')"
@@ -85,11 +86,13 @@
 <script setup lang="ts">
 import { onClickOutside, useWindowScroll } from "@vueuse/core";
 import { storeToRefs } from "pinia";
+import Button from "primevue/button";
 import PreLoginIntentionDialog from "src/components/authentication/intention/PreLoginIntentionDialog.vue";
 import ExitRoutePrompt from "src/components/routeGuard/ExitRoutePrompt.vue";
 import ZKButton from "src/components/ui-library/ZKButton.vue";
 import ZKIcon from "src/components/ui-library/ZKIcon.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
+import { useIdleMount } from "src/composables/ui/useIdleMount";
 import { useTicketVerificationFlow } from "src/composables/zupass/useTicketVerificationFlow";
 import { useZupassVerification } from "src/composables/zupass/useZupassVerification";
 import {
@@ -124,6 +127,12 @@ import {
 } from "./CommentComposer.i18n";
 import OpinionWritingGuidelinesDialog from "./OpinionWritingGuidelinesDialog.vue";
 
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
+
 const props = defineProps<{
   postSlugId: string;
   loginRequiredToParticipate: boolean;
@@ -146,6 +155,9 @@ const emit = defineEmits<{
 const Editor = defineAsyncComponent(
   () => import("src/components/editor/Editor.vue")
 );
+
+// Defer Editor mounting until browser is idle to improve initial page load performance
+const { isMounted: isEditorMounted } = useIdleMount({});
 
 const dummyInput = ref<HTMLInputElement>();
 

--- a/services/agora/src/components/post/comments/OpinionNotFoundBanner.vue
+++ b/services/agora/src/components/post/comments/OpinionNotFoundBanner.vue
@@ -35,6 +35,7 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
 import ZKCard from "src/components/ui-library/ZKCard.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 
@@ -42,6 +43,12 @@ import {
   type OpinionNotFoundBannerTranslations,
   opinionNotFoundBannerTranslations,
 } from "./OpinionNotFoundBanner.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 defineProps<{
   isVisible: boolean;

--- a/services/agora/src/components/post/comments/ui/CommentLoadingError.vue
+++ b/services/agora/src/components/post/comments/ui/CommentLoadingError.vue
@@ -21,6 +21,14 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
+
 defineProps<{
   title: string;
   message?: string | null;

--- a/services/agora/src/components/post/interactionBar/PostActionBar.vue
+++ b/services/agora/src/components/post/interactionBar/PostActionBar.vue
@@ -56,7 +56,6 @@ import { useConversationUrl } from "src/utils/url/conversationUrl";
 import ZKActionDialog from "../../ui-library/ZKActionDialog.vue";
 import ZKButton from "../../ui-library/ZKButton.vue";
 import ZKIcon from "../../ui-library/ZKIcon.vue";
-import ShareDialog from "../ShareDialog.vue";
 import InteractionTab from "./InteractionTab.vue";
 import {
   type PostActionBarTranslations,
@@ -105,12 +104,12 @@ function shareClicked(): void {
       await copyToClipboard(sharePostUrl);
       notify.showNotifyMessage(t("copiedToClipboard"));
     },
-    openQrCodeCallback: () => {
+    openQrCodeCallback: async () => {
+      const { default: ShareDialog } = await import("../ShareDialog.vue");
       $q.dialog({
         component: ShareDialog,
         componentProps: {
           url: sharePostUrl,
-          title: shareTitle,
         },
       });
     },

--- a/services/agora/src/components/report/ReportContentDialog.vue
+++ b/services/agora/src/components/report/ReportContentDialog.vue
@@ -80,6 +80,7 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { MAX_LENGTH_USER_REPORT_EXPLANATION } from "src/shared/shared";
 import type { UserReportReason } from "src/shared/types/zod";
@@ -92,6 +93,12 @@ import {
   type ReportContentDialogTranslations,
   reportContentDialogTranslations,
 } from "./ReportContentDialog.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 const props = defineProps<{
   reportType: "conversation" | "opinion";

--- a/services/agora/src/components/settings/SettingsSearchInput.vue
+++ b/services/agora/src/components/settings/SettingsSearchInput.vue
@@ -23,13 +23,30 @@
 </template>
 
 <script setup lang="ts">
+import IconField from "primevue/iconfield";
+import InputIcon from "primevue/inputicon";
+import InputText from "primevue/inputtext";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
-import { computed,ref } from "vue";
+import { computed, ref } from "vue";
 
 import {
   type SettingsSearchInputTranslations,
   settingsSearchInputTranslations,
 } from "./SettingsSearchInput.i18n";
+
+defineOptions({
+  components: {
+    PrimeIconField: IconField,
+    PrimeInputIcon: InputIcon,
+    PrimeInputText: InputText,
+  },
+});
+
+const props = withDefaults(defineProps<Props>(), {
+  placeholder: undefined,
+});
+
+const emit = defineEmits<Emits>();
 
 interface Props {
   modelValue: string;
@@ -39,12 +56,6 @@ interface Props {
 interface Emits {
   (e: "update:modelValue", value: string): void;
 }
-
-const props = withDefaults(defineProps<Props>(), {
-  placeholder: undefined,
-});
-
-const emit = defineEmits<Emits>();
 
 const { t } = useComponentI18n<SettingsSearchInputTranslations>(
   settingsSearchInputTranslations

--- a/services/agora/src/components/ui-library/ZKConfirmDialog.vue
+++ b/services/agora/src/components/ui-library/ZKConfirmDialog.vue
@@ -28,9 +28,25 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
 import { watch } from "vue";
 
 import ZKBottomDialogContainer from "./ZKBottomDialogContainer.vue";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
+
+withDefaults(defineProps<Props>(), {
+  title: undefined,
+  confirmText: "Confirm",
+  cancelText: "Cancel",
+  variant: "default",
+});
+
+const emit = defineEmits<Emits>();
 
 interface Props {
   title?: string;
@@ -45,15 +61,6 @@ interface Emits {
   (e: "cancel"): void;
   (e: "dialogClosed"): void;
 }
-
-withDefaults(defineProps<Props>(), {
-  title: undefined,
-  confirmText: "Confirm",
-  cancelText: "Cancel",
-  variant: "default",
-});
-
-const emit = defineEmits<Emits>();
 
 const showDialog = defineModel<boolean>({ required: true });
 

--- a/services/agora/src/components/ui-library/ZKInfoBanner.vue
+++ b/services/agora/src/components/ui-library/ZKInfoBanner.vue
@@ -19,18 +19,26 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
+
 import ZKIcon from "./ZKIcon.vue";
 
-export interface Props {
-  message: string;
-  actionLabel?: string;
-}
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 defineProps<Props>();
 
 const emit = defineEmits<{
   action: [];
 }>();
+
+export interface Props {
+  message: string;
+  actionLabel?: string;
+}
 </script>
 
 <style scoped lang="scss">

--- a/services/agora/src/components/ui-library/ZKPhoneNumberInput.vue
+++ b/services/agora/src/components/ui-library/ZKPhoneNumberInput.vue
@@ -1,0 +1,92 @@
+<template>
+  <!--
+    This component has some form of VNode bug that can cause Vite's dev server
+    to lose its rendering instance upon load. It only affects the development server.
+    There are no solution to fix the issue but since it doesn't affect production
+    it can be safely ignored.
+  -->
+  <!-- @vue-expect-error MazPhoneNumberInput types v-model as T | undefined -->
+  <MazPhoneNumberInput
+    :model-value="modelValue"
+    :country-code="countryCode"
+    :success="success"
+    :error="error"
+    :show-code-on-list="showCodeOnList"
+    :placeholder="placeholder"
+    :required="required"
+    :auto-format="autoFormat"
+    :no-validation-error="noValidationError"
+    :aria-describedby="ariaDescribedby"
+    @update="handleUpdate"
+    @country-code="handleCountryCode"
+    @blur="handleBlur"
+    @update:model-value="handleModelValue"
+    @update:country-code="handleCountryCodeUpdate"
+  />
+</template>
+
+<script setup lang="ts">
+import "maz-ui/css/main.css";
+
+import type { CountryCode } from "libphonenumber-js/max";
+import type { Results } from "maz-ui/components/MazPhoneNumberInput";
+import MazPhoneNumberInput from "maz-ui/components/MazPhoneNumberInput";
+
+interface ZKPhoneNumberInputProps {
+  modelValue: string | null;
+  countryCode: CountryCode | null;
+  success?: boolean;
+  error?: boolean;
+  showCodeOnList?: boolean;
+  placeholder?: string;
+  required?: boolean;
+  autoFormat?: boolean;
+  noValidationError?: boolean;
+  ariaDescribedby?: string;
+}
+
+withDefaults(defineProps<ZKPhoneNumberInputProps>(), {
+  success: false,
+  error: false,
+  showCodeOnList: false,
+  placeholder: "",
+  required: false,
+  autoFormat: false,
+  noValidationError: false,
+  ariaDescribedby: undefined,
+});
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string | null];
+  "update:countryCode": [value: CountryCode | null];
+  update: [results: Results];
+  countryCode: [value: CountryCode | null | undefined];
+  blur: [];
+}>();
+
+function handleModelValue(value: string | null) {
+  emit("update:modelValue", value);
+}
+
+function handleCountryCodeUpdate(value: CountryCode | null) {
+  emit("update:countryCode", value);
+}
+
+function handleUpdate(results: Results) {
+  emit("update", results);
+}
+
+function handleCountryCode(value: CountryCode | null | undefined) {
+  emit("countryCode", value);
+}
+
+function handleBlur() {
+  emit("blur");
+}
+</script>
+
+<style scoped lang="scss">
+:deep(.m-phone-number-input) {
+  row-gap: 1rem;
+}
+</style>

--- a/services/agora/src/components/ui/AsyncStateHandler.vue
+++ b/services/agora/src/components/ui/AsyncStateHandler.vue
@@ -103,6 +103,7 @@
 
 <script setup lang="ts">
 import type { UseQueryReturnType } from "@tanstack/vue-query";
+import Button from "primevue/button";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { computed, ref } from "vue";
 
@@ -110,6 +111,12 @@ import {
   type AsyncStateHandlerTranslations,
   asyncStateHandlerTranslations,
 } from "./AsyncStateHandler.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
 
 const props = withDefaults(defineProps<Props>(), {
   config: () => ({}),

--- a/services/agora/src/composables/share/useShareActions.ts
+++ b/services/agora/src/composables/share/useShareActions.ts
@@ -18,7 +18,7 @@ import {
   shareActionsTranslations,
 } from "src/utils/actions/definitions/share-actions.i18n";
 import { useEmbedMode } from "src/utils/ui/embedMode";
-import { type Ref,ref } from "vue";
+import { type Ref, ref } from "vue";
 
 export interface ShareActionsComposable {
   dialogState: Ref<ContentActionDialogState>;

--- a/services/agora/src/composables/ui/useIdleMount.ts
+++ b/services/agora/src/composables/ui/useIdleMount.ts
@@ -1,0 +1,74 @@
+import { onMounted, type Ref, ref } from "vue";
+
+export interface UseIdleMountOptions {
+  /**
+   * Maximum time to wait before forcing mount (ms)
+   * @default 2000
+   */
+  timeout?: number;
+
+  /**
+   * Delay before mounting (for setTimeout fallback)
+   * @default 100
+   */
+  delay?: number;
+
+  /**
+   * Mount immediately on component mount (disable idle defer)
+   * @default false
+   */
+  immediate?: boolean;
+}
+
+export interface UseIdleMountReturn {
+  /**
+   * Whether the component should be mounted
+   */
+  isMounted: Ref<boolean>;
+
+  /**
+   * Manually trigger mount (useful for override scenarios)
+   */
+  mount: () => void;
+}
+
+/**
+ * Composable to defer mounting of heavy components until browser is idle
+ *
+ * Usage:
+ * ```typescript
+ * const { isMounted } = useIdleMount({ timeout: 2000 });
+ * ```
+ *
+ * In template:
+ * ```vue
+ * <HeavyComponent v-if="isMounted" />
+ * ```
+ */
+export function useIdleMount(
+  options?: UseIdleMountOptions
+): UseIdleMountReturn {
+  const { timeout = 2000, delay = 100, immediate = false } = options ?? {};
+
+  const isMounted = ref(immediate);
+
+  function mount(): void {
+    isMounted.value = true;
+  }
+
+  onMounted(() => {
+    if (immediate) return;
+
+    if ("requestIdleCallback" in window) {
+      requestIdleCallback(mount, { timeout });
+    } else {
+      // Fallback for Safari/older browsers that don't support requestIdleCallback
+      setTimeout(mount, delay);
+    }
+  });
+
+  return {
+    isMounted,
+    mount,
+  };
+}

--- a/services/agora/src/pages/conversation/new/create/index.vue
+++ b/services/agora/src/pages/conversation/new/create/index.vue
@@ -150,6 +150,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import Button from "primevue/button";
 import PreLoginIntentionDialog from "src/components/authentication/intention/PreLoginIntentionDialog.vue";
 import ActiveImportBanner from "src/components/conversation/import/ActiveImportBanner.vue";
 import BackButton from "src/components/navigation/buttons/BackButton.vue";
@@ -186,7 +187,15 @@ import {
   createConversationTranslations,
 } from "./index.i18n";
 
-const Editor = defineAsyncComponent(() => import("src/components/editor/Editor.vue"));
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
+
+const Editor = defineAsyncComponent(
+  () => import("src/components/editor/Editor.vue")
+);
 
 const { t } = useComponentI18n<CreateConversationTranslations>(
   createConversationTranslations

--- a/services/agora/src/pages/conversation/new/review/index.vue
+++ b/services/agora/src/pages/conversation/new/review/index.vue
@@ -87,7 +87,20 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import Button from "primevue/button";
 import PreLoginIntentionDialog from "src/components/authentication/intention/PreLoginIntentionDialog.vue";
+
+import {
+  type ConversationReviewTranslations,
+  conversationReviewTranslations,
+} from "./index.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+  },
+});
+
 import ConversationTitleWithPrivacyLabel from "src/components/features/conversation/ConversationTitleWithPrivacyLabel.vue";
 import BackButton from "src/components/navigation/buttons/BackButton.vue";
 import TopMenuWrapper from "src/components/navigation/header/TopMenuWrapper.vue";
@@ -110,11 +123,6 @@ import { useCommonApi } from "src/utils/api/common";
 import { useBackendPostApi } from "src/utils/api/post/post";
 import { type ComponentPublicInstance, nextTick, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
-
-import {
-  type ConversationReviewTranslations,
-  conversationReviewTranslations,
-} from "./index.i18n";
 
 const { isLoggedIn } = storeToRefs(useAuthenticationStore());
 const router = useRouter();

--- a/services/agora/src/pages/dev/opinion-group-visualization.vue
+++ b/services/agora/src/pages/dev/opinion-group-visualization.vue
@@ -64,6 +64,8 @@
 </template>
 
 <script setup lang="ts">
+import Card from "primevue/card";
+import Select from "primevue/select";
 import { StandardMenuBar } from "src/components/navigation/header/variants";
 import OpinionGroupTab from "src/components/post/analysis/opinionGroupTab/OpinionGroupTab.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
@@ -73,12 +75,19 @@ import type {
   PolisClusters,
   PolisKey,
 } from "src/shared/types/zod";
-import { computed, onMounted,ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 
 import {
   type OpinionGroupVisualizationTranslations,
   opinionGroupVisualizationTranslations,
 } from "./opinion-group-visualization.i18n";
+
+defineOptions({
+  components: {
+    PrimeCard: Card,
+    PrimeSelect: Select,
+  },
+});
 
 const { t } = useComponentI18n<OpinionGroupVisualizationTranslations>(
   opinionGroupVisualizationTranslations

--- a/services/agora/src/pages/dev/test-components/AsyncStateHandlerTest.vue
+++ b/services/agora/src/pages/dev/test-components/AsyncStateHandlerTest.vue
@@ -182,14 +182,25 @@
 
 <script setup lang="ts">
 import type { UseQueryReturnType } from "@tanstack/vue-query";
+import Button from "primevue/button";
+import Card from "primevue/card";
+import Tag from "primevue/tag";
 import AsyncStateHandler from "src/components/ui/AsyncStateHandler.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
-import { computed,ref } from "vue";
+import { computed, ref } from "vue";
 
 import {
   type AsyncStateHandlerTestTranslations,
   asyncStateHandlerTestTranslations,
 } from "./AsyncStateHandlerTest.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+    PrimeCard: Card,
+    PrimeTag: Tag,
+  },
+});
 
 const { t } = useComponentI18n<AsyncStateHandlerTestTranslations>(
   asyncStateHandlerTestTranslations

--- a/services/agora/src/pages/dev/test-components/EmbeddedBrowserWarningTest.vue
+++ b/services/agora/src/pages/dev/test-components/EmbeddedBrowserWarningTest.vue
@@ -55,13 +55,25 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
+import Card from "primevue/card";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
-import { type AppKey,useEmbeddedBrowserWarningStore } from "src/stores/embeddedBrowserWarning";
+import {
+  type AppKey,
+  useEmbeddedBrowserWarningStore,
+} from "src/stores/embeddedBrowserWarning";
 
 import {
   type EmbeddedBrowserWarningTestTranslations,
   embeddedBrowserWarningTestTranslations,
 } from "./EmbeddedBrowserWarningTest.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+    PrimeCard: Card,
+  },
+});
 
 const { t } = useComponentI18n<EmbeddedBrowserWarningTestTranslations>(
   embeddedBrowserWarningTestTranslations

--- a/services/agora/src/pages/dev/test-components/OpinionGroupVisualizationTest.vue
+++ b/services/agora/src/pages/dev/test-components/OpinionGroupVisualizationTest.vue
@@ -24,6 +24,8 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
+import Card from "primevue/card";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { useRouter } from "vue-router";
 
@@ -31,6 +33,13 @@ import {
   type OpinionGroupVisualizationTestTranslations,
   opinionGroupVisualizationTestTranslations,
 } from "./OpinionGroupVisualizationTest.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+    PrimeCard: Card,
+  },
+});
 
 const { t } = useComponentI18n<OpinionGroupVisualizationTestTranslations>(
   opinionGroupVisualizationTestTranslations

--- a/services/agora/src/pages/dev/test-components/PreferencesDialogTest.vue
+++ b/services/agora/src/pages/dev/test-components/PreferencesDialogTest.vue
@@ -24,6 +24,8 @@
 </template>
 
 <script setup lang="ts">
+import Button from "primevue/button";
+import Card from "primevue/card";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { useOnboardingPreferencesStore } from "src/stores/onboarding/preferences";
 
@@ -31,6 +33,13 @@ import {
   type PreferencesDialogTestTranslations,
   preferencesDialogTestTranslations,
 } from "./PreferencesDialogTest.i18n";
+
+defineOptions({
+  components: {
+    PrimeButton: Button,
+    PrimeCard: Card,
+  },
+});
 
 const { t } = useComponentI18n<PreferencesDialogTestTranslations>(
   preferencesDialogTestTranslations

--- a/services/agora/src/pages/onboarding/step3-phone-1/index.vue
+++ b/services/agora/src/pages/onboarding/step3-phone-1/index.vue
@@ -24,14 +24,7 @@
             <div class="container">
               <div>{{ t("smsDescription") }}</div>
 
-              <!--
-                This component has some form of VNode bug that can cause Vite's dev server
-                to lose its rendering instance upon load. It only affects the development server.
-                There are no solution to fix the issue but since it doesn't affect production
-                it can be safely ignored.
-              -->
-              <!-- @vue-expect-error MazPhoneNumberInput types v-model as T | undefined -->
-              <MazPhoneNumberInput
+              <ZKPhoneNumberInput
                 v-model="phoneData.phoneNumber"
                 v-model:country-code="phoneData.countryCode"
                 :success="phoneData.isValid"
@@ -95,18 +88,18 @@
 </template>
 
 <script setup lang="ts">
+import type { CountryCode } from "libphonenumber-js/max";
 import {
-  type CountryCode,
   parsePhoneNumberFromString,
   type PhoneNumber as LibPhoneNumber,
 } from "libphonenumber-js/max";
 import type { Results } from "maz-ui/components/MazPhoneNumberInput";
-import MazPhoneNumberInput from "maz-ui/components/MazPhoneNumberInput";
 import { storeToRefs } from "pinia";
 import DefaultImageExample from "src/components/onboarding/backgrounds/DefaultImageExample.vue";
 import StepperLayout from "src/components/onboarding/layouts/StepperLayout.vue";
 import InfoHeader from "src/components/onboarding/ui/InfoHeader.vue";
 import ZKGradientButton from "src/components/ui-library/ZKGradientButton.vue";
+import ZKPhoneNumberInput from "src/components/ui-library/ZKPhoneNumberInput.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import OnboardingLayout from "src/layouts/OnboardingLayout.vue";
 import {
@@ -361,9 +354,5 @@ async function validateNumber(): Promise<boolean> {
 .error-icon {
   font-size: 1rem;
   color: #dc2626;
-}
-
-:deep(.m-phone-number-input) {
-  row-gap: 1rem;
 }
 </style>

--- a/services/agora/src/pages/onboarding/step3-phone-2/index.vue
+++ b/services/agora/src/pages/onboarding/step3-phone-2/index.vue
@@ -83,8 +83,20 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import InputOtp from "primevue/inputotp";
 import { useQuasar } from "quasar";
 import DefaultImageExample from "src/components/onboarding/backgrounds/DefaultImageExample.vue";
+
+import {
+  type Step3Phone2Translations,
+  step3Phone2Translations,
+} from "./index.i18n";
+
+defineOptions({
+  components: {
+    PrimeInputOtp: InputOtp,
+  },
+});
 import StepperLayout from "src/components/onboarding/layouts/StepperLayout.vue";
 import InfoHeader from "src/components/onboarding/ui/InfoHeader.vue";
 import ZKButton from "src/components/ui-library/ZKButton.vue";
@@ -106,11 +118,6 @@ import { createDidOverwriteIfAlreadyExists } from "src/utils/crypto/ucan/operati
 import { useNotify } from "src/utils/ui/notify";
 import { onMounted, ref, watchEffect } from "vue";
 import { useRouter } from "vue-router";
-
-import {
-  type Step3Phone2Translations,
-  step3Phone2Translations,
-} from "./index.i18n";
 
 const { t } = useComponentI18n<Step3Phone2Translations>(
   step3Phone2Translations
@@ -157,12 +164,10 @@ watchEffect(() => {
 
   void (async () => {
     try {
-      const { parsePhoneNumberFromString } = await import(
-        "libphonenumber-js/max"
-      );
+      const { parsePhoneNumberFromString } =
+        await import("libphonenumber-js/max");
       const parsed = parsePhoneNumberFromString(phoneNumber);
-      formattedPhoneNumber.value =
-        parsed?.formatInternational() || phoneNumber;
+      formattedPhoneNumber.value = parsed?.formatInternational() || phoneNumber;
     } catch (e) {
       console.warn("Failed to load phone formatter", e);
     }

--- a/services/agora/src/pages/settings/languages/display-language/index.vue
+++ b/services/agora/src/pages/settings/languages/display-language/index.vue
@@ -92,15 +92,7 @@ function selectDisplayLanguage(
     return; // Already selected
   }
 
-  try {
-    changeDisplayLanguage({ newLanguage: languageCode });
-  } catch (err: unknown) {
-    console.error("Failed to change language:", err);
-    // Type guard for error handling
-    if (err instanceof Error) {
-      console.error("Error message:", err.message);
-    }
-  }
+  void changeDisplayLanguage({ newLanguage: languageCode });
 }
 
 // Load user's language preferences on page mount

--- a/services/agora/src/pages/topics/index.vue
+++ b/services/agora/src/pages/topics/index.vue
@@ -53,6 +53,7 @@
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
+import Chip from "primevue/chip";
 import PreLoginIntentionDialog from "src/components/authentication/intention/PreLoginIntentionDialog.vue";
 import FollowButton from "src/components/features/topics/FollowButton.vue";
 import { HomeMenuBar } from "src/components/navigation/header/variants";
@@ -62,7 +63,13 @@ import { useAuthenticationStore } from "src/stores/authentication";
 import { useTopicStore } from "src/stores/topic";
 import { onMounted, ref } from "vue";
 
-import { type TopicsTranslations,topicsTranslations } from "./index.i18n";
+import { type TopicsTranslations, topicsTranslations } from "./index.i18n";
+
+defineOptions({
+  components: {
+    PrimeChip: Chip,
+  },
+});
 
 const { t } = useComponentI18n<TopicsTranslations>(topicsTranslations);
 
@@ -83,7 +90,7 @@ async function loadInitialData() {
     isLoading.value = true;
     await loadTopicsData();
   } catch (error) {
-    console.error('Failed to load topics:', error);
+    console.error("Failed to load topics:", error);
   } finally {
     isLoading.value = false;
   }

--- a/services/agora/src/utils/api/auth.ts
+++ b/services/agora/src/utils/api/auth.ts
@@ -1,12 +1,7 @@
 import { storeToRefs } from "pinia";
 import { useQuasar } from "quasar";
-import {
-  DefaultApiAxiosParamCreator,
-  DefaultApiFactory,
-} from "src/api";
-import type {
-  DeviceLoginStatus,
-} from "src/shared/types/zod";
+import { DefaultApiAxiosParamCreator, DefaultApiFactory } from "src/api";
+import type { DeviceLoginStatus } from "src/shared/types/zod";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useHomeFeedStore } from "src/stores/homeFeed";
 import { useLanguageStore } from "src/stores/language";
@@ -26,9 +21,7 @@ import { api } from "./client";
 import { useCommonApi } from "./common";
 
 export function useBackendAuthApi() {
-  const {
-    buildEncodedUcan,
-  } = useCommonApi();
+  const { buildEncodedUcan } = useCommonApi();
   const authStore = useAuthenticationStore();
   const { isAuthInitialized } = storeToRefs(authStore);
   const { loadPostData } = useHomeFeedStore();
@@ -81,8 +74,9 @@ export function useBackendAuthApi() {
   }
 
   async function loadAuthenticatedModules() {
-    await Promise.all([
-      loadUserProfile(),
+    await loadUserProfile();
+
+    void Promise.all([
       loadPostData(),
       loadNotificationData(false),
       loadTopicsData(),
@@ -123,8 +117,12 @@ export function useBackendAuthApi() {
       }
 
       // Extract userId from old and new status for comparison
-      const oldUserId = oldLoginStatus.isKnown ? oldLoginStatus.userId : undefined;
-      const newUserId = newLoginStatus.isKnown ? newLoginStatus.userId : undefined;
+      const oldUserId = oldLoginStatus.isKnown
+        ? oldLoginStatus.userId
+        : undefined;
+      const newUserId = newLoginStatus.isKnown
+        ? newLoginStatus.userId
+        : undefined;
       const userIdChanged = oldUserId !== newUserId;
 
       const authStateChanged =

--- a/services/agora/src/utils/crypto/ucan/operation.ts
+++ b/services/agora/src/utils/crypto/ucan/operation.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-case-declarations */
-import * as ucans from "@ucans/ucans";
 import { SecureSigning } from "@zkorum/capacitor-secure-signing";
 import { publicKeyToDid } from "src/shared/did/util";
 import { base64Decode, base64Encode } from "src/shared-app-api/base64";
@@ -135,6 +134,8 @@ async function buildWebUcan({
   method,
   lifetimeInSeconds = DEFAULT_UCAN_LIFETIME_SECONDS,
 }: CreateUcanProps): Promise<string> {
+  const ucans = await import("@ucans/ucans");
+
   const webCryptoStore = await getWebCryptoStore();
   const u = await ucans.Builder.create()
     .issuedBy({
@@ -163,6 +164,8 @@ async function buildMobileUcan({
   method,
   lifetimeInSeconds = DEFAULT_UCAN_LIFETIME_SECONDS,
 }: CreateUcanProps): Promise<string> {
+  const ucans = await import("@ucans/ucans");
+
   const u = await ucans.Builder.create()
     .issuedBy({
       did: () => did,


### PR DESCRIPTION
This PR will be rebased against the main branch once it is ready for review as it relies on a few compilation fixes from the other pull request (https://github.com/zkorum/agora/pull/457).

Changes:

- Removed manual Vite chunking
  - The reason is that in profiling tests, we discovered that it is degrading the loading performance rather than enhancing it. In a 4G test with cache disabled, we are loading at 15.3 seconds (manual chunking disabled) vs 16 seconds (manual chunking optimizations enabled).
- Unified the icon library to Iconify
   - Repeated tests showed a speedup of 0.3 seconds on a 4G test with cache disabled. Observing a drop from 12.9 seconds to 12.6 seconds.
- QR code library deferred loading for the share functionality
- Maz UI will now only load on the specific component instead of globally
- i18n loads English only at the beginning
- Prioritized the authentication API call
- Lazy load crypto ucan 
- Deferred TipTap editor's loading