### PR TITLE
fix(api): keep opinion_content column at varchar(3000) for retro-compatibility

### DIFF
--- a/services/agora/src/shared/shared.ts
+++ b/services/agora/src/shared/shared.ts
@@ -7,6 +7,7 @@ export const MAX_LENGTH_BODY = 1000;
 export const MAX_LENGTH_BODY_HTML = 3000; // Reserve extra space for HTML tags
 export const MAX_LENGTH_OPINION = 280;
 export const MAX_LENGTH_OPINION_HTML = 840; // Reserve extra space for HTML tags
+export const MAX_LENGTH_OPINION_HTML_OUTPUT = 3000; // Old value for database retro-compatibility of existing data
 export const MAX_LENGTH_NAME_CREATOR = 65;
 export const MAX_LENGTH_USERNAME = 20;
 export const MIN_LENGTH_USERNAME = 2;

--- a/services/agora/src/shared/types/dto-auth.ts
+++ b/services/agora/src/shared/types/dto-auth.ts
@@ -86,4 +86,3 @@ export type VerifyOtpReqBody = z.infer<typeof verifyOtpReqBody>;
 export type AuthenticateResponse = z.infer<typeof authenticate200>;
 export type VerifyOtp200 = z.infer<typeof verifyOtp200>;
 export type IsLoggedInResponse = z.infer<typeof isLoggedInResponse>;
-

--- a/services/agora/src/shared/types/zod.ts
+++ b/services/agora/src/shared/types/zod.ts
@@ -12,6 +12,7 @@ import {
     MAX_LENGTH_OPINION_HTML,
     MAX_LENGTH_USER_REPORT_EXPLANATION,
     validateHtmlStringCharacterCount,
+    MAX_LENGTH_OPINION_HTML_OUTPUT,
 } from "../shared.js";
 import { isValidPolisUrl } from "../utils/polis.js";
 import {
@@ -83,8 +84,7 @@ export const zodOrganization = z
     .object({
         name: z.string(),
         imageUrl: z.string(),
-        websiteUrl: z
-            .url({ message: "Invalid organization website url" }),
+        websiteUrl: z.url({ message: "Invalid organization website url" }),
         description: z.string(),
     })
     .strict();
@@ -482,8 +482,8 @@ export const zodOpinionContentInput = z
 export const zodOpinionContentOutput = z
     .string()
     .min(1)
-    .max(MAX_LENGTH_OPINION_HTML, {
-        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML)} characters`,
+    .max(MAX_LENGTH_OPINION_HTML_OUTPUT, {
+        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML_OUTPUT)} characters`,
     });
 export const zodAgreementType = z.enum(["agree", "disagree"]);
 export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);

--- a/services/api/database/flyway/V0033__chubby_lockheed.sql
+++ b/services/api/database/flyway/V0033__chubby_lockheed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "conversation" ADD COLUMN "is_closed" boolean DEFAULT false NOT NULL;

--- a/services/api/database/flyway/V0033__wild_magneto.sql
+++ b/services/api/database/flyway/V0033__wild_magneto.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "opinion_content" ALTER COLUMN "content" SET DATA TYPE varchar(840);--> statement-breakpoint
-ALTER TABLE "conversation" ADD COLUMN "is_closed" boolean DEFAULT false NOT NULL;

--- a/services/api/drizzle/0032_chubby_lockheed.sql
+++ b/services/api/drizzle/0032_chubby_lockheed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "conversation" ADD COLUMN "is_closed" boolean DEFAULT false NOT NULL;

--- a/services/api/drizzle/0032_wild_magneto.sql
+++ b/services/api/drizzle/0032_wild_magneto.sql
@@ -1,2 +1,0 @@
-ALTER TABLE "opinion_content" ALTER COLUMN "content" SET DATA TYPE varchar(840);--> statement-breakpoint
-ALTER TABLE "conversation" ADD COLUMN "is_closed" boolean DEFAULT false NOT NULL;

--- a/services/api/drizzle/meta/0032_snapshot.json
+++ b/services/api/drizzle/meta/0032_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "4592fd0f-527d-4174-ad14-437c0f466d5d",
+  "id": "7e0b4440-6a3b-4896-8583-1634d659ab5d",
   "prevId": "2c5c93d9-85d4-4baf-869c-94d2a37f3f7b",
   "version": "7",
   "dialect": "postgresql",
