### PR TITLE
fix(app): fix OG meta tags for prerendered pages and blog posts

### DIFF
--- a/services/app/src/app.d.ts
+++ b/services/app/src/app.d.ts
@@ -2,11 +2,15 @@
 // for information about these interfaces
 import "unplugin-icons/types/svelte";
 
+import type { SeoData } from "$lib/seo";
+
 declare global {
   namespace App {
     // interface Error {}
     // interface Locals {}
-    // interface PageData {}
+    interface PageData {
+      seo?: SeoData;
+    }
     // interface PageState {}
     // interface Platform {}
   }

--- a/services/app/src/lib/seo.ts
+++ b/services/app/src/lib/seo.ts
@@ -1,0 +1,11 @@
+export const SITE_ORIGIN = "https://www.agoracitizen.network";
+export const DEFAULT_OG_IMAGE = `${SITE_ORIGIN}/thumbnail_2_1.png`;
+
+export interface SeoData {
+  title: string;
+  description: string;
+  ogType: "website" | "article";
+  ogImage?: string;
+  ogImageType?: string;
+  articleAuthor?: string;
+}

--- a/services/app/src/lib/server/landing/blog.ts
+++ b/services/app/src/lib/server/landing/blog.ts
@@ -16,6 +16,7 @@ export interface BlogPost {
   author: string;
   date: string;
   thumbnail: string;
+  image: string;
   content: string;
 }
 
@@ -26,6 +27,7 @@ export interface BlogPostMeta {
   author: string;
   date: string;
   thumbnail: string;
+  image: string;
 }
 
 const markdownFiles: Record<string, string> = import.meta.glob(
@@ -61,6 +63,7 @@ export function getBlogPosts({ locale }: { locale: string }): BlogPostMeta[] {
       author: getString(data.author),
       date: getString(data.date),
       thumbnail: getString(data.thumbnail),
+      image: getString(data.image),
     });
   }
 
@@ -79,6 +82,7 @@ export function getBlogPosts({ locale }: { locale: string }): BlogPostMeta[] {
         author: getString(data.author),
         date: getString(data.date),
         thumbnail: getString(data.thumbnail),
+        image: getString(data.image),
       });
     }
   }
@@ -122,6 +126,7 @@ export async function getBlogPost({
     author: getString(data.author),
     date: getString(data.date),
     thumbnail: getString(data.thumbnail),
+    image: getString(data.image),
     content: String(result),
   };
 }

--- a/services/app/src/routes/+layout.svelte
+++ b/services/app/src/routes/+layout.svelte
@@ -7,44 +7,46 @@
   import Header from "$components/landing/header.svelte";
   import * as m from "$lib/paraglide/messages.js";
   import { locales, localizeHref } from "$lib/paraglide/runtime";
+  import { DEFAULT_OG_IMAGE } from "$lib/seo";
 
   let { children } = $props();
+
+  const seo = $derived(page.data.seo);
+  const title = $derived(seo?.title ?? m.meta_title());
+  const description = $derived(seo?.description ?? m.meta_description());
+  const ogType = $derived(seo?.ogType ?? "website");
+  const ogImage = $derived(seo?.ogImage ?? DEFAULT_OG_IMAGE);
+  const ogImageType = $derived(seo?.ogImageType ?? "image/png");
 </script>
 
 <svelte:head>
-  <title>{m.meta_title()}</title>
-  <meta name="description" content={m.meta_description()} />
+  <title>{title}</title>
+  <meta name="description" content={description} />
   <meta name="keywords" content="civic tech, social network, peace" />
   <meta name="author" content="Agora Citizen Network" />
 
   <!-- Open Graph -->
-  <meta property="og:title" content={m.meta_title()} />
-  <meta property="og:description" content={m.meta_description()} />
+  <meta property="og:title" content={title} />
+  <meta property="og:description" content={description} />
   <meta property="og:url" content={page.url.href} />
-  <meta property="og:type" content="website" />
+  <meta property="og:type" content={ogType} />
   <meta property="og:site_name" content="Agora" />
