### PR TITLE
fix(agora): standardize text wrapping and force light mode for Maz UI

### DIFF
--- a/services/agora/src/boot/maz-ui.ts
+++ b/services/agora/src/boot/maz-ui.ts
@@ -7,6 +7,8 @@ export default defineBoot(({ app }) => {
   app.use(MazUi, {
     theme: {
       preset: agoraPreset,
+      colorMode: "light",
+      mode: "light",
     },
   });
 });

--- a/services/agora/src/components/conversation/export/ExportStatusView.vue
+++ b/services/agora/src/components/conversation/export/ExportStatusView.vue
@@ -393,7 +393,6 @@ function getFailureReasonText(reason: ExportFailureReason): string {
 .export-info-value {
   font-size: 1rem;
   color: $color-text-strong;
-  word-break: break-word;
 }
 
 .status-message {
@@ -511,7 +510,6 @@ function getFailureReasonText(reason: ExportFailureReason): string {
   font-size: 1.1rem;
   font-weight: var(--font-weight-semibold);
   color: $color-text-strong;
-  word-break: break-word;
 }
 
 .file-details {

--- a/services/agora/src/components/conversation/import/ImportStatusView.vue
+++ b/services/agora/src/components/conversation/import/ImportStatusView.vue
@@ -199,7 +199,6 @@ function getFailureReasonText(reason: ImportFailureReason): string {
 .import-info-value {
   font-size: 1rem;
   color: $color-text-strong;
-  word-break: break-word;
 }
 
 .status-message {

--- a/services/agora/src/components/editor/Editor.vue
+++ b/services/agora/src/components/editor/Editor.vue
@@ -406,8 +406,6 @@ watch(
   outline: none;
   font-size: 1rem;
   line-height: normal;
-  overflow-wrap: break-word;
-  word-break: break-word;
   max-height: 40vh;
   overflow-y: auto;
 }

--- a/services/agora/src/components/features/conversation/ConversationTitleWithPrivacyLabel.vue
+++ b/services/agora/src/components/features/conversation/ConversationTitleWithPrivacyLabel.vue
@@ -62,8 +62,6 @@ const { t } = useComponentI18n<ConversationTitleWithPrivacyLabelTranslations>(
   font-weight: var(--font-weight-medium);
   color: #0a0714;
   line-height: 1.3;
-  overflow-wrap: break-word;
-  word-break: break-word;
   min-width: 0;
   max-width: 100%;
 }

--- a/services/agora/src/components/features/user/UserIdentityCard.vue
+++ b/services/agora/src/components/features/user/UserIdentityCard.vue
@@ -22,7 +22,6 @@
           :author-verified="authorVerified"
           :user-identity="userIdentity"
           :show-verified-text="showVerifiedText"
-          :user-type="organizationImageUrl != '' ? 'organization' : 'normal'"
         />
       </div>
 

--- a/services/agora/src/components/features/user/UserMetadata.vue
+++ b/services/agora/src/components/features/user/UserMetadata.vue
@@ -2,10 +2,6 @@
   <div class="authorContainer">
     <DisplayUsername
       class="usernameStyle"
-      :class="{
-        wordBreakNormal: userType == 'normal',
-        wordBreakOrganization: userType == 'organization',
-      }"
       :username="userIdentity"
       :show-is-guest="showIsGuest"
     />
@@ -30,7 +26,6 @@ defineProps<{
   userIdentity: string;
   authorVerified: boolean;
   showVerifiedText: boolean;
-  userType: "organization" | "normal";
 }>();
 
 const { t } = useComponentI18n<UserMetadataTranslations>(
@@ -44,14 +39,6 @@ const { t } = useComponentI18n<UserMetadataTranslations>(
   font-size: 0.875rem;
   font-weight: var(--font-weight-medium);
   color: #0a0714;
-}
-
-.wordBreakNormal {
-  word-break: break-all;
-}
-
-.wordBreakOrganization {
-  word-break: break-word;
 }
 
 .verifiedMessage {

--- a/services/agora/src/components/newConversation/dialog/PostAsAccountDialog.vue
+++ b/services/agora/src/components/newConversation/dialog/PostAsAccountDialog.vue
@@ -129,9 +129,6 @@ function isAccountSelected(isOrganization: boolean, name: string): boolean {
 .account-name {
   font-size: 16px;
   font-weight: var(--font-weight-medium);
-  word-break: break-word;
-  overflow-wrap: break-word;
-  hyphens: auto;
   line-height: 1.4;
 }
 </style>

--- a/services/agora/src/components/newConversation/import/csv/CsvDropZone.vue
+++ b/services/agora/src/components/newConversation/import/csv/CsvDropZone.vue
@@ -404,7 +404,6 @@ function formatFileSize(bytes: number): string {
   font-size: 0.75rem;
   color: $color-text-weak;
   white-space: pre-wrap;
-  word-break: break-word;
   display: flex;
   align-items: center;
   gap: 0.5rem;

--- a/services/agora/src/components/newConversation/import/csv/CsvErrorDetailsDialog.vue
+++ b/services/agora/src/components/newConversation/import/csv/CsvErrorDetailsDialog.vue
@@ -142,7 +142,6 @@ function handleClose(): void {
     font-family: monospace;
     color: #c62828;
     white-space: pre-wrap;
-    word-break: break-word;
     line-height: 1.6;
     display: block;
   }

--- a/services/agora/src/components/newConversation/import/url/PolisUrlInput.vue
+++ b/services/agora/src/components/newConversation/import/url/PolisUrlInput.vue
@@ -193,8 +193,6 @@ defineExpose({
       border-radius: 3px;
       font-size: 0.75rem;
       color: #495057;
-      word-break: break-all;
-      overflow-wrap: break-word;
       max-width: 100%;
     }
   }

--- a/services/agora/src/components/ui-library/ZKHtmlContent.vue
+++ b/services/agora/src/components/ui-library/ZKHtmlContent.vue
@@ -62,10 +62,6 @@ const handleClick = (event: Event) => {
 .textBreak {
   font-size: 0.9rem;
   line-height: normal;
-  word-break: break-word;
-  /* Prevent potential layout issues with long content */
-  overflow-wrap: break-word;
-  hyphens: auto;
 }
 
 :deep(p) {

--- a/services/agora/src/css/app.scss
+++ b/services/agora/src/css/app.scss
@@ -58,6 +58,8 @@ body {
   background-color: $app-background-color;
   color: rgb(24, 28, 31);
   line-height: normal;
+  word-wrap: break-word; /* legacy alias for older browsers (WeChat X5 kernel) */
+  overflow-wrap: break-word; /* modern standard */
 
   /* Mobile-specific font optimizations */
   -webkit-text-size-adjust: 100%;
@@ -79,6 +81,7 @@ a {
 html {
   overscroll-behavior: none;
   overflow-y: scroll;
+  color-scheme: light; /* app doesn't support dark mode */
 }
 
 /* Mobile-specific font optimizations */

--- a/services/agora/src/pages/user-profile.vue
+++ b/services/agora/src/pages/user-profile.vue
@@ -28,7 +28,6 @@
               :user-identity="profileData.userName"
               :show-is-guest="isGuest"
               :show-verified-text="true"
-              user-type="normal"
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Standardize text wrapping globally via `word-wrap`/`overflow-wrap` on `body` instead of inconsistent per-component CSS that was causing mid-word text breaks (`hyphens: auto`, `word-break: break-all`, non-standard `word-break: break-word`)
- Remove redundant word-wrapping declarations from 10 components
- Force Maz UI to light mode (`colorMode: "light"`, `mode: "light"`) to fix dark phone input background when OS is in dark mode
- Add `color-scheme: light` on `html` to prevent system dark mode from affecting browser-native UI controls

## Test plan
- [ ] Run `make dev-app` and open a conversation — statement text should wrap at word boundaries, not mid-word
- [ ] Check feed view — statement previews should wrap correctly
- [ ] Check editor — typing long text should still wrap
- [ ] Check conversation titles — should wrap, not overflow
- [ ] Set OS to dark mode — phone input on onboarding should have white/light background
- [ ] Verify long URLs in statements still wrap (don't overflow containers)