### PR TITLE
fix(math-updater): use direct Job type import from pg-boss

### DIFF
--- a/services/math-updater/src/index.ts
+++ b/services/math-updater/src/index.ts
@@ -1,6 +1,6 @@
 import { log } from "./app.js";
 import { config } from "./config.js";
-import { PgBoss } from "pg-boss";
+import { PgBoss, type Job } from "pg-boss";
 import { scanConversations } from "./jobs/scanConversations.js";
 import {
     UpdateConversationMathData,
@@ -31,7 +31,7 @@ function createMathWorkerHandler({
     googleCloudCredentials: GoogleCloudCredentials | undefined;
     onWorkerCalled: () => void;
 }) {
-    return async (jobs: PgBoss.Job<UpdateConversationMathData>[]) => {
+    return async (jobs: Job<UpdateConversationMathData>[]) => {
         log.info(`[Math Updater] Worker called with ${jobs.length} job(s)`);
         onWorkerCalled();
 

--- a/services/math-updater/src/jobs/updateConversationMath.ts
+++ b/services/math-updater/src/jobs/updateConversationMath.ts
@@ -15,7 +15,7 @@ import { nowZeroMs } from "@/shared/util.js";
 import { AxiosInstance } from "axios";
 import { and, eq } from "drizzle-orm";
 import { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import type { PgBoss } from "pg-boss";
+import type { Job } from "pg-boss";
 
 export interface UpdateConversationMathData {
     conversationId: number;
@@ -86,7 +86,7 @@ export interface UpdateConversationMathData {
  * we prevent duplicate job creation at the application level.
  */
 export async function updateConversationMathHandler(
-    job: PgBoss.Job<UpdateConversationMathData>,
+    job: Job<UpdateConversationMathData>,
     db: PostgresJsDatabase,
     axiosPolis: AxiosInstance,
     googleCloudCredentials?: GoogleCloudCredentials,


### PR DESCRIPTION
## Summary
- pg-boss v12 exports `Job` as a standalone type, not as a member of a `PgBoss` namespace
- Replace `PgBoss.Job<T>` with `Job<T>` in `src/index.ts` and `src/jobs/updateConversationMath.ts` to fix TS2702 build errors

## Test plan
- [x] `pnpm build` succeeds in `services/math-updater`
- [ ] Docker image build succeeds