### PR TITLE
fix(agora): fix tiptap editor cropping on narrow screens

### DIFF
--- a/services/agora/src/components/editor/Editor.vue
+++ b/services/agora/src/components/editor/Editor.vue
@@ -362,6 +362,12 @@ watch(
   padding-bottom: 0rem;
 }
 
+.editor-wrapper {
+  width: 100%;
+  min-width: 0;
+  overflow: hidden;
+}
+
 .toolbar {
   display: flex;
   gap: 0.25rem;
@@ -393,6 +399,8 @@ watch(
   outline: none;
   font-size: 1rem;
   line-height: normal;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .editor :deep(.ProseMirror p) {

--- a/services/agora/src/components/navigation/FloatingBottomContainer.vue
+++ b/services/agora/src/components/navigation/FloatingBottomContainer.vue
@@ -12,6 +12,8 @@
 .bottomBar {
   position: fixed;
   bottom: 0rem;
+  left: 50%;
+  transform: translateX(-50%);
   width: min(35rem, 100%);
   z-index: 100;
   padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));


### PR DESCRIPTION
## Summary
- Fix editor content extending beyond container on mobile/narrow screens
- Center the floating bottom container to match centered content above
- Add proper text wrapping rules to ProseMirror editor

## Test plan
- [ ] Open DevTools and set viewport to narrow width (320px, 486px)
- [ ] Navigate to a conversation with comment composer
- [ ] Verify editor no longer extends beyond its container
- [ ] Verify editor is centered and aligned with content above
- [ ] Test on actual mobile device

Deploy: agora