### PR TITLE
fix(agora): improve statistical significance wording

### DIFF
--- a/services/agora/src/components/post/analysis/common/LoadMoreWarningDialog.i18n.ts
+++ b/services/agora/src/components/post/analysis/common/LoadMoreWarningDialog.i18n.ts
@@ -3,6 +3,7 @@ import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
 export interface LoadMoreWarningDialogTranslations {
   title: string;
   description: string;
+  descriptionEmphasis: string;
   cancelButton: string;
   loadMoreButton: string;
 }
@@ -14,47 +15,56 @@ export const loadMoreWarningDialogTranslations: Record<
   en: {
     title: "Load all statements",
     description:
-      "All statements will be shown in decreasing order of statistical significance, including some that may not really be significant.",
+      "All statements will be shown in decreasing order of statistical significance, including some that may not {emphasis} be significant.",
+    descriptionEmphasis: "actually",
     cancelButton: "Cancel",
     loadMoreButton: "Load all",
   },
   ar: {
     title: "تحميل جميع المقترحات",
     description:
-      "ستُعرض جميع المقترحات مرتبة حسب الدلالة الإحصائية تنازليًا، بما في ذلك بعض المقترحات التي قد لا تكون ذات دلالة حقًا.",
+      "ستُعرض جميع المقترحات مرتبة حسب الدلالة الإحصائية تنازليًا، بما في ذلك بعض المقترحات التي قد لا تكون ذات دلالة {emphasis}.",
+    descriptionEmphasis: "حقًا",
     cancelButton: "إلغاء",
     loadMoreButton: "تحميل الكل",
   },
   es: {
     title: "Cargar todas las proposiciones",
     description:
-      "Se mostrarán todas las proposiciones en orden decreciente de significancia estadística, incluidas algunas que pueden no ser realmente significativas.",
+      "Se mostrarán todas las proposiciones en orden decreciente de significancia estadística, incluidas algunas que pueden no ser {emphasis} significativas.",
+    descriptionEmphasis: "realmente",
     cancelButton: "Cancelar",
     loadMoreButton: "Cargar todo",
   },
   fr: {
     title: "Charger toutes les propositions",
     description:
-      "Toutes les propositions seront affichées par ordre de significativité statistique décroissante, y compris certaines qui pourraient ne pas vraiment être significatives.",
+      "Toutes les propositions seront affichées par ordre de significativité statistique décroissante, y compris certaines qui pourraient ne pas {emphasis} être significatives.",
+    descriptionEmphasis: "vraiment",
     cancelButton: "Annuler",
     loadMoreButton: "Tout charger",
   },
   "zh-Hans": {
     title: "加载所有观点",
-    description: "将显示所有观点，按统计显著性从高到低排序，包括一些可能并不真正具有显著性的观点。",
+    description:
+      "将显示所有观点，按统计显著性从高到低排序，包括一些可能并不{emphasis}具有显著性的观点。",
+    descriptionEmphasis: "真正",
     cancelButton: "取消",
     loadMoreButton: "全部加载",
   },
   "zh-Hant": {
     title: "載入所有觀點",
-    description: "將顯示所有觀點，按統計顯著性從高到低排序，包括一些可能並不真正具有顯著性的觀點。",
+    description:
+      "將顯示所有觀點，按統計顯著性從高到低排序，包括一些可能並不{emphasis}具有顯著性的觀點。",
+    descriptionEmphasis: "真正",
     cancelButton: "取消",
     loadMoreButton: "全部載入",
   },
   ja: {
     title: "すべての意見を読み込む",
     description:
-      "すべての意見が統計的有意性の高い順に表示されます。本当に有意とは言えないものも含まれます。",
+      "すべての意見が統計的有意性の高い順に表示されます。{emphasis}有意とは言えないものも含まれます。",
+    descriptionEmphasis: "本当に",
     cancelButton: "キャンセル",
     loadMoreButton: "すべて読み込む",
   },

