### PR TITLE
fix(agora): improve opinion writing guidelines dialog UX on mobile

### DIFF
--- a/services/agora/src/components/post/comments/OpinionWritingGuidelinesDialog.vue
+++ b/services/agora/src/components/post/comments/OpinionWritingGuidelinesDialog.vue
@@ -2,68 +2,79 @@
   <div>
     <q-dialog v-model="showDialog" position="bottom">
       <ZKBottomDialogContainer>
-        <div class="title">{{ t("title") }}</div>
-
-        <div class="guideline">
-          <div class="guideline-title">{{ t("singleIdeaTitle") }}</div>
-          <div class="guideline-description">
-            {{ t("singleIdeaDescription") }}
-          </div>
-          <ul class="examples-list">
-            <li class="example-good">
-              ✅ {{ t("singleIdeaExampleGood") }}
-            </li>
-            <li class="example-bad">❌ {{ t("singleIdeaExampleBad") }}</li>
-          </ul>
+        <div class="header">
+          <div class="title">{{ t("title") }}</div>
+          <ZKButton
+            button-type="icon"
+            aria-label="Close"
+            @click="showDialog = false"
+          >
+            <ZKIcon color="#6d6a74" name="mdi-close" size="1.2rem" />
+          </ZKButton>
         </div>
 
-        <div class="guideline">
-          <div class="guideline-title">{{ t("easyVoteTitle") }}</div>
-          <div class="guideline-description">
-            {{ t("easyVoteDescription") }}
+        <div class="guidelines-content">
+          <div class="guideline">
+            <div class="guideline-title">{{ t("singleIdeaTitle") }}</div>
+            <div class="guideline-description">
+              {{ t("singleIdeaDescription") }}
+            </div>
+            <ul class="examples-list">
+              <li class="example-good">
+                ✅ {{ t("singleIdeaExampleGood") }}
+              </li>
+              <li class="example-bad">❌ {{ t("singleIdeaExampleBad") }}</li>
+            </ul>
           </div>
-          <ul class="examples-list">
-            <li class="example-good">✅ {{ t("easyVoteExampleGood") }}</li>
-            <li class="example-bad">❌ {{ t("easyVoteExampleBad") }}</li>
-          </ul>
-        </div>
 
-        <div class="guideline">
-          <div class="guideline-title">{{ t("keepBriefTitle") }}</div>
-          <div class="guideline-description">
-            {{ t("keepBriefDescription") }}
+          <div class="guideline">
+            <div class="guideline-title">{{ t("easyVoteTitle") }}</div>
+            <div class="guideline-description">
+              {{ t("easyVoteDescription") }}
+            </div>
+            <ul class="examples-list">
+              <li class="example-good">✅ {{ t("easyVoteExampleGood") }}</li>
+              <li class="example-bad">❌ {{ t("easyVoteExampleBad") }}</li>
+            </ul>
           </div>
-          <ul class="examples-list">
-            <li class="example-good">✅ {{ t("keepBriefExampleGood") }}</li>
-            <li class="example-bad">❌ {{ t("keepBriefExampleBad") }}</li>
-          </ul>
-        </div>
 
-        <div class="guideline">
-          <div class="guideline-title">{{ t("beClearTitle") }}</div>
-          <div class="guideline-description">
-            {{ t("beClearDescription") }}
+          <div class="guideline">
+            <div class="guideline-title">{{ t("keepBriefTitle") }}</div>
+            <div class="guideline-description">
+              {{ t("keepBriefDescription") }}
+            </div>
+            <ul class="examples-list">
+              <li class="example-good">✅ {{ t("keepBriefExampleGood") }}</li>
+              <li class="example-bad">❌ {{ t("keepBriefExampleBad") }}</li>
+            </ul>
           </div>
-          <ul class="examples-list">
-            <li class="example-good">✅ {{ t("beClearExampleGood") }}</li>
-            <li class="example-bad">❌ {{ t("beClearExampleBad") }}</li>
-          </ul>
-        </div>
 
-        <div class="guideline">
-          <div class="guideline-title">{{ t("dontCombineTitle") }}</div>
-          <div class="guideline-description">
-            {{ t("dontCombineDescription") }}
+          <div class="guideline">
+            <div class="guideline-title">{{ t("beClearTitle") }}</div>
+            <div class="guideline-description">
+              {{ t("beClearDescription") }}
+            </div>
+            <ul class="examples-list">
+              <li class="example-good">✅ {{ t("beClearExampleGood") }}</li>
+              <li class="example-bad">❌ {{ t("beClearExampleBad") }}</li>
+            </ul>
           </div>
-          <ul class="examples-list">
-            <li class="example-bad">❌ {{ t("dontCombineExampleBad") }}</li>
-            <li class="example-good">
-              ✅ {{ t("dontCombineExampleGood1") }}
-            </li>
-            <li class="example-good">
-              ✅ {{ t("dontCombineExampleGood2") }}
-            </li>
-          </ul>
+
+          <div class="guideline">
+            <div class="guideline-title">{{ t("dontCombineTitle") }}</div>
+            <div class="guideline-description">
+              {{ t("dontCombineDescription") }}
+            </div>
+            <ul class="examples-list">
+              <li class="example-bad">❌ {{ t("dontCombineExampleBad") }}</li>
+              <li class="example-good">
+                ✅ {{ t("dontCombineExampleGood1") }}
+              </li>
+              <li class="example-good">
+                ✅ {{ t("dontCombineExampleGood2") }}
+              </li>
+            </ul>
+          </div>
         </div>
       </ZKBottomDialogContainer>
     </q-dialog>
@@ -72,6 +83,8 @@
 
 <script setup lang="ts">
 import ZKBottomDialogContainer from "src/components/ui-library/ZKBottomDialogContainer.vue";
+import ZKButton from "src/components/ui-library/ZKButton.vue";
+import ZKIcon from "src/components/ui-library/ZKIcon.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 
 import {
@@ -87,10 +100,23 @@ const showDialog = defineModel<boolean>({ required: true });
 </script>
 
 <style lang="scss" scoped>
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 0.5rem;
+  flex-shrink: 0;
+}
+
 .title {
   font-size: 1.1rem;
   font-weight: var(--font-weight-medium);
-  padding-bottom: 1rem;
+}
+
+.guidelines-content {
+  max-height: 60vh;
+  max-height: 60dvh;
+  overflow-y: auto;
 }
 
 .guideline {

--- a/services/agora/src/components/ui-library/ZKBottomDialogContainer.vue
+++ b/services/agora/src/components/ui-library/ZKBottomDialogContainer.vue
@@ -13,5 +13,6 @@
   background-color: white;
   border-radius: 25px 25px 0 0;
   width: min(30rem, 100%);
+  overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
## Summary
- Fix opinion writing guidelines dialog taking up entire screen on mobile, making it impossible to dismiss
- Add close button (X) in dialog header for explicit dismissal
- Add scrollable content area with max-height constraint (60dvh)

## Test plan
- [ ] Open app on mobile viewport (~486px width)
- [ ] Tap comment composer to expand it
- [ ] Tap the info icon (i)
- [ ] Verify dialog shows header with close button + scrollable content
- [ ] Verify backdrop area is visible above dialog for tap-to-dismiss
- [ ] Verify close button (X) dismisses dialog
- [ ] Verify content scrolls within the constrained area