### PR TITLE
fix(app): allow pnpm build scripts for sentry-cli and esbuild

### DIFF
--- a/services/app/package.json
+++ b/services/app/package.json
@@ -57,5 +57,11 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "unified": "^11.0.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@sentry/cli",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
These packages need to run post-install scripts to download platform-specific binaries. Without this, Netlify builds fail due to pnpm's security feature that blocks build scripts by default.

Deploy: app