### PR TITLE
fix(agora): show load more button for non-representative items

### DIFF
--- a/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.vue
+++ b/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.vue
@@ -40,7 +40,8 @@
         <EmptyStateMessage
           v-if="
             props.itemList.length === 0 ||
-            Object.keys(props.clusters).length <= 1
+            Object.keys(props.clusters).length <= 1 ||
+            (compactMode && representativeItems.length === 0)
           "
           :message="emptyMessage"
         />
@@ -57,7 +58,7 @@
           <div
             v-if="
               additionalItems.length > 0 ||
-              (representativeItems.length === 0 && !compactMode)
+              (representativeItems.length === 0 && !compactMode && props.itemList.length > 0)
             "
             class="reliability-divider"
           >
@@ -77,28 +78,12 @@
             />
           </div>
 
-          <template v-if="representativeItems.length === 0 && !compactMode">
-            <div
-              v-for="consensusItem in props.itemList"
-              :key="consensusItem.opinion"
-              class="muted-item"
-            >
-              <ConsensusItem
-                :conversation-slug-id="props.conversationSlugId"
-                :opinion-item="consensusItem"
-                :opinion-item-for-visualizer="consensusItem"
-                :cluster-labels="props.clusterLabels"
-              />
-            </div>
-          </template>
-
           <button
             v-if="
               !compactMode &&
               remainingCount > 0 &&
               !hasLoadedMore &&
-              Object.keys(props.clusters).length > 1 &&
-              representativeItems.length > 0
+              Object.keys(props.clusters).length > 1
             "
             class="load-more-button"
             @click="handleLoadMore"

--- a/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.vue
+++ b/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.vue
@@ -36,7 +36,8 @@
         <EmptyStateMessage
           v-if="
             props.itemList.length === 0 ||
-            Object.keys(props.clusters).length <= 1
+            Object.keys(props.clusters).length <= 1 ||
+            (compactMode && representativeItems.length === 0)
           "
           :message="t('noDivisiveOpinionsMessage')"
         />
@@ -53,7 +54,7 @@
           <div
             v-if="
               additionalItems.length > 0 ||
-              (representativeItems.length === 0 && !compactMode)
+              (representativeItems.length === 0 && !compactMode && props.itemList.length > 0)
             "
             class="reliability-divider"
           >
@@ -73,28 +74,12 @@
             />
           </div>
 
-          <template v-if="representativeItems.length === 0 && !compactMode">
-            <div
-              v-for="consensusItem in props.itemList"
-              :key="consensusItem.opinion"
-              class="muted-item"
-            >
-              <ConsensusItem
-                :conversation-slug-id="props.conversationSlugId"
-                :opinion-item="consensusItem"
-                :opinion-item-for-visualizer="consensusItem"
-                :cluster-labels="props.clusterLabels"
-              />
-            </div>
-          </template>
-
           <button
             v-if="
               !compactMode &&
               remainingCount > 0 &&
               !hasLoadedMore &&
-              Object.keys(props.clusters).length > 1 &&
-              representativeItems.length > 0
+              Object.keys(props.clusters).length > 1
             "
             class="load-more-button"
             @click="handleLoadMore"


### PR DESCRIPTION
## Summary
- **Full view (specific tabs)**: When no representative items exist, show the "Less representative" divider and "Load more" button instead of directly loading all items. Users choose whether to load them.
- **Summary view**: Show the empty state message instead of a blank section when no representative items pass the quality threshold.

Fixes the behavior introduced in 598013ec where non-representative items loaded directly without user consent.

## Test plan
- [ ] Open a conversation where "Rejected" tab has items but none with `groupAwareConsensusDisagree >= 0.5`
- [ ] **Summary view**: Rejected section shows empty message + "View more"
- [ ] **Full "Rejected" tab**: Shows "Less representative" divider + "Load more (N)" button
- [ ] Clicking "Load more" triggers warning dialog, then shows all items muted
- [ ] Approved/Divisive sections with representative items still work as before