### PR TITLE
fix(agora): recover from stale chunk loads after deployment

### DIFF
--- a/services/agora/src/router/index.ts
+++ b/services/agora/src/router/index.ts
@@ -58,15 +58,29 @@ export default defineRouter(function (/* { store, ssrContext } */) {
     }
   });
 
-  /*
+  // Auto-reload when a stale chunk fails to load after deployment.
   // @see https://stackoverflow.com/questions/69300341/typeerror-failed-to-fetch-dynamically-imported-module-on-vue-vite-vanilla-set
   // @see https://github.com/vitejs/vite/issues/11804#issuecomment-1406182566
   Router.onError((error, to) => {
-    if (error.message.includes("Failed to fetch dynamically imported module")) {
+    if (
+      error.message.includes("Failed to fetch dynamically imported module") ||
+      error.message.includes("Loading chunk") ||
+      error.message.includes("Loading CSS chunk")
+    ) {
+      const reloadKey = "chunk-reload";
+      const lastReload = sessionStorage.getItem(reloadKey);
+      const now = Date.now();
+      if (lastReload && now - Number(lastReload) < 10000) {
+        console.error(
+          "[Router] Chunk load failed after reload, giving up",
+          error
+        );
+        return;
+      }
+      sessionStorage.setItem(reloadKey, String(now));
       window.location.href = to.fullPath;
     }
   });
-  */
 
   /*
   // This will update routes at runtime without reloading the page

--- a/services/agora/src/utils/crypto/store.ts
+++ b/services/agora/src/utils/crypto/store.ts
@@ -1,15 +1,21 @@
 import * as BrowserCrypto from "../crypto/ucan/implementation/browser.js";
 import { type Implementation } from "./ucan/implementation.js";
 
-// localForage instance for storing keys only
 let webCryptoStore: Implementation | undefined = undefined;
+let initPromise: Promise<Implementation> | undefined = undefined;
 
 export async function getWebCryptoStore(): Promise<Implementation> {
   if (webCryptoStore !== undefined) {
     return webCryptoStore;
   }
-  webCryptoStore = await BrowserCrypto.implementation({
-    storeName: "agora-keys",
-  });
-  return webCryptoStore;
+  if (initPromise === undefined) {
+    initPromise = BrowserCrypto.implementation({
+      storeName: "agora-keys",
+    }).then((store) => {
+      webCryptoStore = store;
+      initPromise = undefined;
+      return store;
+    });
+  }
+  return initPromise;
 }

--- a/services/agora/src/utils/crypto/ucan/operation.ts
+++ b/services/agora/src/utils/crypto/ucan/operation.ts
@@ -1,3 +1,4 @@
+import * as ucans from "@ucans/ucans";
 import {
   httpMethodToAbility,
   httpPathnameToResourcePointer,
@@ -65,8 +66,6 @@ export async function buildUcan({
   method,
   lifetimeInSeconds = DEFAULT_UCAN_LIFETIME_SECONDS,
 }: BuildUcanProps): Promise<string> {
-  const ucans = await import("@ucans/ucans");
-
   const webCryptoStore = await getWebCryptoStore();
   const u = await ucans.Builder.create()
     .issuedBy({


### PR DESCRIPTION
## Summary

Fixes Sentry issue AGORA-APP-2: `TypeError: Failed to fetch dynamically imported module`.

When a new version is deployed, users with the SPA already open get blank pages on navigation because Vite chunk hashes change and old chunks no longer exist on the server. The Axios Network Errors on conversation/opinion endpoints were caused by the `@ucans/ucans` dynamic import also failing to load its stale chunk.

- Enable `Router.onError` handler to auto-reload on chunk load failures, with a sessionStorage guard to prevent infinite reload loops
- Convert `@ucans/ucans` from dynamic to static import — it's needed on every authenticated API call, so there's no code-splitting benefit; this eliminates a runtime failure point during deployments
- Fix race condition in `getWebCryptoStore()` where concurrent callers could trigger duplicate IndexedDB initializations

## Test plan

- [ ] `pnpm lint:fix` passes
- [ ] Deploy new version while a tab has the old version open, then navigate — should auto-reload instead of blank page
- [ ] Verify conversation pages load and API calls succeed normally