--- a/services/agora/src/components/post/analysis/consensusTab/CommonGroundInformationDialog.i18n.ts
+++ b/services/agora/src/components/post/analysis/consensusTab/CommonGroundInformationDialog.i18n.ts
@@ -14,57 +14,57 @@ export const commonGroundInformationDialogTranslations: Record<
   en: {
     agreementsTitle: "Approved",
     agreementsDescription:
-      "These are statements all opinion groups agree to agree on.\n\nThis goes beyond a simple majority: even if most individuals approve, a single group's disapproval — no matter how small the group — is enough to exclude a statement.\n\nOnly statements that reflect true cross-group consensus appear here, not those based on majority rule alone.",
+      "These are statements all opinion groups agree to agree on.\n\nThis goes beyond a simple majority: even if most individuals approve, a single group's disapproval — no matter how small the group — is enough to exclude a statement.\n\nOnly statements that reflect true cross-group consensus appear here, not those based on majority rule alone.\n\nOnly the most statistically significant are shown first.",
     disagreementsTitle: "Rejected",
     disagreementsDescription:
-      "These are statements all opinion groups agree to disagree on.\n\nThis goes beyond a simple majority: even if most individuals reject, a single group's approval — no matter how small the group — is enough to exclude a statement.\n\nOnly statements that reflect true cross-group consensus appear here, not those based on majority rule alone.",
+      "These are statements all opinion groups agree to disagree on.\n\nThis goes beyond a simple majority: even if most individuals reject, a single group's approval — no matter how small the group — is enough to exclude a statement.\n\nOnly statements that reflect true cross-group consensus appear here, not those based on majority rule alone.\n\nOnly the most statistically significant are shown first.",
   },
   ar: {
     agreementsTitle: "معتمدة",
     agreementsDescription:
-      "هذه المقترحات معتمدة بالإجماع من كل مجموعة رأي.\n\nهذا يتجاوز الأغلبية البسيطة: حتى لو وافق معظم الأفراد، فإن رفض مجموعة واحدة — مهما كان حجمها — يكفي لاستبعاد المقترح.\n\nلا تظهر هنا سوى المقترحات التي تعكس إجماعاً حقيقياً بين المجموعات، وليس تلك القائمة على حكم الأغلبية فقط.",
+      "هذه المقترحات معتمدة بالإجماع من كل مجموعة رأي.\n\nهذا يتجاوز الأغلبية البسيطة: حتى لو وافق معظم الأفراد، فإن رفض مجموعة واحدة — مهما كان حجمها — يكفي لاستبعاد المقترح.\n\nلا تظهر هنا سوى المقترحات التي تعكس إجماعاً حقيقياً بين المجموعات، وليس تلك القائمة على حكم الأغلبية فقط.\n\nتُعرض الأكثر دلالة إحصائياً أولاً.",
     disagreementsTitle: "مرفوضة",
     disagreementsDescription:
-      "هذه المقترحات مرفوضة بالإجماع من كل مجموعة رأي.\n\nهذا يتجاوز الأغلبية البسيطة: حتى لو رفض معظم الأفراد، فإن موافقة مجموعة واحدة — مهما كان حجمها — تكفي لاستبعاد المقترح.\n\nلا تظهر هنا سوى المقترحات التي تعكس إجماعاً حقيقياً بين المجموعات، وليس تلك القائمة على حكم الأغلبية فقط.",
+      "هذه المقترحات مرفوضة بالإجماع من كل مجموعة رأي.\n\nهذا يتجاوز الأغلبية البسيطة: حتى لو رفض معظم الأفراد، فإن موافقة مجموعة واحدة — مهما كان حجمها — تكفي لاستبعاد المقترح.\n\nلا تظهر هنا سوى المقترحات التي تعكس إجماعاً حقيقياً بين المجموعات، وليس تلك القائمة على حكم الأغلبية فقط.\n\nتُعرض الأكثر دلالة إحصائياً أولاً.",
   },
   es: {
     agreementsTitle: "Aprobados",
     agreementsDescription:
-      "Estas proposiciones son aprobadas por unanimidad por cada grupo de opinión.\n\nEsto va más allá de una simple mayoría: aunque una gran parte de los individuos las aprueben, el rechazo de un solo grupo — sin importar su tamaño — basta para excluirlas.\n\nAsí, solo se presentan aquí las proposiciones que son objeto de un verdadero consenso entre grupos, y no las que se basan únicamente en una regla mayoritaria.",
+      "Estas proposiciones son aprobadas por unanimidad por cada grupo de opinión.\n\nEsto va más allá de una simple mayoría: aunque una gran parte de los individuos las aprueben, el rechazo de un solo grupo — sin importar su tamaño — basta para excluirlas.\n\nAsí, solo se presentan aquí las proposiciones que son objeto de un verdadero consenso entre grupos, y no las que se basan únicamente en una regla mayoritaria.\n\nSolo se muestran las más estadísticamente significativas primero.",
     disagreementsTitle: "Rechazados",
     disagreementsDescription:
-      "Estas proposiciones son rechazadas por unanimidad por cada grupo de opinión.\n\nEsto va más allá de una simple mayoría: aunque una gran parte de los individuos las rechacen, la aprobación de un solo grupo — sin importar su tamaño — basta para excluirlas.\n\nAsí, solo se presentan aquí las proposiciones que son objeto de un verdadero consenso entre grupos, y no las que se basan únicamente en una regla mayoritaria.",
+      "Estas proposiciones son rechazadas por unanimidad por cada grupo de opinión.\n\nEsto va más allá de una simple mayoría: aunque una gran parte de los individuos las rechacen, la aprobación de un solo grupo — sin importar su tamaño — basta para excluirlas.\n\nAsí, solo se presentan aquí las proposiciones que son objeto de un verdadero consenso entre grupos, y no las que se basan únicamente en una regla mayoritaria.\n\nSolo se muestran las más estadísticamente significativas primero.",
   },
   fr: {
     agreementsTitle: "Approuvés",
     agreementsDescription:
-      "Ces propositions sont approuvées à l'unanimité par chaque groupe d'opinion.\n\nCela dépasse le cadre d'une simple majorité : même si une large part des individus les approuvent, le rejet d'un seul groupe — quelle que soit sa taille — suffit à les exclure.\n\nAinsi, seules les propositions faisant l'objet d'un véritable consensus inter-groupes sont présentées ici, et non celles qui ne reposent que sur une règle majoritaire.",
+      "Ces propositions sont approuvées à l'unanimité par chaque groupe d'opinion.\n\nCela dépasse le cadre d'une simple majorité : même si une large part des individus les approuvent, le rejet d'un seul groupe — quelle que soit sa taille — suffit à les exclure.\n\nAinsi, seules les propositions faisant l'objet d'un véritable consensus inter-groupes sont présentées ici, et non celles qui ne reposent que sur une règle majoritaire.\n\nSeules les plus statistiquement significatives sont affichées en premier.",
     disagreementsTitle: "Rejetés",
     disagreementsDescription:
-      "Ces propositions sont rejetées à l'unanimité par chaque groupe d'opinion.\n\nCela dépasse le cadre d'une simple majorité : même si une large part des individus les rejettent, l'approbation d'un seul groupe — quelle que soit sa taille — suffit à les exclure.\n\nAinsi, seules les propositions faisant l'objet d'un véritable consensus inter-groupes sont présentées ici, et non celles qui ne reposent que sur une règle majoritaire.",
+      "Ces propositions sont rejetées à l'unanimité par chaque groupe d'opinion.\n\nCela dépasse le cadre d'une simple majorité : même si une large part des individus les rejettent, l'approbation d'un seul groupe — quelle que soit sa taille — suffit à les exclure.\n\nAinsi, seules les propositions faisant l'objet d'un véritable consensus inter-groupes sont présentées ici, et non celles qui ne reposent que sur une règle majoritaire.\n\nSeules les plus statistiquement significatives sont affichées en premier.",
   },
   "zh-Hans": {
     agreementsTitle: "通过",
     agreementsDescription:
-      "这些观点获得了每个意见群组的一致认可。\n\n这超越了简单多数：即使大多数个体认可，一个群组的反对——无论其规模多小——就足以排除该观点。\n\n只有反映真正跨群组共识的观点才会出现在这里，而非仅基于多数决定的观点。",
+      "这些观点获得了每个意见群组的一致认可。\n\n这超越了简单多数：即使大多数个体认可，一个群组的反对——无论其规模多小——就足以排除该观点。\n\n只有反映真正跨群组共识的观点才会出现在这里，而非仅基于多数决定的观点。\n\n仅先显示统计上最显著的观点。",
     disagreementsTitle: "否决",
     disagreementsDescription:
-      "这些观点被每个意见群组一致否决。\n\n这超越了简单多数：即使大多数个体否决，一个群组的认可——无论其规模多小——就足以排除该观点。\n\n只有反映真正跨群组共识的观点才会出现在这里，而非仅基于多数决定的观点。",
+      "这些观点被每个意见群组一致否决。\n\n这超越了简单多数：即使大多数个体否决，一个群组的认可——无论其规模多小——就足以排除该观点。\n\n只有反映真正跨群组共识的观点才会出现在这里，而非仅基于多数决定的观点。\n\n仅先显示统计上最显著的观点。",
   },
   "zh-Hant": {
     agreementsTitle: "通過",
     agreementsDescription:
-      "這些觀點獲得了每個意見群組的一致認可。\n\n這超越了簡單多數：即使大多數個體認可，一個群組的反對——無論其規模多小——就足以排除該觀點。\n\n只有反映真正跨群組共識的觀點才會出現在這裡，而非僅基於多數決定的觀點。",
+      "這些觀點獲得了每個意見群組的一致認可。\n\n這超越了簡單多數：即使大多數個體認可，一個群組的反對——無論其規模多小——就足以排除該觀點。\n\n只有反映真正跨群組共識的觀點才會出現在這裡，而非僅基於多數決定的觀點。\n\n僅先顯示統計上最顯著的觀點。",
     disagreementsTitle: "否決",
     disagreementsDescription:
-      "這些觀點被每個意見群組一致否決。\n\n這超越了簡單多數：即使大多數個體否決，一個群組的認可——無論其規模多小——就足以排除該觀點。\n\n只有反映真正跨群組共識的觀點才會出現在這裡，而非僅基於多數決定的觀點。",
+      "這些觀點被每個意見群組一致否決。\n\n這超越了簡單多數：即使大多數個體否決，一個群組的認可——無論其規模多小——就足以排除該觀點。\n\n只有反映真正跨群組共識的觀點才會出現在這裡，而非僅基於多數決定的觀點。\n\n僅先顯示統計上最顯著的觀點。",
   },
   ja: {
     agreementsTitle: "承認",
     agreementsDescription:
-      "これらの意見はすべての意見グループに全会一致で承認されています。\n\n単純な多数決を超えたものです：大多数が承認しても、一つのグループの反対——その規模に関わらず——だけでその意見は除外されます。\n\n真のグループ間合意を反映する意見のみがここに表示され、多数決だけに基づく意見は表示されません。",
+      "これらの意見はすべての意見グループに全会一致で承認されています。\n\n単純な多数決を超えたものです：大多数が承認しても、一つのグループの反対——その規模に関わらず——だけでその意見は除外されます。\n\n真のグループ間合意を反映する意見のみがここに表示され、多数決だけに基づく意見は表示されません。\n\n統計的に最も有意なものが最初に表示されます。",
     disagreementsTitle: "否決",
     disagreementsDescription:
-      "これらの意見はすべての意見グループに全会一致で否決されています。\n\n単純な多数決を超えたものです：大多数が否決しても、一つのグループの承認——その規模に関わらず——だけでその意見は除外されます。\n\n真のグループ間合意を反映する意見のみがここに表示され、多数決だけに基づく意見は表示されません。",
+      "これらの意見はすべての意見グループに全会一致で否決されています。\n\n単純な多数決を超えたものです：大多数が否決しても、一つのグループの承認——その規模に関わらず——だけでその意見は除外されます。\n\n真のグループ間合意を反映する意見のみがここに表示され、多数決だけに基づく意見は表示されません。\n\n統計的に最も有意なものが最初に表示されます。",
   },
 };

