### PR TITLE
fix(agora,app): move email login link closer to buttons and fix netlify ignore

### DIFF
--- a/services/agora/src/pages/onboarding/step1-login/index.vue
+++ b/services/agora/src/pages/onboarding/step1-login/index.vue
@@ -33,6 +33,14 @@
             @click="goToPhoneLogin()"
           />
 
+          <ZKGradientButton
+            :label="t('loginWithEmail')"
+            variant="text"
+            label-color="#6B4EFF"
+            class="email-login-link"
+            @click="goToEmailLogin()"
+          />
+
           <p><SignupAgreement /></p>
         </template>
       </StepperLayout>
@@ -68,6 +76,14 @@ async function goToPassportLogin() {
 async function goToPhoneLogin() {
   await router.push({ name: "/onboarding/step3-phone-1/" });
 }
+
+async function goToEmailLogin() {
+  await router.push({ name: "/onboarding/step3-email-1/" });
+}
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.email-login-link {
+  margin-top: -0.75rem;
+}
+</style>

--- a/services/app/netlify.toml
+++ b/services/app/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "pnpm build"
 publish = "build"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- services/app/"
+ignore = "test -n \"$CACHED_COMMIT_REF\" && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- services/app/"
 
 [build.environment]
 NODE_VERSION = "24"


### PR DESCRIPTION
## Summary

- Move "I prefer to login with email" link closer to the login buttons by reducing the gap with a negative top margin
- Fix Netlify build ignore command that skipped builds when `$CACHED_COMMIT_REF` was empty (first deploy / cache clear), because the `git diff` collapsed to a single-ref comparison against a clean working tree — always returning exit 0 (skip)

## Test plan

- [ ] Check login page visually — email link should be closer to the phone number button
- [ ] Verify Netlify builds proceed correctly after merge to main