### PR TITLE
fix(app): guard netlify ignore against empty CACHED_COMMIT_REF

### DIFF
--- a/services/app/netlify.toml
+++ b/services/app/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "pnpm build"
 publish = "build"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- services/app/"
+ignore = "test -n \"$CACHED_COMMIT_REF\" && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- services/app/"
 
 [build.environment]
 NODE_VERSION = "24"


### PR DESCRIPTION
## Summary

- Guard the Netlify build ignore command against empty `$CACHED_COMMIT_REF` (first deploy or cache clear)
- When empty, `git diff --quiet $COMMIT_REF -- services/app/` compares the clean working tree to itself, always returning exit 0 (skip), causing builds to be incorrectly canceled

## Test plan

- [ ] Merge to main and verify Netlify build proceeds instead of being canceled