### PR TITLE
fix(app): increase spacing between mobile nav drawer items

### DIFF
--- a/services/app/src/lib/ui/shared/mobile-nav-drawer.svelte
+++ b/services/app/src/lib/ui/shared/mobile-nav-drawer.svelte
@@ -54,7 +54,7 @@
 
   <!-- Nav links using Chip -->
   <nav
-    class="flex flex-1 flex-col gap-2 overflow-y-auto px-5 py-2"
+    class="flex flex-1 flex-col gap-3 overflow-y-auto px-5 py-2"
     aria-label="Mobile navigation"
   >
     {#each links as link (link.href)}


### PR DESCRIPTION
## Summary
- Increase gap between navigation links in the mobile side drawer from `gap-2` (8px) to `gap-3` (12px) for better touch target separation

## Test plan
- [ ] Open app on mobile viewport
- [ ] Open the side navigation drawer
- [ ] Verify nav items have more breathing room between them