### PR TITLE
feat(api): allow organization members to close/reopen organization posts

### DIFF
--- a/services/api/src/service/authUtil.ts
+++ b/services/api/src/service/authUtil.ts
@@ -157,6 +157,30 @@ export async function isUserPartOfOrganization({
     return result[0].organizationId;
 }
 
+interface IsUserPartOfOrganizationByIdProps {
+    db: PostgresDatabase;
+    userId: string;
+    organizationId: number;
+}
+
+export async function isUserPartOfOrganizationById({
+    db,
+    userId,
+    organizationId,
+}: IsUserPartOfOrganizationByIdProps): Promise<boolean> {
+    const result = await db
+        .select({ id: userOrganizationMappingTable.id })
+        .from(userOrganizationMappingTable)
+        .where(
+            and(
+                eq(userOrganizationMappingTable.userId, userId),
+                eq(userOrganizationMappingTable.organizationId, organizationId),
+            ),
+        )
+        .limit(1);
+    return result.length > 0;
+}
+
 interface GetDeviceStatusParams {
     db: PostgresDatabase;
     didWrite: string;

--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -426,6 +426,7 @@ export async function closeConversation({
             conversationId: conversationTable.id,
             authorId: conversationTable.authorId,
             isClosed: conversationTable.isClosed,
+            organizationId: conversationTable.organizationId,
         })
         .from(conversationTable)
         .where(eq(conversationTable.slugId, conversationSlugId))
@@ -436,8 +437,19 @@ export async function closeConversation({
         throw httpErrors.notFound("Conversation not found");
     }
 
-    // Check ownership in-memory
-    if (conversation[0].authorId !== userId) {
+    // Check authorization: user must be author OR member of the conversation's organization
+    const isAuthor = conversation[0].authorId === userId;
+    let isAuthorized = isAuthor;
+
+    if (!isAuthorized && conversation[0].organizationId !== null) {
+        isAuthorized = await authUtilService.isUserPartOfOrganizationById({
+            db,
+            userId,
+            organizationId: conversation[0].organizationId,
+        });
+    }
+
+    if (!isAuthorized) {
         return { success: false, reason: "not_allowed" };
     }
 
@@ -472,6 +484,7 @@ export async function openConversation({
             conversationId: conversationTable.id,
             authorId: conversationTable.authorId,
             isClosed: conversationTable.isClosed,
+            organizationId: conversationTable.organizationId,
         })
         .from(conversationTable)
         .where(eq(conversationTable.slugId, conversationSlugId))
@@ -482,8 +495,19 @@ export async function openConversation({
         throw httpErrors.notFound("Conversation not found");
     }
 
-    // Check ownership in-memory
-    if (conversation[0].authorId !== userId) {
+    // Check authorization: user must be author OR member of the conversation's organization
+    const isAuthor = conversation[0].authorId === userId;
+    let isAuthorized = isAuthor;
+
+    if (!isAuthorized && conversation[0].organizationId !== null) {
+        isAuthorized = await authUtilService.isUserPartOfOrganizationById({
+            db,
+            userId,
+            organizationId: conversation[0].organizationId,
+        });
+    }
+
+    if (!isAuthorized) {
         return { success: false, reason: "not_allowed" };
     }
 


### PR DESCRIPTION
## Summary
- Allow any organization member (not just the author) to close/reopen organization posts
- Individual posts still require the author to close/reopen

## Test plan
- [ ] Author closes their individual post → should work
- [ ] Author closes their organization post → should work
- [ ] Org member (non-author) closes an organization post → should now work
- [ ] Non-member closes an organization post → should fail with "not_allowed"
- [ ] Non-author closes an individual post → should fail with "not_allowed"
- [ ] Same scenarios for reopening conversations