### PR TITLE
fix(app): improve case study card text readability

### DIFF
--- a/services/app/src/app.css
+++ b/services/app/src/app.css
@@ -213,7 +213,7 @@
   /* Backgrounds */
   --background: var(--sky-lightest);
   --surface-hover: var(--sky-lightest);
-  --overlay-dark: rgba(0, 0, 0, 0.6);
+  --overlay-dark: rgba(0, 0, 0, 0.75);
 
   /* Text */
   --foreground: var(--ink-light);

--- a/services/app/src/lib/components/landing/case-studies.svelte
+++ b/services/app/src/lib/components/landing/case-studies.svelte
@@ -43,12 +43,12 @@
         />
         <div
           class="
-            absolute inset-0 bg-linear-to-b from-transparent from-50%
+            absolute inset-0 bg-linear-to-b from-transparent from-30%
             to-overlay-dark
           "
         ></div>
-        <div class="relative z-10 flex flex-col gap-2">
-          <Text size="lg" weight="semibold" element="h3" class="text-white">
+        <div class="relative z-10 flex flex-col gap-2 drop-shadow-lg">
+          <Text size="xl" weight="semibold" element="h3" class="text-white">
             {m.casestudy_bloquonstout_title()}
           </Text>
           <div class="flex items-center justify-between">
@@ -89,12 +89,12 @@
         />
         <div
           class="
-            absolute inset-0 bg-linear-to-b from-transparent from-50%
+            absolute inset-0 bg-linear-to-b from-transparent from-30%
             to-overlay-dark
           "
         ></div>
-        <div class="relative z-10 flex flex-col gap-2">
-          <Text size="lg" weight="semibold" element="h3" class="text-white">
+        <div class="relative z-10 flex flex-col gap-2 drop-shadow-lg">
+          <Text size="xl" weight="semibold" element="h3" class="text-white">
             {m.casestudy_tech4nature_title()}
           </Text>
           <div class="flex items-center justify-between">
@@ -135,12 +135,12 @@
         />
         <div
           class="
-            absolute inset-0 bg-linear-to-b from-transparent from-50%
+            absolute inset-0 bg-linear-to-b from-black/30 from-0%
             to-overlay-dark
           "
         ></div>
-        <div class="relative z-10 flex flex-col gap-2">
-          <Text size="lg" weight="semibold" element="h3" class="text-white">
+        <div class="relative z-10 flex flex-col gap-2 drop-shadow-lg">
+          <Text size="xl" weight="semibold" element="h3" class="text-white">
             {m.casestudy_unesco_mil_title()}
           </Text>
           <div class="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- Increase title text size from `lg` to `xl` across all case study cards
- Start dark gradient overlay earlier (from 30% instead of 50%) for better contrast
- Increase overlay opacity from 0.6 to 0.75
- Add `drop-shadow-lg` to text containers for extra contrast
- Use full-card dark tint (`from-black/30`) on UNESCO card to handle its busy background image

## Test plan
- [ ] Verify all three case study card titles are readable on desktop and mobile
- [ ] Check the UNESCO card specifically — white text should be clearly legible against the bright background