### PR TITLE
fix(python-bridge): update red-dwarf for geometric mean consensus

### DIFF
--- a/services/python-bridge/pyproject.toml
+++ b/services/python-bridge/pyproject.toml
@@ -70,5 +70,5 @@ dependencies = [
 	"urllib3==2.6.3",
 	"Werkzeug==3.1.6",
 	"gunicorn==23.0.0",
-	"red-dwarf @ git+https://github.com/nicobao/red-dwarf.git@e6fd28dfcbecfc9b470f5ec8ee7ebf1609cf5a73",
+	"red-dwarf @ git+https://github.com/nicobao/red-dwarf.git@b8660dd0c1a31d169ab1309022dacaf2883d361e",
 ]


### PR DESCRIPTION
## Summary
- Update red-dwarf dependency to upstream main which uses geometric mean (`product^(1/n_groups)`) instead of raw product for group-aware consensus scores
- Fixes the "Approved" tab showing "No consensus has emerged" even for statements with 93% cross-group agreement across all opinion groups (6 groups)
- Root cause: raw product of per-group probabilities shrinks exponentially with more groups (scored ~0.33 with 6 groups, below the 0.5 frontend threshold)

Upstream PR: https://github.com/polis-community/red-dwarf/pull/118

## Test plan
- [ ] Deploy python-bridge with updated red-dwarf
- [ ] Verify conversations with 4-6 opinion groups now show consensus statements in the "Approved" tab