--- a/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.i18n.ts
+++ b/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.i18n.ts
@@ -9,8 +9,6 @@ export interface ConsensusTabTranslations {
   disagreementsKeyword: string;
   subtitleAgree: string;
   subtitleDisagree: string;
-  subtitleLoadMoreHint: string;
-  subtitleLoadMoreHintEmphasis: string;
   loadMore: string;
   noAgreementsMessage: string;
   noDisagreementsMessage: string;
@@ -31,11 +29,9 @@ export const consensusTabTranslations: Record<
     agreementsKeyword: "approved",
     disagreementsKeyword: "rejected",
     subtitleAgree:
-      "Statements all opinion groups agree to agree on. Not a simple majority, but a cross-group consensus. Ranked by statistical significance.",
+      "Statements all opinion groups agree to agree on. Not a simple majority, but a cross-group consensus. Only the most statistically significant are shown.",
     subtitleDisagree:
-      "Statements all opinion groups agree to disagree on. Not a simple majority, but a cross-group consensus. Ranked by statistical significance.",
-    subtitleLoadMoreHint: "Load all to show {emphasis} statement.",
-    subtitleLoadMoreHintEmphasis: "every",
+      "Statements all opinion groups agree to disagree on. Not a simple majority, but a cross-group consensus. Only the most statistically significant are shown.",
     loadMore: "Load all",
     noAgreementsMessage: "No consensus has emerged yet.",
     noDisagreementsMessage: "No consensus has emerged yet.",
@@ -51,11 +47,9 @@ export const consensusTabTranslations: Record<
     agreementsKeyword: "المعتمدة",
     disagreementsKeyword: "المرفوضة",
     subtitleAgree:
-      "مقترحات تتفق جميع مجموعات الرأي على الموافقة عليها — إجماع بين المجموعات، وليس مجرد تصويت أغلبية. مرتبة حسب الدلالة الإحصائية.",
+      "مقترحات تتفق جميع مجموعات الرأي على الموافقة عليها — إجماع بين المجموعات، وليس مجرد تصويت أغلبية. تُعرض فقط الأكثر دلالة إحصائياً.",
     subtitleDisagree:
-      "مقترحات تتفق جميع مجموعات الرأي على رفضها — إجماع بين المجموعات، وليس مجرد تصويت أغلبية. مرتبة حسب الدلالة الإحصائية.",
-    subtitleLoadMoreHint: "حمّل الكل لعرض {emphasis} المقترحات.",
-    subtitleLoadMoreHintEmphasis: "جميع",
+      "مقترحات تتفق جميع مجموعات الرأي على رفضها — إجماع بين المجموعات، وليس مجرد تصويت أغلبية. تُعرض فقط الأكثر دلالة إحصائياً.",
     loadMore: "تحميل الكل",
     noAgreementsMessage: "لم يظهر أي إجماع بعد.",
     noDisagreementsMessage: "لم يظهر أي إجماع بعد.",
@@ -71,11 +65,9 @@ export const consensusTabTranslations: Record<
     agreementsKeyword: "aprobadas",
     disagreementsKeyword: "rechazadas",
     subtitleAgree:
-      "Proposiciones aprobadas por unanimidad por todos los grupos de opinión. No se trata de una simple mayoría, sino de un consenso entre grupos. Ordenadas por significancia estadística.",
+      "Proposiciones aprobadas por unanimidad por todos los grupos de opinión. No se trata de una simple mayoría, sino de un consenso entre grupos. Solo se muestran las más estadísticamente significativas.",
     subtitleDisagree:
-      "Proposiciones rechazadas por unanimidad por todos los grupos de opinión. No se trata de una simple mayoría, sino de un consenso entre grupos. Ordenadas por significancia estadística.",
-    subtitleLoadMoreHint: "Cargue todo para mostrar {emphasis} proposición.",
-    subtitleLoadMoreHintEmphasis: "cada",
+      "Proposiciones rechazadas por unanimidad por todos los grupos de opinión. No se trata de una simple mayoría, sino de un consenso entre grupos. Solo se muestran las más estadísticamente significativas.",
     loadMore: "Cargar todo",
     noAgreementsMessage: "Aún no ha surgido ningún consenso.",
     noDisagreementsMessage: "Aún no ha surgido ningún consenso.",
@@ -91,11 +83,9 @@ export const consensusTabTranslations: Record<
     agreementsKeyword: "approuvées",
     disagreementsKeyword: "rejetées",
     subtitleAgree:
-      "Propositions approuvées à l'unanimité par tous les groupes d'opinion. Il ne s'agit pas d'une simple majorité, mais d'un consensus inter-groupes. Elles sont classées par significativité statistique.",
+      "Propositions approuvées à l'unanimité par tous les groupes d'opinion. Il ne s'agit pas d'une simple majorité, mais d'un consensus inter-groupes. Seules les plus statistiquement significatives sont affichées.",
     subtitleDisagree:
-      "Propositions rejetées à l'unanimité par tous les groupes d'opinion. Il ne s'agit pas d'une simple majorité, mais d'un consensus inter-groupes. Elles sont classées par significativité statistique.",
-    subtitleLoadMoreHint: "Tout charger pour afficher {emphasis} proposition.",
-    subtitleLoadMoreHintEmphasis: "chaque",
+      "Propositions rejetées à l'unanimité par tous les groupes d'opinion. Il ne s'agit pas d'une simple majorité, mais d'un consensus inter-groupes. Seules les plus statistiquement significatives sont affichées.",
     loadMore: "Tout charger",
     noAgreementsMessage: "Aucun consensus n'a encore émergé.",
     noDisagreementsMessage: "Aucun consensus n'a encore émergé.",
@@ -109,11 +99,9 @@ export const consensusTabTranslations: Record<
     agreementsKeyword: "认可",
     disagreementsKeyword: "否决",
     subtitleAgree:
-      "所有意见群组一致同意认可的观点——跨群组共识，而非简单的多数投票。按统计显著性排序。",
+      "所有意见群组一致同意认可的观点——跨群组共识，而非简单的多数投票。仅显示统计上最显著的观点。",
     subtitleDisagree:
-      "所有意见群组一致同意否决的观点——跨群组共识，而非简单的多数投票。按统计显著性排序。",
-    subtitleLoadMoreHint: "全部加载以显示{emphasis}观点。",
-    subtitleLoadMoreHintEmphasis: "每个",
+      "所有意见群组一致同意否决的观点——跨群组共识，而非简单的多数投票。仅显示统计上最显著的观点。",
     loadMore: "全部加载",
     noAgreementsMessage: "尚未形成共识。",
     noDisagreementsMessage: "尚未形成共识。",
@@ -127,11 +115,9 @@ export const consensusTabTranslations: Record<
     agreementsKeyword: "認可",
     disagreementsKeyword: "否決",
     subtitleAgree:
-      "所有意見群組一致同意認可的觀點——跨群組共識，而非簡單的多數投票。按統計顯著性排序。",
+      "所有意見群組一致同意認可的觀點——跨群組共識，而非簡單的多數投票。僅顯示統計上最顯著的觀點。",
     subtitleDisagree:
-      "所有意見群組一致同意否決的觀點——跨群組共識，而非簡單的多數投票。按統計顯著性排序。",
-    subtitleLoadMoreHint: "全部載入以顯示{emphasis}觀點。",
-    subtitleLoadMoreHintEmphasis: "每個",
+      "所有意見群組一致同意否決的觀點——跨群組共識，而非簡單的多數投票。僅顯示統計上最顯著的觀點。",
     loadMore: "全部載入",
     noAgreementsMessage: "尚未形成共識。",
     noDisagreementsMessage: "尚未形成共識。",
@@ -147,11 +133,9 @@ export const consensusTabTranslations: Record<
     agreementsKeyword: "承認",
     disagreementsKeyword: "否決",
     subtitleAgree:
-      "すべての意見グループが合意して承認した意見です——多数決ではなく、グループ間の合意です。統計的有意性の順に表示。",
+      "すべての意見グループが合意して承認した意見です——多数決ではなく、グループ間の合意です。統計的に最も有意なもののみ表示されます。",
     subtitleDisagree:
-      "すべての意見グループが合意して否決した意見です——多数決ではなく、グループ間の合意です。統計的有意性の順に表示。",
-    subtitleLoadMoreHint: "すべて読み込んで{emphasis}意見を表示。",
-    subtitleLoadMoreHintEmphasis: "各",
+      "すべての意見グループが合意して否決した意見です——多数決ではなく、グループ間の合意です。統計的に最も有意なもののみ表示されます。",
     loadMore: "すべて読み込む",
     noAgreementsMessage: "まだ合意は形成されていません。",
     noDisagreementsMessage: "まだ合意は形成されていません。",

--- a/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.vue
+++ b/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.vue
@@ -31,9 +31,6 @@
       <template #body>
         <div v-if="!compactMode" class="statistical-subtitle">
           {{ props.direction === "agree" ? t("subtitleAgree") : t("subtitleDisagree") }}
-          <template v-if="Object.keys(props.clusters).length > 1">
-            {{ loadMoreHintParts[0] }}<em>{{ t("subtitleLoadMoreHintEmphasis") }}</em>{{ loadMoreHintParts[1] }}
-          </template>
         </div>
 
         <EmptyStateMessage
@@ -97,11 +94,12 @@
     <ZKConfirmDialog
       v-model="showLoadMoreWarning"
       :title="tWarning('title')"
-      :message="tWarning('description')"
       :confirm-text="tWarning('loadMoreButton')"
       :cancel-text="tWarning('cancelButton')"
       @confirm="hasLoadedMore = true"
-    />
+    >
+      {{ warningDescriptionParts[0] }}<em>{{ tWarning('descriptionEmphasis') }}</em>{{ warningDescriptionParts[1] }}
+    </ZKConfirmDialog>
   </div>
 </template>
 
@@ -184,8 +182,8 @@ const emptyMessage = computed(() =>
     : t("noDisagreementsMessage")
 );
 
-const loadMoreHintParts = computed(() =>
-  t("subtitleLoadMoreHint").split("{emphasis}")
+const warningDescriptionParts = computed(() =>
+  tWarning("description").split("{emphasis}")
 );
 
 const {

--- a/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.i18n.ts
+++ b/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.i18n.ts
@@ -5,8 +5,6 @@ export interface DivisiveTabTranslations {
   divisiveLongTitle: string;
   divisiveKeyword: string;
   subtitle: string;
-  subtitleLoadMoreHint: string;
-  subtitleLoadMoreHintEmphasis: string;
   loadMore: string;
   noDivisiveOpinionsMessage: string;
   lowerRankedDivider: string;
@@ -21,9 +19,7 @@ export const divisiveTabTranslations: Record<
     divisiveLongTitle: "What {keyword} people across groups?",
     divisiveKeyword: "divides",
     subtitle:
-      "Statements that split opinion groups against each other. Ranked by statistical significance.",
-    subtitleLoadMoreHint: "Load all to show {emphasis} statement.",
-    subtitleLoadMoreHintEmphasis: "every",
+      "Statements that split opinion groups against each other. Only the most statistically significant are shown.",
     loadMore: "Load all",
     noDivisiveOpinionsMessage: "No significant divisive statements found yet.",
     lowerRankedDivider: "Less statistically significant",
@@ -33,9 +29,7 @@ export const divisiveTabTranslations: Record<
     divisiveLongTitle: "ما الذي {keyword} المشاركين عبر مجموعات الرأي؟",
     divisiveKeyword: "يقسم",
     subtitle:
-      "مقترحات تقسم مجموعات الرأي ضد بعضها البعض. مرتبة حسب الدلالة الإحصائية.",
-    subtitleLoadMoreHint: "حمّل الكل لعرض {emphasis} المقترحات.",
-    subtitleLoadMoreHintEmphasis: "جميع",
+      "مقترحات تقسم مجموعات الرأي ضد بعضها البعض. تُعرض فقط الأكثر دلالة إحصائياً.",
     loadMore: "تحميل الكل",
     noDivisiveOpinionsMessage: "لم يتم العثور على مقترحات مثيرة للجدل ذات دلالة بعد.",
     lowerRankedDivider: "أقل دلالة إحصائياً",
@@ -45,9 +39,7 @@ export const divisiveTabTranslations: Record<
     divisiveLongTitle: "¿Qué {keyword} a los participantes entre los grupos de opinión?",
     divisiveKeyword: "divide",
     subtitle:
-      "Proposiciones que dividen a los grupos de opinión entre sí. Ordenadas por significancia estadística.",
-    subtitleLoadMoreHint: "Cargue todo para mostrar {emphasis} proposición.",
-    subtitleLoadMoreHintEmphasis: "cada",
+      "Proposiciones que dividen a los grupos de opinión entre sí. Solo se muestran las más estadísticamente significativas.",
     loadMore: "Cargar todo",
     noDivisiveOpinionsMessage:
       "Aún no se encontraron proposiciones divisivas significativas.",
@@ -58,9 +50,7 @@ export const divisiveTabTranslations: Record<
     divisiveLongTitle: "Qu'est-ce qui {keyword} les participants entre les groupes d'opinion ?",
     divisiveKeyword: "divise",
     subtitle:
-      "Propositions qui divisent les groupes d'opinion entre eux. Elles sont classées par significativité statistique.",
-    subtitleLoadMoreHint: "Tout charger pour afficher {emphasis} proposition.",
-    subtitleLoadMoreHintEmphasis: "chaque",
+      "Propositions qui divisent les groupes d'opinion entre eux. Seules les plus statistiquement significatives sont affichées.",
     loadMore: "Tout charger",
     noDivisiveOpinionsMessage:
       "Aucune proposition controversée significative trouvée pour le moment.",
@@ -71,9 +61,7 @@ export const divisiveTabTranslations: Record<
     divisiveLongTitle: "什么使参与者在各意见群组之间产生{keyword}？",
     divisiveKeyword: "分歧",
     subtitle:
-      "使意见群组之间产生对立的观点。按统计显著性排序。",
-    subtitleLoadMoreHint: "全部加载以显示{emphasis}观点。",
-    subtitleLoadMoreHintEmphasis: "每个",
+      "使意见群组之间产生对立的观点。仅显示统计上最显著的观点。",
     loadMore: "全部加载",
     noDivisiveOpinionsMessage: "尚未找到显著的分歧观点。",
     lowerRankedDivider: "统计显著性较低",
@@ -83,9 +71,7 @@ export const divisiveTabTranslations: Record<
     divisiveLongTitle: "什麼使參與者在各意見群組之間產生{keyword}？",
     divisiveKeyword: "分歧",
     subtitle:
-      "使意見群組之間產生對立的觀點。按統計顯著性排序。",
-    subtitleLoadMoreHint: "全部載入以顯示{emphasis}觀點。",
-    subtitleLoadMoreHintEmphasis: "每個",
+      "使意見群組之間產生對立的觀點。僅顯示統計上最顯著的觀點。",
     loadMore: "全部載入",
     noDivisiveOpinionsMessage: "尚未找到顯著的分歧觀點。",
     lowerRankedDivider: "統計顯著性較低",
@@ -95,9 +81,7 @@ export const divisiveTabTranslations: Record<
     divisiveLongTitle: "意見グループ間で参加者を{keyword}しているものは何ですか？",
     divisiveKeyword: "分断",
     subtitle:
-      "意見グループ同士を対立させる意見です。統計的有意性の順に表示。",
-    subtitleLoadMoreHint: "すべて読み込んで{emphasis}意見を表示。",
-    subtitleLoadMoreHintEmphasis: "各",
+      "意見グループ同士を対立させる意見です。統計的に最も有意なもののみ表示されます。",
     loadMore: "すべて読み込む",
     noDivisiveOpinionsMessage: "有意な分断的主張はまだ見つかりません。",
     lowerRankedDivider: "統計的有意性が低い",

--- a/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.vue
+++ b/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.vue
@@ -31,9 +31,6 @@
       <template #body>
         <div v-if="!compactMode" class="statistical-subtitle">
           {{ t("subtitle") }}
-          <template v-if="Object.keys(props.clusters).length > 1">
-            {{ loadMoreHintParts[0] }}<em>{{ t("subtitleLoadMoreHintEmphasis") }}</em>{{ loadMoreHintParts[1] }}
-          </template>
         </div>
 
         <EmptyStateMessage
@@ -94,11 +91,12 @@
     <ZKConfirmDialog
       v-model="showLoadMoreWarning"
       :title="tWarning('title')"
-      :message="tWarning('description')"
       :confirm-text="tWarning('loadMoreButton')"
       :cancel-text="tWarning('cancelButton')"
       @confirm="hasLoadedMore = true"
-    />
+    >
+      {{ warningDescriptionParts[0] }}<em>{{ tWarning('descriptionEmphasis') }}</em>{{ warningDescriptionParts[1] }}
+    </ZKConfirmDialog>
   </div>
 </template>
 
@@ -152,8 +150,8 @@ const isSmallScreen = useMediaQuery("(max-width: 599px)");
 const keyword = computed(() => t("divisiveKeyword"));
 const titleParts = computed(() => t("divisiveLongTitle").split("{keyword}"));
 const showDivisiveInfo = ref(false);
-const loadMoreHintParts = computed(() =>
-  t("subtitleLoadMoreHint").split("{emphasis}")
+const warningDescriptionParts = computed(() =>
+  tWarning("description").split("{emphasis}")
 );
 
 const {

--- a/services/agora/src/components/ui-library/ZKConfirmDialog.vue
+++ b/services/agora/src/components/ui-library/ZKConfirmDialog.vue
@@ -4,7 +4,9 @@
       <div class="confirm-dialog">
         <div class="dialog-header">
           <h3 v-if="title" class="dialog-title">{{ title }}</h3>
-          <p class="dialog-message">{{ message }}</p>
+          <p v-if="message || $slots.default" class="dialog-message">
+            <slot>{{ message }}</slot>
+          </p>
         </div>
 
         <div class="dialog-actions">
@@ -41,6 +43,7 @@ defineOptions({
 
 withDefaults(defineProps<Props>(), {
   title: undefined,
+  message: undefined,
   confirmText: "Confirm",
   cancelText: "Cancel",
   variant: "default",
@@ -50,7 +53,7 @@ const emit = defineEmits<Emits>();
 
 interface Props {
   title?: string;
-  message: string;
+  message?: string;
   confirmText?: string;
   cancelText?: string;
   variant?: "default" | "destructive";
@@ -104,13 +107,12 @@ watch(showDialog, (newValue) => {
 }
 
 .dialog-header {
-  text-align: center;
-
   .dialog-title {
     margin: 0 0 1rem 0;
     font-size: 1.1rem;
     font-weight: var(--font-weight-semibold);
     color: $color-text-strong;
+    text-align: center;
   }
 
   .dialog-message {
@@ -118,6 +120,7 @@ watch(showDialog, (newValue) => {
     font-size: 1rem;
     color: black;
     line-height: 1.5;
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
## Summary
- Subtitles now clarify it's a **selection**: "Only the most statistically significant are shown" (replaces "Ranked by statistical significance")
- Warning dialog uses italic emphasis: "may not *actually* be significant"
- Consensus "Learn more" dialog now mentions the selection (divisive already did)
- Removed redundant `subtitleLoadMoreHint` text
- ZKConfirmDialog: added slot support for rich content, left-aligned message text (title stays centered)
- All 7 languages updated (en, ar, es, fr, zh-Hans, zh-Hant, ja)

## Test plan
- [ ] Navigate to a conversation analysis tab (consensus + divisive)
- [ ] Verify subtitles say "Only the most statistically significant are shown"
- [ ] Click "Load all" → verify warning dialog shows "actually" in italic
- [ ] Click "Learn more" on consensus tab → verify it mentions selection
- [ ] Check dialog text is left-aligned, title is centered
- [ ] Test in French and Arabic to verify translations