### PR TITLE
fix(app): improve mobile layout for landing page sections

### DIFF
--- a/services/app/src/lib/components/landing/ForCitizens.svelte
+++ b/services/app/src/lib/components/landing/ForCitizens.svelte
@@ -16,8 +16,9 @@
     />
     <div
       class="
-        relative z-10 grid grid-cols-1 items-center gap-12 px-20 py-24
-        md:grid-cols-2
+        relative z-10 grid grid-cols-1 items-center gap-12 px-6 py-12
+        sm:px-12 sm:py-16
+        md:grid-cols-2 md:px-20 md:py-24
       "
     >
       <div class="flex flex-col gap-2">
@@ -27,7 +28,12 @@
         <p class="text-2xl leading-[1.3] tracking-[-0.24px] text-text-primary">
           {m.citizens_description()}
         </p>
-        <div class="mt-6">
+        <div
+          class="
+            mt-6 flex justify-center
+            md:justify-start
+          "
+        >
           <GradientButton
             href="https://www.agoracitizen.app/"
             variant="primary"

--- a/services/app/src/lib/components/landing/ForFacilitators.svelte
+++ b/services/app/src/lib/components/landing/ForFacilitators.svelte
@@ -9,24 +9,28 @@
       chip: () => m.facilitators_chip_polis(),
       text: () => m.facilitators_feature_polis(),
       source: () => m.facilitators_feature_polis_source(),
+      sourceUrl: "https://pol.is/",
     },
     {
       img: "/images/screenshot-sensemaker.png",
       chip: () => m.facilitators_chip_sensemaker(),
       text: () => m.facilitators_feature_sensemaker(),
       source: () => m.facilitators_feature_sensemaker_source(),
+      sourceUrl: "https://jigsaw-code.github.io/sensemaking-tools/",
     },
     {
       img: "/images/screenshot-auth.png",
       chip: () => m.facilitators_chip_auth(),
       text: () => m.facilitators_feature_auth(),
       source: null,
+      sourceUrl: null,
     },
     {
       img: "/images/screenshot-demographics.png",
       chip: () => m.facilitators_chip_demographics(),
       text: () => m.facilitators_feature_demographics(),
       source: null,
+      sourceUrl: null,
     },
   ];
 </script>
@@ -39,7 +43,7 @@
       </p>
       <p
         class="
-          mt-2 text-base leading-[1.4] tracking-[-0.16px] text-text-secondary
+          mt-2 text-2xl leading-[1.3] tracking-[-0.24px] text-text-primary
         "
       >
         {m.facilitators_description()}
@@ -48,8 +52,8 @@
 
     <div
       class="