@@ -2627,7 +2627,7 @@
         },
         "content": {
           "name": "content",
-          "type": "varchar(840)",
+          "type": "varchar(3000)",
           "primaryKey": false,
           "notNull": true
         },

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -229,8 +229,8 @@
     {
       "idx": 32,
       "version": "7",
-      "when": 1768683632236,
-      "tag": "0032_wild_magneto",
+      "when": 1769022463445,
+      "tag": "0032_chubby_lockheed",
       "breakpoints": true
     }
   ]

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -1984,7 +1984,7 @@
                                                     "opinion": {
                                                         "type": "string",
                                                         "minLength": 1,
-                                                        "maxLength": 840
+                                                        "maxLength": 3000
                                                     },
                                                     "numParticipants": {
                                                         "type": "integer",
@@ -2521,7 +2521,7 @@
                                             "opinion": {
                                                 "type": "string",
                                                 "minLength": 1,
-                                                "maxLength": 840
+                                                "maxLength": 3000
                                             },
                                             "numParticipants": {
                                                 "type": "integer",
@@ -2696,7 +2696,7 @@
                                                     "opinion": {
                                                         "type": "string",
                                                         "minLength": 1,
-                                                        "maxLength": 840
+                                                        "maxLength": 3000
                                                     },
                                                     "numParticipants": {
                                                         "type": "integer",
@@ -2882,7 +2882,7 @@
                                                     "opinion": {
                                                         "type": "string",
                                                         "minLength": 1,
-                                                        "maxLength": 840
+                                                        "maxLength": 3000
                                                     },
                                                     "numParticipants": {
                                                         "type": "integer",
@@ -3098,7 +3098,7 @@
                                                                 "opinion": {
                                                                     "type": "string",
                                                                     "minLength": 1,
-                                                                    "maxLength": 840
+                                                                    "maxLength": 3000
                                                                 },
                                                                 "numParticipants": {
                                                                     "type": "integer",
@@ -3338,7 +3338,7 @@
                                             "opinion": {
                                                 "type": "string",
                                                 "minLength": 1,
-                                                "maxLength": 840
+                                                "maxLength": 3000
                                             },
                                             "numParticipants": {
                                                 "type": "integer",
@@ -3510,7 +3510,7 @@
                                             "opinion": {
                                                 "type": "string",
                                                 "minLength": 1,
-                                                "maxLength": 840
+                                                "maxLength": 3000
                                             },
                                             "numParticipants": {
                                                 "type": "integer",

--- a/services/api/src/shared-backend/db.ts
+++ b/services/api/src/shared-backend/db.ts
@@ -15,21 +15,26 @@ async function createPostgresClient(
     log: Pick<pino.BaseLogger, "info" | "error">,
     useReadReplica = false,
 ) {
-    const awsSecretId = useReadReplica && config.AWS_SECRET_ID_READ
-        ? config.AWS_SECRET_ID_READ
-        : config.AWS_SECRET_ID;
-    const awsSecretRegion = useReadReplica && config.AWS_SECRET_REGION_READ
-        ? config.AWS_SECRET_REGION_READ
-        : config.AWS_SECRET_REGION;
-    const dbHost = useReadReplica && config.DB_HOST_READ
-        ? config.DB_HOST_READ
-        : config.DB_HOST;
-    const dbPort = useReadReplica && config.DB_HOST_READ
-        ? config.DB_PORT_READ
-        : config.DB_PORT;
-    const connectionString = useReadReplica && config.CONNECTION_STRING_READ
-        ? config.CONNECTION_STRING_READ
-        : config.CONNECTION_STRING;
+    const awsSecretId =
+        useReadReplica && config.AWS_SECRET_ID_READ
+            ? config.AWS_SECRET_ID_READ
+            : config.AWS_SECRET_ID;
+    const awsSecretRegion =
+        useReadReplica && config.AWS_SECRET_REGION_READ
+            ? config.AWS_SECRET_REGION_READ
+            : config.AWS_SECRET_REGION;
+    const dbHost =
+        useReadReplica && config.DB_HOST_READ
+            ? config.DB_HOST_READ
+            : config.DB_HOST;
+    const dbPort =
+        useReadReplica && config.DB_HOST_READ
+            ? config.DB_PORT_READ
+            : config.DB_PORT;
+    const connectionString =
+        useReadReplica && config.CONNECTION_STRING_READ
+            ? config.CONNECTION_STRING_READ
+            : config.CONNECTION_STRING;
 
     if (
         config.NODE_ENV === "production" &&
@@ -109,7 +114,9 @@ async function createPostgresClient(
                 ssl: config.NODE_ENV === "production" ? "require" : undefined,
             });
         } catch (e) {
-            log.error(`Unable to connect to the database (${useReadReplica ? 'read replica' : 'primary'})`);
+            log.error(
+                `Unable to connect to the database (${useReadReplica ? "read replica" : "primary"})`,
+            );
             log.error(e);
             process.exit(1);
         }
@@ -133,7 +140,9 @@ export async function createDb(
     // Check if read replica config exists
     const hasReadReplica = !!(
         config.CONNECTION_STRING_READ ??
-        (config.AWS_SECRET_ID_READ && config.AWS_SECRET_REGION_READ && config.DB_HOST_READ)
+        (config.AWS_SECRET_ID_READ &&
+            config.AWS_SECRET_REGION_READ &&
+            config.DB_HOST_READ)
     );
 
     if (hasReadReplica) {
@@ -142,13 +151,17 @@ export async function createDb(
             logger: new DrizzleFastifyLogger(log),
         });
 
-        log.info("Connected to read replica - SELECTs will use replica, writes use primary");
+        log.info(
+            "Connected to read replica - SELECTs will use replica, writes use primary",
+        );
 
         // Use Drizzle's built-in withReplicas
         // Automatically routes SELECT queries to replica, writes to primary
         return withReplicas(primaryDb, [readDb]);
     } else {
-        log.info("No read replica configured, using primary for all operations");
+        log.info(
+            "No read replica configured, using primary for all operations",
+        );
         return primaryDb;
     }
 }

--- a/services/api/src/shared-backend/schema.ts
+++ b/services/api/src/shared-backend/schema.ts
@@ -27,7 +27,7 @@ const MAX_LENGTH_TITLE = 140;
 const MAX_LENGTH_BODY = 1000;
 const MAX_LENGTH_BODY_HTML = 3000; // Reserve extra space for HTML tags
 // const MAX_LENGTH_OPINION = 280;
-const MAX_LENGTH_OPINION_HTML = 840; // Reserve extra space for HTML tags
+const MAX_LENGTH_OPINION_HTML = 3000; // is lower now, kept this value For retro-compatibility
 const MAX_LENGTH_NAME_CREATOR = 65;
 const MAX_LENGTH_DESCRIPTION_CREATOR = 280;
 const MAX_LENGTH_USERNAME = 20;
@@ -1816,29 +1816,26 @@ export const notificationTable = pgTable(
 );
 
 // content changes over time as much as the conversation receives opinions and votes
-export const polisContentTable = pgTable(
-    "polis_content",
-    {
-        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-        conversationId: integer("conversation_id")
-            .references(() => conversationTable.id)
-            .notNull(), // not unique, there will be multiple rows over the life of the conversation
-        rawData: jsonb("raw_data").notNull(), // from external polis system
-        createdAt: timestamp("created_at", {
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-        updatedAt: timestamp("updated_at", {
-            // aiSummary may be set at a later data
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-    },
-);
+export const polisContentTable = pgTable("polis_content", {
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    conversationId: integer("conversation_id")
+        .references(() => conversationTable.id)
+        .notNull(), // not unique, there will be multiple rows over the life of the conversation
+    rawData: jsonb("raw_data").notNull(), // from external polis system
+    createdAt: timestamp("created_at", {
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+    updatedAt: timestamp("updated_at", {
+        // aiSummary may be set at a later data
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+});
 
 // one polisContent has many polisClusters
 export const polisClusterTable = pgTable("polis_cluster", {

--- a/services/api/src/shared/shared.ts
+++ b/services/api/src/shared/shared.ts
@@ -7,6 +7,7 @@ export const MAX_LENGTH_BODY = 1000;
 export const MAX_LENGTH_BODY_HTML = 3000; // Reserve extra space for HTML tags
 export const MAX_LENGTH_OPINION = 280;
 export const MAX_LENGTH_OPINION_HTML = 840; // Reserve extra space for HTML tags
+export const MAX_LENGTH_OPINION_HTML_OUTPUT = 3000; // Old value for database retro-compatibility of existing data
 export const MAX_LENGTH_NAME_CREATOR = 65;
 export const MAX_LENGTH_USERNAME = 20;
 export const MIN_LENGTH_USERNAME = 2;

--- a/services/api/src/shared/types/dto-auth.ts
+++ b/services/api/src/shared/types/dto-auth.ts
@@ -86,4 +86,3 @@ export type VerifyOtpReqBody = z.infer<typeof verifyOtpReqBody>;
 export type AuthenticateResponse = z.infer<typeof authenticate200>;
 export type VerifyOtp200 = z.infer<typeof verifyOtp200>;
 export type IsLoggedInResponse = z.infer<typeof isLoggedInResponse>;
-

--- a/services/api/src/shared/types/zod.ts
+++ b/services/api/src/shared/types/zod.ts
@@ -12,6 +12,7 @@ import {
     MAX_LENGTH_OPINION_HTML,
     MAX_LENGTH_USER_REPORT_EXPLANATION,
     validateHtmlStringCharacterCount,
+    MAX_LENGTH_OPINION_HTML_OUTPUT,
 } from "../shared.js";
 import { isValidPolisUrl } from "../utils/polis.js";
 import {
@@ -83,8 +84,7 @@ export const zodOrganization = z
     .object({
         name: z.string(),
         imageUrl: z.string(),
-        websiteUrl: z
-            .url({ message: "Invalid organization website url" }),
+        websiteUrl: z.url({ message: "Invalid organization website url" }),
         description: z.string(),
     })
     .strict();
@@ -482,8 +482,8 @@ export const zodOpinionContentInput = z
 export const zodOpinionContentOutput = z
     .string()
     .min(1)
-    .max(MAX_LENGTH_OPINION_HTML, {
-        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML)} characters`,
+    .max(MAX_LENGTH_OPINION_HTML_OUTPUT, {
+        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML_OUTPUT)} characters`,
     });
 export const zodAgreementType = z.enum(["agree", "disagree"]);
 export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);

--- a/services/load-testing/src/shared/shared.ts
+++ b/services/load-testing/src/shared/shared.ts
@@ -7,6 +7,7 @@ export const MAX_LENGTH_BODY = 1000;
 export const MAX_LENGTH_BODY_HTML = 3000; // Reserve extra space for HTML tags
 export const MAX_LENGTH_OPINION = 280;
 export const MAX_LENGTH_OPINION_HTML = 840; // Reserve extra space for HTML tags
+export const MAX_LENGTH_OPINION_HTML_OUTPUT = 3000; // Old value for database retro-compatibility of existing data
 export const MAX_LENGTH_NAME_CREATOR = 65;
 export const MAX_LENGTH_USERNAME = 20;
 export const MIN_LENGTH_USERNAME = 2;

--- a/services/load-testing/src/shared/types/dto-auth.ts
+++ b/services/load-testing/src/shared/types/dto-auth.ts
@@ -86,4 +86,3 @@ export type VerifyOtpReqBody = z.infer<typeof verifyOtpReqBody>;
 export type AuthenticateResponse = z.infer<typeof authenticate200>;
 export type VerifyOtp200 = z.infer<typeof verifyOtp200>;
 export type IsLoggedInResponse = z.infer<typeof isLoggedInResponse>;
-

--- a/services/load-testing/src/shared/types/zod.ts
+++ b/services/load-testing/src/shared/types/zod.ts
@@ -12,6 +12,7 @@ import {
     MAX_LENGTH_OPINION_HTML,
     MAX_LENGTH_USER_REPORT_EXPLANATION,
     validateHtmlStringCharacterCount,
+    MAX_LENGTH_OPINION_HTML_OUTPUT,
 } from "../shared.js";
 import { isValidPolisUrl } from "../utils/polis.js";
 import {
@@ -83,8 +84,7 @@ export const zodOrganization = z
     .object({
         name: z.string(),
         imageUrl: z.string(),
-        websiteUrl: z
-            .url({ message: "Invalid organization website url" }),
+        websiteUrl: z.url({ message: "Invalid organization website url" }),
         description: z.string(),
     })
     .strict();
@@ -482,8 +482,8 @@ export const zodOpinionContentInput = z
 export const zodOpinionContentOutput = z
     .string()
     .min(1)
-    .max(MAX_LENGTH_OPINION_HTML, {
-        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML)} characters`,
+    .max(MAX_LENGTH_OPINION_HTML_OUTPUT, {
+        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML_OUTPUT)} characters`,
     });
 export const zodAgreementType = z.enum(["agree", "disagree"]);
 export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);

--- a/services/math-updater/src/shared-backend/db.ts
+++ b/services/math-updater/src/shared-backend/db.ts
@@ -15,21 +15,26 @@ async function createPostgresClient(
     log: Pick<pino.BaseLogger, "info" | "error">,
     useReadReplica = false,
 ) {
-    const awsSecretId = useReadReplica && config.AWS_SECRET_ID_READ
-        ? config.AWS_SECRET_ID_READ
-        : config.AWS_SECRET_ID;
-    const awsSecretRegion = useReadReplica && config.AWS_SECRET_REGION_READ
-        ? config.AWS_SECRET_REGION_READ
-        : config.AWS_SECRET_REGION;
-    const dbHost = useReadReplica && config.DB_HOST_READ
-        ? config.DB_HOST_READ
-        : config.DB_HOST;
-    const dbPort = useReadReplica && config.DB_HOST_READ
-        ? config.DB_PORT_READ
-        : config.DB_PORT;
-    const connectionString = useReadReplica && config.CONNECTION_STRING_READ
-        ? config.CONNECTION_STRING_READ
-        : config.CONNECTION_STRING;
+    const awsSecretId =
+        useReadReplica && config.AWS_SECRET_ID_READ
+            ? config.AWS_SECRET_ID_READ
+            : config.AWS_SECRET_ID;
+    const awsSecretRegion =
+        useReadReplica && config.AWS_SECRET_REGION_READ
+            ? config.AWS_SECRET_REGION_READ
+            : config.AWS_SECRET_REGION;
+    const dbHost =
+        useReadReplica && config.DB_HOST_READ
+            ? config.DB_HOST_READ
+            : config.DB_HOST;
+    const dbPort =
+        useReadReplica && config.DB_HOST_READ
+            ? config.DB_PORT_READ
+            : config.DB_PORT;
+    const connectionString =
+        useReadReplica && config.CONNECTION_STRING_READ
+            ? config.CONNECTION_STRING_READ
+            : config.CONNECTION_STRING;
 
     if (
         config.NODE_ENV === "production" &&
@@ -109,7 +114,9 @@ async function createPostgresClient(
                 ssl: config.NODE_ENV === "production" ? "require" : undefined,
             });
         } catch (e) {
-            log.error(`Unable to connect to the database (${useReadReplica ? 'read replica' : 'primary'})`);
+            log.error(
+                `Unable to connect to the database (${useReadReplica ? "read replica" : "primary"})`,
+            );
             log.error(e);
             process.exit(1);
         }
@@ -133,7 +140,9 @@ export async function createDb(
     // Check if read replica config exists
     const hasReadReplica = !!(
         config.CONNECTION_STRING_READ ??
-        (config.AWS_SECRET_ID_READ && config.AWS_SECRET_REGION_READ && config.DB_HOST_READ)
+        (config.AWS_SECRET_ID_READ &&
+            config.AWS_SECRET_REGION_READ &&
+            config.DB_HOST_READ)
     );
 
     if (hasReadReplica) {
@@ -142,13 +151,17 @@ export async function createDb(
             logger: new DrizzleFastifyLogger(log),
         });
 
-        log.info("Connected to read replica - SELECTs will use replica, writes use primary");
+        log.info(
+            "Connected to read replica - SELECTs will use replica, writes use primary",
+        );
 
         // Use Drizzle's built-in withReplicas
         // Automatically routes SELECT queries to replica, writes to primary
         return withReplicas(primaryDb, [readDb]);
     } else {
-        log.info("No read replica configured, using primary for all operations");
+        log.info(
+            "No read replica configured, using primary for all operations",
+        );
         return primaryDb;
     }
 }

--- a/services/math-updater/src/shared-backend/schema.ts
+++ b/services/math-updater/src/shared-backend/schema.ts
@@ -27,7 +27,7 @@ const MAX_LENGTH_TITLE = 140;
 const MAX_LENGTH_BODY = 1000;
 const MAX_LENGTH_BODY_HTML = 3000; // Reserve extra space for HTML tags
 // const MAX_LENGTH_OPINION = 280;
-const MAX_LENGTH_OPINION_HTML = 840; // Reserve extra space for HTML tags
+const MAX_LENGTH_OPINION_HTML = 3000; // is lower now, kept this value For retro-compatibility
 const MAX_LENGTH_NAME_CREATOR = 65;
 const MAX_LENGTH_DESCRIPTION_CREATOR = 280;
 const MAX_LENGTH_USERNAME = 20;
@@ -1816,29 +1816,26 @@ export const notificationTable = pgTable(
 );
 
 // content changes over time as much as the conversation receives opinions and votes
-export const polisContentTable = pgTable(
-    "polis_content",
-    {
-        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-        conversationId: integer("conversation_id")
-            .references(() => conversationTable.id)
-            .notNull(), // not unique, there will be multiple rows over the life of the conversation
-        rawData: jsonb("raw_data").notNull(), // from external polis system
-        createdAt: timestamp("created_at", {
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-        updatedAt: timestamp("updated_at", {
-            // aiSummary may be set at a later data
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-    },
-);
+export const polisContentTable = pgTable("polis_content", {
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    conversationId: integer("conversation_id")
+        .references(() => conversationTable.id)
+        .notNull(), // not unique, there will be multiple rows over the life of the conversation
+    rawData: jsonb("raw_data").notNull(), // from external polis system
+    createdAt: timestamp("created_at", {
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+    updatedAt: timestamp("updated_at", {
+        // aiSummary may be set at a later data
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+});
 
 // one polisContent has many polisClusters
 export const polisClusterTable = pgTable("polis_cluster", {

--- a/services/math-updater/src/shared/shared.ts
+++ b/services/math-updater/src/shared/shared.ts
@@ -7,6 +7,7 @@ export const MAX_LENGTH_BODY = 1000;
 export const MAX_LENGTH_BODY_HTML = 3000; // Reserve extra space for HTML tags
 export const MAX_LENGTH_OPINION = 280;
 export const MAX_LENGTH_OPINION_HTML = 840; // Reserve extra space for HTML tags
+export const MAX_LENGTH_OPINION_HTML_OUTPUT = 3000; // Old value for database retro-compatibility of existing data
 export const MAX_LENGTH_NAME_CREATOR = 65;
 export const MAX_LENGTH_USERNAME = 20;
 export const MIN_LENGTH_USERNAME = 2;

--- a/services/math-updater/src/shared/types/dto-auth.ts
+++ b/services/math-updater/src/shared/types/dto-auth.ts
@@ -86,4 +86,3 @@ export type VerifyOtpReqBody = z.infer<typeof verifyOtpReqBody>;
 export type AuthenticateResponse = z.infer<typeof authenticate200>;
 export type VerifyOtp200 = z.infer<typeof verifyOtp200>;
 export type IsLoggedInResponse = z.infer<typeof isLoggedInResponse>;
-

--- a/services/math-updater/src/shared/types/zod.ts
+++ b/services/math-updater/src/shared/types/zod.ts
@@ -12,6 +12,7 @@ import {
     MAX_LENGTH_OPINION_HTML,
     MAX_LENGTH_USER_REPORT_EXPLANATION,
     validateHtmlStringCharacterCount,
+    MAX_LENGTH_OPINION_HTML_OUTPUT,
 } from "../shared.js";
 import { isValidPolisUrl } from "../utils/polis.js";
 import {
@@ -83,8 +84,7 @@ export const zodOrganization = z
     .object({
         name: z.string(),
         imageUrl: z.string(),
-        websiteUrl: z
-            .url({ message: "Invalid organization website url" }),
+        websiteUrl: z.url({ message: "Invalid organization website url" }),
         description: z.string(),
     })
     .strict();
@@ -482,8 +482,8 @@ export const zodOpinionContentInput = z
 export const zodOpinionContentOutput = z
     .string()
     .min(1)
-    .max(MAX_LENGTH_OPINION_HTML, {
-        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML)} characters`,
+    .max(MAX_LENGTH_OPINION_HTML_OUTPUT, {
+        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML_OUTPUT)} characters`,
     });
 export const zodAgreementType = z.enum(["agree", "disagree"]);
 export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);

--- a/services/shared-backend/src/db.ts
+++ b/services/shared-backend/src/db.ts
@@ -14,21 +14,26 @@ async function createPostgresClient(
     log: Pick<pino.BaseLogger, "info" | "error">,
     useReadReplica = false,
 ) {
-    const awsSecretId = useReadReplica && config.AWS_SECRET_ID_READ
-        ? config.AWS_SECRET_ID_READ
-        : config.AWS_SECRET_ID;
-    const awsSecretRegion = useReadReplica && config.AWS_SECRET_REGION_READ
-        ? config.AWS_SECRET_REGION_READ
-        : config.AWS_SECRET_REGION;
-    const dbHost = useReadReplica && config.DB_HOST_READ
-        ? config.DB_HOST_READ
-        : config.DB_HOST;
-    const dbPort = useReadReplica && config.DB_HOST_READ
-        ? config.DB_PORT_READ
-        : config.DB_PORT;
-    const connectionString = useReadReplica && config.CONNECTION_STRING_READ
-        ? config.CONNECTION_STRING_READ
-        : config.CONNECTION_STRING;
+    const awsSecretId =
+        useReadReplica && config.AWS_SECRET_ID_READ
+            ? config.AWS_SECRET_ID_READ
+            : config.AWS_SECRET_ID;
+    const awsSecretRegion =
+        useReadReplica && config.AWS_SECRET_REGION_READ
+            ? config.AWS_SECRET_REGION_READ
+            : config.AWS_SECRET_REGION;
+    const dbHost =
+        useReadReplica && config.DB_HOST_READ
+            ? config.DB_HOST_READ
+            : config.DB_HOST;
+    const dbPort =
+        useReadReplica && config.DB_HOST_READ
+            ? config.DB_PORT_READ
+            : config.DB_PORT;
+    const connectionString =
+        useReadReplica && config.CONNECTION_STRING_READ
+            ? config.CONNECTION_STRING_READ
+            : config.CONNECTION_STRING;
 
     if (
         config.NODE_ENV === "production" &&
@@ -108,7 +113,9 @@ async function createPostgresClient(
                 ssl: config.NODE_ENV === "production" ? "require" : undefined,
             });
         } catch (e) {
-            log.error(`Unable to connect to the database (${useReadReplica ? 'read replica' : 'primary'})`);
+            log.error(
+                `Unable to connect to the database (${useReadReplica ? "read replica" : "primary"})`,
+            );
             log.error(e);
             process.exit(1);
         }
@@ -132,7 +139,9 @@ export async function createDb(
     // Check if read replica config exists
     const hasReadReplica = !!(
         config.CONNECTION_STRING_READ ??
-        (config.AWS_SECRET_ID_READ && config.AWS_SECRET_REGION_READ && config.DB_HOST_READ)
+        (config.AWS_SECRET_ID_READ &&
+            config.AWS_SECRET_REGION_READ &&
+            config.DB_HOST_READ)
     );
 
     if (hasReadReplica) {
@@ -141,13 +150,17 @@ export async function createDb(
             logger: new DrizzleFastifyLogger(log),
         });
 
-        log.info("Connected to read replica - SELECTs will use replica, writes use primary");
+        log.info(
+            "Connected to read replica - SELECTs will use replica, writes use primary",
+        );
 
         // Use Drizzle's built-in withReplicas
         // Automatically routes SELECT queries to replica, writes to primary
         return withReplicas(primaryDb, [readDb]);
     } else {
-        log.info("No read replica configured, using primary for all operations");
+        log.info(
+            "No read replica configured, using primary for all operations",
+        );
         return primaryDb;
     }
 }

--- a/services/shared-backend/src/schema.ts
+++ b/services/shared-backend/src/schema.ts
@@ -26,7 +26,7 @@ const MAX_LENGTH_TITLE = 140;
 const MAX_LENGTH_BODY = 1000;
 const MAX_LENGTH_BODY_HTML = 3000; // Reserve extra space for HTML tags
 // const MAX_LENGTH_OPINION = 280;
-const MAX_LENGTH_OPINION_HTML = 840; // Reserve extra space for HTML tags
+const MAX_LENGTH_OPINION_HTML = 3000; // is lower now, kept this value For retro-compatibility
 const MAX_LENGTH_NAME_CREATOR = 65;
 const MAX_LENGTH_DESCRIPTION_CREATOR = 280;
 const MAX_LENGTH_USERNAME = 20;
@@ -1815,29 +1815,26 @@ export const notificationTable = pgTable(
 );
 
 // content changes over time as much as the conversation receives opinions and votes
-export const polisContentTable = pgTable(
-    "polis_content",
-    {
-        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-        conversationId: integer("conversation_id")
-            .references(() => conversationTable.id)
-            .notNull(), // not unique, there will be multiple rows over the life of the conversation
-        rawData: jsonb("raw_data").notNull(), // from external polis system
-        createdAt: timestamp("created_at", {
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-        updatedAt: timestamp("updated_at", {
-            // aiSummary may be set at a later data
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-    },
-);
+export const polisContentTable = pgTable("polis_content", {
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    conversationId: integer("conversation_id")
+        .references(() => conversationTable.id)
+        .notNull(), // not unique, there will be multiple rows over the life of the conversation
+    rawData: jsonb("raw_data").notNull(), // from external polis system
+    createdAt: timestamp("created_at", {
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+    updatedAt: timestamp("updated_at", {
+        // aiSummary may be set at a later data
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+});
 
 // one polisContent has many polisClusters
 export const polisClusterTable = pgTable("polis_cluster", {

--- a/services/shared/src/shared.ts
+++ b/services/shared/src/shared.ts
@@ -6,6 +6,7 @@ export const MAX_LENGTH_BODY = 1000;
 export const MAX_LENGTH_BODY_HTML = 3000; // Reserve extra space for HTML tags
 export const MAX_LENGTH_OPINION = 280;
 export const MAX_LENGTH_OPINION_HTML = 840; // Reserve extra space for HTML tags
+export const MAX_LENGTH_OPINION_HTML_OUTPUT = 3000; // Old value for database retro-compatibility of existing data
 export const MAX_LENGTH_NAME_CREATOR = 65;
 export const MAX_LENGTH_USERNAME = 20;
 export const MIN_LENGTH_USERNAME = 2;

--- a/services/shared/src/types/dto-auth.ts
+++ b/services/shared/src/types/dto-auth.ts
@@ -85,4 +85,3 @@ export type VerifyOtpReqBody = z.infer<typeof verifyOtpReqBody>;
 export type AuthenticateResponse = z.infer<typeof authenticate200>;
 export type VerifyOtp200 = z.infer<typeof verifyOtp200>;
 export type IsLoggedInResponse = z.infer<typeof isLoggedInResponse>;
-

--- a/services/shared/src/types/zod.ts
+++ b/services/shared/src/types/zod.ts
@@ -11,6 +11,7 @@ import {
     MAX_LENGTH_OPINION_HTML,
     MAX_LENGTH_USER_REPORT_EXPLANATION,
     validateHtmlStringCharacterCount,
+    MAX_LENGTH_OPINION_HTML_OUTPUT,
 } from "../shared.js";
 import { isValidPolisUrl } from "../utils/polis.js";
 import {
@@ -82,8 +83,7 @@ export const zodOrganization = z
     .object({
         name: z.string(),
         imageUrl: z.string(),
-        websiteUrl: z
-            .url({ message: "Invalid organization website url" }),
+        websiteUrl: z.url({ message: "Invalid organization website url" }),
         description: z.string(),
     })
     .strict();
@@ -481,8 +481,8 @@ export const zodOpinionContentInput = z
 export const zodOpinionContentOutput = z
     .string()
     .min(1)
-    .max(MAX_LENGTH_OPINION_HTML, {
-        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML)} characters`,
+    .max(MAX_LENGTH_OPINION_HTML_OUTPUT, {
+        message: `Raw HTML content exceeds maximum length of ${String(MAX_LENGTH_OPINION_HTML_OUTPUT)} characters`,
     });
 export const zodAgreementType = z.enum(["agree", "disagree"]);
 export const zodVotingOption = z.enum(["agree", "disagree", "pass"]);


### PR DESCRIPTION
## Summary
- Keep DB column at varchar(3000) to accommodate existing data
- Add separate `MAX_LENGTH_OPINION_HTML_OUTPUT` constant (3000) for output validation
- Keep `MAX_LENGTH_OPINION_HTML` (840) for input validation of new opinions
- Regenerate migration to only include `is_closed` column addition

## Problem
The previous migration (V0033__wild_magneto) incorrectly tried to shrink the `opinion_content.content` column from varchar(3000) to varchar(840). This would fail in production if any existing opinions exceed 840 characters.

## Solution
- New opinions are validated at 840 chars (input via `zodOpinionContentInput`)
- Existing opinions > 840 chars can still be read (output via `zodOpinionContentOutput`)
- No data truncation or migration failures in production

## Test plan
- [ ] Verify migration only contains `is_closed` column addition
- [ ] Verify new opinion input is limited to 840 chars
- [ ] Verify existing opinions > 840 chars can be fetched without validation errors

## Deploy
api, agora, math-updater