### PR TITLE
fix(app): improve landing page mobile responsiveness and UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -670,6 +670,23 @@ Key variables:
 - **Component Hierarchy**: Routes → Components → UI (keep routes simple)
 - **SSR Safety**: Don't use module-level `$state()` for user data
 
+### Icons
+
+Icons use **Iconify via Tailwind CSS v4** (`@iconify/tailwind4` plugin). Never use inline SVGs for standard icons — use the `icon-[collection--name]` class pattern instead.
+
+**Available collections**: `lucide` (UI icons), `simple-icons` (brand logos)
+
+**Usage**: `<span class="icon-[lucide--menu] h-6 w-6"></span>`
+
+**Applying the brand gradient to icons**: Use the `gradient-primary` Tailwind utility class alongside the icon class. The iconify plugin renders icons as CSS masks, so the gradient background shows through the icon shape:
+```svelte
+<span class="icon-[lucide--menu] h-6 w-6 gradient-primary"></span>
+```
+
+**Gradient utilities** (defined in `app.css`): `gradient-primary` (purple→blue with hover), `gradient-secondary` (light purple→blue), `gradient-chip` (nav chip style), `gradient-border` / `gradient-border-light`
+
+**Icon wrapper components** are in `$ui/shared/icons/` for social/external link icons (e.g., `icon-link-github.svelte`).
+
 ### Development
 
 ```bash

--- a/services/app/src/lib/components/landing/for-facilitators.svelte
+++ b/services/app/src/lib/components/landing/for-facilitators.svelte
@@ -6,6 +6,7 @@
   import * as m from "$lib/paraglide/messages.js";
   import Chip from "$ui/shared/chip.svelte";
   import GradientButton from "$ui/shared/gradient-button.svelte";
+  import GradientLink from "$ui/shared/gradient-link.svelte";
   import GradientText from "$ui/shared/gradient-text.svelte";
   import Text from "$ui/shared/text.svelte";
 
@@ -100,12 +101,8 @@
           </div>
           <Chip>{feature.chip()}</Chip>
           <Text size="base" class="pl-2 text-secondary-foreground">
-            {feature.text()}{#if feature.source}{#if feature.sourceUrl}<a
-                  href={feature.sourceUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="hover:underline"
-                  ><GradientText angle={81}>{feature.source()}</GradientText></a
+            {feature.text()}{#if feature.source}{#if feature.sourceUrl}<GradientLink
+                  href={feature.sourceUrl}>{feature.source()}</GradientLink
                 >{:else}<GradientText angle={81}
                   >{feature.source()}</GradientText
                 >{/if}{/if}

--- a/services/app/src/lib/components/landing/header.svelte
+++ b/services/app/src/lib/components/landing/header.svelte
@@ -74,31 +74,13 @@
       type="button"
       class="
         inline-flex items-center justify-center rounded-md p-2
-        text-muted-foreground
         hover:bg-zinc-100
         lg:hidden
       "
       onclick={() => (mobileMenuOpen = true)}
       aria-label="Open navigation menu"
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <line x1="4" x2="20" y1="12" y2="12" /><line
-          x1="4"
-          x2="20"
-          y1="6"
-          y2="6"
-        /><line x1="4" x2="20" y1="18" y2="18" />
-      </svg>
+      <span class="icon-[lucide--menu] h-6 w-6 gradient-primary"></span>
     </button>
   {/snippet}
 </TopBar>

--- a/services/app/src/lib/components/landing/pricing.svelte
+++ b/services/app/src/lib/components/landing/pricing.svelte
@@ -5,7 +5,13 @@
   import Text from "$ui/shared/text.svelte";
 </script>
 
-<section id="pricing" class="px-8 py-20">
+<section
+  id="pricing"
+  class="
+    px-4 py-20
+    sm:px-8
+  "
+>
   <div class="mx-auto max-w-[1120px]">
     <Text size="base" weight="bold" class="mb-2 text-center">
       <GradientText angle={174}>{m.pricing_label()}</GradientText>
@@ -21,7 +27,12 @@
       "
     >
       <!-- Tier 1: Agora Lite -->
-      <div class="flex flex-1 flex-col rounded-2xl border border-border p-6">
+      <div
+        class="
+          flex flex-1 flex-col rounded-2xl border border-border p-4
+          sm:p-6
+        "
+      >
         <Text size="xl" weight="bold">
           <GradientText>{m.pricing_lite_name()}</GradientText>
         </Text>
@@ -29,7 +40,7 @@
           {m.pricing_lite_desc()}
         </Text>
         <div class="mt-4 flex flex-col pb-10">
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <GradientText angle={107} class="text-xl">✓</GradientText>
             <Text
               size="sm"
@@ -40,7 +51,7 @@
               {m.pricing_lite_feature_1()}
             </Text>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <GradientText angle={107} class="text-xl">✓</GradientText>
             <Text
               size="sm"
@@ -55,7 +66,12 @@
       </div>
 
       <!-- Tier 2: Agora Pro -->
-      <div class="flex flex-1 flex-col rounded-2xl border border-border p-6">
+      <div
+        class="
+          flex flex-1 flex-col rounded-2xl border border-border p-4
+          sm:p-6
+        "
+      >
         <Text size="xl" weight="bold">
           <GradientText>{m.pricing_pro_name()}</GradientText>
         </Text>
@@ -63,7 +79,7 @@
           {m.pricing_pro_desc()}
         </Text>
         <div class="mt-4 flex flex-col pb-10">
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <GradientText angle={107} class="text-xl">✓</GradientText>
             <Text
               size="sm"
@@ -74,7 +90,7 @@
               {m.pricing_pro_feature_1()}
             </Text>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <GradientText angle={107} class="text-xl">✓</GradientText>
             <Text
               size="sm"
@@ -85,7 +101,7 @@
               {m.pricing_pro_feature_2()}
             </Text>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <GradientText angle={107} class="text-xl">✓</GradientText>
             <Text
               size="sm"
@@ -100,7 +116,12 @@
       </div>
 
       <!-- Tier 3: Facilitation & Consulting -->
-      <div class="flex flex-1 flex-col rounded-2xl border border-border p-6">
+      <div
+        class="
+          flex flex-1 flex-col rounded-2xl border border-border p-4
+          sm:p-6
+        "
+      >
         <Text size="xl" weight="bold">
           <GradientText>{m.pricing_consulting_name()}</GradientText>
         </Text>
@@ -108,7 +129,7 @@
           {m.pricing_consulting_desc()}
         </Text>
         <div class="mt-4 flex flex-col pb-10">
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <GradientText angle={107} class="text-xl">✓</GradientText>
             <Text
               size="sm"
@@ -119,7 +140,7 @@
               {m.pricing_consulting_feature_1()}
             </Text>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <GradientText angle={107} class="text-xl">✓</GradientText>
             <Text
               size="sm"
@@ -130,7 +151,7 @@
               {m.pricing_consulting_feature_2()}
             </Text>
           </div>
-          <div class="flex items-center gap-2">
+          <div class="flex items-start gap-2">
             <GradientText angle={107} class="text-xl">✓</GradientText>
             <Text
               size="sm"

--- a/services/app/src/lib/components/landing/testimonials.svelte
+++ b/services/app/src/lib/components/landing/testimonials.svelte
@@ -52,14 +52,16 @@
       <div
         class="
           relative z-10 flex flex-col gap-6 p-6
-          sm:p-[128px]
+          sm:p-12
+          lg:p-16
+          xl:p-[128px]
         "
       >
         <!-- Top row: 3 cards -->
         <div
           class="
             grid grid-cols-1 gap-6
-            md:grid-cols-3
+            lg:grid-cols-3
           "
         >
           {#each topRow as testimonial (testimonial.name)}

--- a/services/app/src/lib/components/landing/use-cases.svelte
+++ b/services/app/src/lib/components/landing/use-cases.svelte
@@ -239,13 +239,13 @@
     <div
       class="
         grid grid-cols-1 justify-items-center gap-x-5 gap-y-10
-        md:grid-cols-2 md:justify-items-start
+        xl:grid-cols-2 xl:justify-items-start
       "
     >
       {#each useCases as useCase, i (i)}
         <div
           class="
-            flex flex-col items-center gap-4
+            flex w-full max-w-[560px] flex-col items-center gap-4
             sm:flex-row sm:items-start sm:gap-6
           "
         >
@@ -262,9 +262,9 @@
           </div>
           <div
             class="
-              flex min-w-0 flex-col gap-[6px]
+              flex min-w-0 self-stretch flex-col gap-[6px]
               sm:pt-6
-              md:min-w-[323px]
+              xl:min-w-[323px]
             "
           >
             <Chip

--- a/services/app/src/lib/ui/shared/mobile-nav-drawer.svelte
+++ b/services/app/src/lib/ui/shared/mobile-nav-drawer.svelte
@@ -54,7 +54,7 @@
 
   <!-- Nav links using Chip -->
   <nav
-    class="flex flex-1 flex-col gap-3 overflow-y-auto px-5 py-2"
+    class="flex flex-1 flex-col gap-5 overflow-y-auto px-5 py-2"
     aria-label="Mobile navigation"
   >
     {#each links as link (link.href)}


### PR DESCRIPTION
## Summary

- Replace inline SVG hamburger icon with iconify `icon-[lucide--menu]` using `gradient-primary` class
- Increase mobile nav drawer item spacing (`gap-3` → `gap-5`)
- Fix pricing section mobile layout: reduce padding on small screens, align checkmarks to top of text
- Fix testimonials section: graduated padding across breakpoints (`p-6` → `sm:p-12` → `lg:p-16` → `xl:p-[128px]`), 3-column grid activates at `lg` instead of `md`
- Fix use cases section: consistent card width (`max-w-[560px]`) with centered grid items in single-column mode, 2-column grid at `xl` breakpoint, `self-stretch` on text container for consistent alignment on mobile
- Replace inline Polis/Jigsaw `<a>` + `GradientText` with `GradientLink` component in for-facilitators section
- Update AGENTS.md with iconify icon patterns

## Test plan

- [ ] Open at mobile viewport (~375px): verify gradient hamburger icon, drawer spacing, pricing card padding, single-column use cases centered with aligned text
- [ ] Open at tablet viewport (~768px–1024px): verify testimonials and use cases are single-column and well-spaced
- [ ] Open at `lg` viewport (~1024px): verify testimonials switch to 3-column grid
- [ ] Open at `xl` viewport (~1280px): verify use cases switch to 2-column grid
- [ ] Open at desktop (~1440px+): verify full layout with proper padding
- [ ] Run `cd services/app && pnpm lint && pnpm check`