### PR TITLE
fix(app): fix netlify build ignore logic

### DIFF
--- a/services/app/netlify.toml
+++ b/services/app/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "pnpm build"
 publish = "build"
-ignore = "bash -c '[[ $BRANCH == dependabot/* ]] || ! git diff --name-only $CACHED_COMMIT_REF $COMMIT_REF -- services/app/ | grep -q .'"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- services/app/"
 
 [build.environment]
 NODE_VERSION = "24"


### PR DESCRIPTION
## Summary
- Replace fragile `bash -c '... ! git diff --name-only ... | grep -q .'` ignore command with `git diff --quiet` which handles missing/invalid `$CACHED_COMMIT_REF` safely (errors → build proceeds)
- Remove dependabot branch exception so all branches follow the same rule: only build when `services/app/` is affected

## Test plan
- [ ] Merge this PR and verify the Netlify deploy preview triggers correctly
- [ ] Push a commit that only changes files outside `services/app/` and verify the build is skipped