-  <meta
-    property="og:image"
-    content="https://www.agoracitizen.network/images/favicon/thumbnail_2_1.png"
-  />
-  <meta
-    property="og:image:secure_url"
-    content="https://www.agoracitizen.network/images/favicon/thumbnail_2_1.png"
-  />
-  <meta property="og:image:type" content="image/png" />
+  <meta property="og:image" content={ogImage} />
+  <meta property="og:image:secure_url" content={ogImage} />
+  <meta property="og:image:type" content={ogImageType} />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="600" />
+  {#if seo?.articleAuthor}
+    <meta property="article:author" content={seo.articleAuthor} />
+  {/if}
 
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content={page.url.href} />
   <meta name="twitter:site" content="@join_agora" />
-  <meta name="twitter:title" content={m.meta_title()} />
-  <meta name="twitter:description" content={m.meta_description()} />
-  <meta
-    name="twitter:image"
-    content="https://www.agoracitizen.network/images/favicon/thumbnail_2_1.png"
-  />
+  <meta name="twitter:title" content={title} />
+  <meta name="twitter:description" content={description} />
+  <meta name="twitter:image" content={ogImage} />
 
   <!-- Favicon -->
   <link

--- a/services/app/src/routes/blog/[slug]/+page.server.ts
+++ b/services/app/src/routes/blog/[slug]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error } from "@sveltejs/kit";
 
 import { getLocale } from "$lib/paraglide/runtime";
+import { type SeoData, SITE_ORIGIN } from "$lib/seo";
 import { getAllSlugs, getBlogPost } from "$server/landing/blog";
 
 import type { EntryGenerator, PageServerLoad } from "./$types";
@@ -11,6 +12,19 @@ export const entries: EntryGenerator = () => {
   return getAllSlugs().map((slug) => ({ slug }));
 };
 
+function resolveImageUrl(imagePath: string): string {
+  if (imagePath.startsWith("http://") || imagePath.startsWith("https://")) {
+    return imagePath;
+  }
+  return `${SITE_ORIGIN}${imagePath}`;
+}
+
+function inferImageType(url: string): string | undefined {
+  if (url.endsWith(".jpg") || url.endsWith(".jpeg")) return "image/jpeg";
+  if (url.endsWith(".png")) return "image/png";
+  return undefined;
+}
+
 export const load: PageServerLoad = async ({ params }) => {
   const locale = getLocale();
   const post = await getBlogPost({ slug: params.slug, locale });
@@ -19,5 +33,17 @@ export const load: PageServerLoad = async ({ params }) => {
     error(404, "Post not found");
   }
 
-  return { post };
+  const ogImagePath = post.image || post.thumbnail;
+  const ogImage = ogImagePath ? resolveImageUrl(ogImagePath) : undefined;
+
+  const seo: SeoData = {
+    title: post.title,
+    description: post.description,
+    ogType: "article",
+    ogImage,
+    ogImageType: ogImage ? inferImageType(ogImage) : undefined,
+    articleAuthor: post.author,
+  };
+
+  return { post, seo };
 };

--- a/services/app/svelte.config.js
+++ b/services/app/svelte.config.js
@@ -7,6 +7,10 @@ const config = {
   kit: {
     adapter: adapter(),
 
+    prerender: {
+      origin: "https://www.agoracitizen.network",
+    },
+
     alias: {
       $ui: "src/lib/ui",
       $components: "src/lib/components",


### PR DESCRIPTION
## Summary

- Fixed `og:url` / `twitter:url` rendering as `http://sveltekit-prerender/` by setting `prerender.origin` in SvelteKit config
- Blog posts now show per-post OG title, description, image, and `og:type=article` instead of generic site-wide defaults
- Fixed default OG image path (was pointing to nonexistent `/images/favicon/thumbnail_2_1.png`, corrected to `/thumbnail_2_1.png`)

## Test plan

- [ ] Build with `cd services/app && pnpm build` and inspect `build/index.html` — verify `og:url` contains `https://www.agoracitizen.network/`
- [ ] Inspect `build/blog/bloquonstout.html` — verify `og:title` shows blog post title, `og:type` is `article`, `og:image` is post-specific
- [ ] Share a blog post URL on social media preview tools (e.g., https://www.opengraph.xyz/) and verify correct preview
- [ ] Run `pnpm lint:fix && pnpm check` — no errors