-        mb-8 flex flex-col gap-[13px]
-        md:flex-row
+        mb-8 flex flex-col items-center gap-[13px]
+        md:flex-row md:items-start
       "
     >
       {#each features as feature (feature.img)}
@@ -72,18 +76,30 @@
           </span>
           <p
             class="
-              text-base leading-[1.4] tracking-[-0.16px] text-text-secondary
+              pl-2 text-base leading-[1.4] tracking-[-0.16px]
+              text-text-secondary
             "
           >
-            {feature.text()}{#if feature.source}<GradientText angle={81}
-                >{feature.source()}</GradientText
-              >{/if}
+            {feature.text()}{#if feature.source}{#if feature.sourceUrl}<a
+                  href={feature.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="hover:underline"
+                  ><GradientText angle={81}>{feature.source()}</GradientText></a
+                >{:else}<GradientText angle={81}
+                  >{feature.source()}</GradientText
+                >{/if}{/if}
           </p>
         </div>
       {/each}
     </div>
 
-    <div class="flex justify-end">
+    <div
+      class="
+        flex justify-center
+        md:justify-end
+      "
+    >
       <GradientButton
         href="https://www.agoracitizen.app/conversation/new/create"
         variant="primary"

--- a/services/app/src/lib/components/landing/HeroSection.svelte
+++ b/services/app/src/lib/components/landing/HeroSection.svelte
@@ -27,8 +27,9 @@
     </div>
     <div
       class="
-        relative z-10 flex flex-col gap-8 px-20 py-24
-        md:max-w-[550px]
+        relative z-10 flex flex-col gap-8 px-6 py-12
+        sm:px-12 sm:py-16
+        md:max-w-[550px] md:px-20 md:py-24
       "
     >
       <p
@@ -39,7 +40,12 @@
         <GradientText>{m.hero_tagline()}</GradientText>
       </p>
 
-      <div class="flex gap-3">
+      <div
+        class="
+          flex flex-col gap-3
+          sm:flex-row
+        "
+      >
         <GradientButton href="#facilitators" variant="primary">
           {m.hero_cta_primary()}
         </GradientButton>

--- a/services/app/src/lib/components/landing/OurTeam.svelte
+++ b/services/app/src/lib/components/landing/OurTeam.svelte
@@ -63,7 +63,12 @@
             </p>
           </div>
           {#if index === 0}
-            <div class="mt-16 flex justify-center">
+            <div
+              class="
+                mt-16 hidden justify-center
+                md:flex
+              "
+            >
               <GradientArrow />
             </div>
           {/if}

--- a/services/app/src/lib/components/landing/UseCases.svelte
+++ b/services/app/src/lib/components/landing/UseCases.svelte
@@ -236,26 +236,39 @@
 
     <div
       class="
-        grid grid-cols-1 gap-x-5 gap-y-10
-        md:grid-cols-2
+        grid grid-cols-1 justify-items-center gap-x-5 gap-y-10
+        md:grid-cols-2 md:justify-items-start
       "
     >
       {#each useCases as useCase, i (i)}
-        <div class="flex gap-6">
+        <div
+          class="
+            flex flex-col items-center gap-4
+            sm:flex-row sm:items-start sm:gap-6
+          "
+        >
           <div
             class="
-              size-[192px] shrink-0 overflow-hidden rounded-2xl
+              size-[160px] shrink-0 overflow-hidden rounded-2xl
               bg-[linear-gradient(115deg,var(--color-gradient-light-purple)_46%,var(--color-gradient-light-blue)_100%)]
+              sm:size-[192px]
             "
           >
             <!-- eslint-disable-next-line svelte/no-at-html-tags -- SVG is static developer-controlled content -->
             {@html useCase.svg}
           </div>
-          <div class="flex min-w-[323px] flex-col gap-[6px] pt-6">
+          <div
+            class="
+              flex min-w-0 flex-col gap-[6px]
+              sm:pt-6
+              md:min-w-[323px]
+            "
+          >
             <span
               class="
-                inline-flex w-fit rounded-[9px] bg-surface-hover px-2 py-[7px]
-                text-base/4 tracking-[-0.16px]
+                inline-flex w-fit self-center rounded-[9px] bg-surface-hover
+                px-2 py-[7px] text-base/4 tracking-[-0.16px]
+                sm:self-start
               "
             >
               <GradientText angle={154}>{useCase.chip()}</GradientText>
@@ -270,7 +283,7 @@
             </p>
             <ul
               class="
-                list-disc pl-4 text-base leading-[1.4] tracking-[-0.16px]
+                list-disc pl-6 text-base leading-[1.4] tracking-[-0.16px]
                 text-text-secondary
               "
             >


### PR DESCRIPTION
## Summary
- Fix mobile layout issues across landing page sections
- Add responsive padding and button stacking in HeroSection
- Center feature cards and improve text styling in ForFacilitators  
- Add clickable links for @Polis and @Jigsaw Sensemaker
- Hide decorative arrow on mobile in OurTeam section
- Center use case cards and chips on mobile in UseCases

## Test plan
- [ ] Verify hero buttons stack vertically and are fully visible on mobile (375px)
- [ ] Verify ForFacilitators cards are centered on mobile
- [ ] Verify @Polis and @Jigsaw Sensemaker links open in new tabs
- [ ] Verify team arrow is hidden on mobile, visible on desktop
- [ ] Verify UseCases cards and chips are centered on mobile
- [ ] Verify all sections look correct on desktop (1280px)