### PR TITLE
docs: remove L3→L1 arrow from tri-layer architecture diagram

### DIFF
--- a/doc/decentralized-protocol/0013-agora-atproto-walkaway.md
+++ b/doc/decentralized-protocol/0013-agora-atproto-walkaway.md
@@ -297,15 +297,15 @@ Standard AT Protocol prioritizes usability but doesn't guarantee walkaway. DDS a
 ┌────────────────────────────────────────────────┐
 │ L1: AT PROTOCOL (Hot Path - Usability)         │
 │ ┌──────────────┐  ┌──────────────┐            │
-│ │ PDS (Storage)│→ │Firehose (Pub)│  ↖         │
-│ │ - did:plc    │  │ - Permissionless  ↖       │
-│ │ - Encrypted  │  │   indexing         (login) │
-│ │   Vault      │  │ - Real-time         ↖     │
-│ │ - OAuth      │  │   distribution       ↖    │
-│ └──────────────┘  └──────────────┘        ↖   │
-│          ↓                ↓                 ↖  │
-│    ┌──────────────────────────┐             ↖ │
-│    │ AppViews (Discovery)     │              ↖│
+│ │ PDS (Storage)│→ │Firehose (Pub)│            │
+│ │ - did:plc    │  │ - Permissionless          │
+│ │ - Encrypted  │  │   indexing                │
+│ │   Vault      │  │ - Real-time               │
+│ │ - OAuth      │  │   distribution            │
+│ └──────────────┘  └──────────────┘            │
+│          ↓                ↓                    │
+│    ┌──────────────────────────┐               │
+│    │ AppViews (Discovery)     │               │
 │    │ - Instant search (SQL)   │               │
 │    │ - Real-time notifications│               │
 │    │ - Filter/sort            │               │
@@ -329,7 +329,7 @@ Standard AT Protocol prioritizes usability but doesn't guarantee walkaway. DDS a
          ↓ (recovery)           ↓ (verification)
 ┌────────────────────────────────────────────────┐
 │ L3: ETHEREUM (Truth - Verification)            │
-│ - Wallet Master Key (see hierarchy below) ─────┘
+│ - Wallet Master Key (see hierarchies below)    │
 │ - Hash(Result) commitments (fraud proving)     │
 │ - Token-gating (permission control)            │
 │ - Prover staking/slashing (economic security)  │


### PR DESCRIPTION
## Summary

Removes the diagonal arrow visual from the main tri-layer architecture diagram while keeping the detailed hierarchy diagrams that clearly explain the relationships.

## Changes

- Removed diagonal arrows (↖) and "(login)" label from L1 diagram
- Updated L3 reference from "hierarchy" to "hierarchies" (plural)
- Kept both detailed diagrams intact:
  - Ethereum Wallet Master Key Hierarchy (Type A)
  - Web2/Non-Wallet Auth & Self-Hosted comparison

## Rationale

The arrow was redundant - the login flow relationship is already clearly explained in the detailed "Ethereum Wallet Master Key Hierarchy" diagram below. Removing it simplifies the main architecture diagram while maintaining all the important information in the detailed sections.

## Related

Supersedes PR #476 and corrects merged PR #475.