### PR TITLE
docs(protocol): clean up DDS spec structure and auth model

### DIFF
--- a/doc/decentralized-protocol/0013-privacy-addendum.md
+++ b/doc/decentralized-protocol/0013-privacy-addendum.md
@@ -1,6 +1,6 @@
 # Addendum: Privacy Considerations for Decentralized Deliberation
 
-**Related RFC:** [RFC 0013 - DDS: Verifiable Deliberation on AT Protocol](./0013-agora-atproto-walkaway.md)
+**Related:** [DDS: Verifiable Deliberation on AT Protocol](./0013-agora-atproto-walkaway.md)
 **Date:** 2026-02-05
 **Status:** Discussion notes
 


### PR DESCRIPTION
## Summary

- Remove RFC numbering from all DDS documents (drop "RFC 0013", "Supersedes" metadata)
- Replace IPFS/Arweave references with Arweave/Filecoin/Logos Storage
- Rewrite Section 3 (Ownership vs Convenience) with three new subsections:
  - **Flexible Authentication**: bring-your-own-credential interface (email, phone, wallet, ZK passport, Zupass, eIDAS, etc.)
  - **Shared Organizations**: cross-tool org/membership records via Firehose
  - **Encrypted Key Vault**: concepts only, implementation details in addendum
- Move PDS hosting tiers, OAuth details, and 72h safety net to implementation addendum
- Fix all cross-references and section numbering

## Test plan
- [ ] Verify all internal links resolve correctly between the three documents
- [ ] Read Section 3 flow: Walkaway Test → Flexible Auth → Shared Orgs → Encrypted Key Vault
- [ ] Confirm implementation addendum section numbering is consistent (1→2→3→4)