### PR TITLE
fix(agora): show character count in conversation creation editors

### DIFF
--- a/services/agora/src/pages/conversation/new/create/index.vue
+++ b/services/agora/src/pages/conversation/new/create/index.vue
@@ -61,6 +61,7 @@
             :single-line="true"
             :disabled="false"
             :max-length="MAX_LENGTH_TITLE"
+            :show-character-count="true"
             min-height="auto"
             class="title-editor"
             @update:model-value="updateTitle"
@@ -96,6 +97,7 @@
               :single-line="false"
               :disabled="false"
               :max-length="MAX_LENGTH_BODY"
+              :show-character-count="true"
               @update:model-value="updateContent"
               @update:is-over-limit="(v: boolean) => (isBodyOverLimit = v)"
             />


### PR DESCRIPTION
## Summary
- Explicitly pass `:show-character-count="true"` to both title and body Editor components on the conversation creation page
- The character count was not displaying because the prop defaults to `false`; the opinion editor (CommentComposer) already passes it explicitly

## Test plan
- [ ] Navigate to conversation creation page
- [ ] Confirm character count displays below both title and body editors
- [ ] Type text and verify the count updates
- [ ] Paste >1000 chars in body and confirm count turns red and "Next" is disabled