### PR TITLE
fix: migrate pg-boss to v12 and maz-ui to v4

### DIFF
--- a/services/agora/src/components/ui-library/ZKPhoneNumberInput.vue
+++ b/services/agora/src/components/ui-library/ZKPhoneNumberInput.vue
@@ -5,8 +5,8 @@
     There are no solution to fix the issue but since it doesn't affect production
     it can be safely ignored.
   -->
-  <!-- @vue-expect-error MazPhoneNumberInput types v-model as T | undefined -->
-  <MazPhoneNumberInput
+  <!-- @vue-expect-error MazInputPhoneNumber types v-model as T | undefined -->
+  <MazInputPhoneNumber
     :model-value="modelValue"
     :country-code="countryCode"
     :success="success"
@@ -17,7 +17,7 @@
     :auto-format="autoFormat"
     :no-validation-error="noValidationError"
     :aria-describedby="ariaDescribedby"
-    @update="handleUpdate"
+    @data="handleUpdate"
     @country-code="handleCountryCode"
     @blur="handleBlur"
     @update:model-value="handleModelValue"
@@ -26,11 +26,11 @@
 </template>
 
 <script setup lang="ts">
-import "maz-ui/css/main.css";
+import "maz-ui/styles";
 
 import type { CountryCode } from "libphonenumber-js/max";
-import type { Results } from "maz-ui/components/MazPhoneNumberInput";
-import MazPhoneNumberInput from "maz-ui/components/MazPhoneNumberInput";
+import type { Results } from "maz-ui/components/MazInputPhoneNumber";
+import MazInputPhoneNumber from "maz-ui/components/MazInputPhoneNumber";
 
 interface ZKPhoneNumberInputProps {
   modelValue: string | null;

--- a/services/agora/src/pages/onboarding/step3-phone-1/index.vue
+++ b/services/agora/src/pages/onboarding/step3-phone-1/index.vue
@@ -93,7 +93,7 @@ import {
   parsePhoneNumberFromString,
   type PhoneNumber as LibPhoneNumber,
 } from "libphonenumber-js/max";
-import type { Results } from "maz-ui/components/MazPhoneNumberInput";
+import type { Results } from "maz-ui/components/MazInputPhoneNumber";
 import { storeToRefs } from "pinia";
 import DefaultImageExample from "src/components/onboarding/backgrounds/DefaultImageExample.vue";
 import StepperLayout from "src/components/onboarding/layouts/StepperLayout.vue";

--- a/services/math-updater/src/index.ts
+++ b/services/math-updater/src/index.ts
@@ -1,6 +1,6 @@
 import { log } from "./app.js";
 import { config } from "./config.js";
-import PgBoss from "pg-boss";
+import { PgBoss } from "pg-boss";
 import { scanConversations } from "./jobs/scanConversations.js";
 import {
     UpdateConversationMathData,

--- a/services/math-updater/src/jobs/scanConversations.ts
+++ b/services/math-updater/src/jobs/scanConversations.ts
@@ -6,7 +6,7 @@ import {
 import { and, eq, or, isNull, lt, gt, sql } from "drizzle-orm";
 import { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { nowZeroMs } from "@/shared/util.js";
-import PgBoss from "pg-boss";
+import { PgBoss } from "pg-boss";
 
 // Threshold for detecting stale jobs
 // If a job is in CREATED state (queued) for longer than this, it's considered stuck

--- a/services/math-updater/src/jobs/updateConversationMath.ts
+++ b/services/math-updater/src/jobs/updateConversationMath.ts
@@ -15,7 +15,7 @@ import { nowZeroMs } from "@/shared/util.js";
 import { AxiosInstance } from "axios";
 import { and, eq } from "drizzle-orm";
 import { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import type PgBoss from "pg-boss";
+import type { PgBoss } from "pg-boss";
 
 export interface UpdateConversationMathData {
     conversationId: number;


### PR DESCRIPTION
Prerequisite code changes needed before merging Dependabot PRs #519 (pg-boss 11→12) and #526 (maz-ui 3→4).

## pg-boss v12

pg-boss v12 dropped the default export in favor of named exports. Updated all 3 import sites:

- `services/math-updater/src/index.ts`
- `services/math-updater/src/jobs/scanConversations.ts`
- `services/math-updater/src/jobs/updateConversationMath.ts`

No call-site changes needed — `work`/`offWork`/`send`/`createQueue` signatures are unchanged.

## maz-ui v4

maz-ui v4 renamed `MazPhoneNumberInput` → `MazInputPhoneNumber`, changed the CSS import from `maz-ui/css/main.css` → `maz-ui/styles`, and renamed `@update` event → `@data`.

Updated:
- `services/agora/src/components/ui-library/ZKPhoneNumberInput.vue`
- `services/agora/src/pages/onboarding/step3-phone-1/index.vue` (type import only)