### PR TITLE
docs(protocol): add WhiteWind blog link to DDS spec

### DIFF
--- a/doc/decentralized-protocol/0013-agora-atproto-walkaway.md
+++ b/doc/decentralized-protocol/0013-agora-atproto-walkaway.md
@@ -5,7 +5,7 @@
 | **Title**      | DDS: Verifiable Deliberation on AT Protocol    |
 | **Status**     | Draft                                          |
 | **Created**    | 2026-01-13                                     |
-| **Related**    | [Privacy Addendum](./0013-privacy-addendum.md), [Implementation Addendum](./0013-implementation-addendum.md) |
+| **Related**    | [Privacy Addendum](./0013-privacy-addendum.md), [Implementation Addendum](./0013-implementation-addendum.md), [Background: From ZK-first to AT Protocol](https://whtwnd.com/agoracitizen.network/3meq2b36rw42s) |
 
 ## 1. Design Philosophy
 


### PR DESCRIPTION
## Summary
- Add link to the WhiteWind blog post "From ZK-first to AT Protocol" in the DDS spec Related metadata

## Test plan
- [ ] Verify the link resolves: https://whtwnd.com/agoracitizen.network/3meq2b36rw42s