### PR TITLE
fix(agora): remove gap detection for consensus display

### DIFF
--- a/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.vue
+++ b/services/agora/src/components/post/analysis/consensusTab/ConsensusTab.vue
@@ -200,7 +200,7 @@ const {
     props.direction === "agree"
       ? item.groupAwareConsensusAgree
       : item.groupAwareConsensusDisagree,
-  minScore: 0.5,
+  minScore: 0.6,
 });
 
 function switchTab() {

--- a/services/agora/src/utils/component/analysis/statisticalRelevance.ts
+++ b/services/agora/src/utils/component/analysis/statisticalRelevance.ts
@@ -1,98 +1,34 @@
 import { computed, type ComputedRef, type Ref, ref } from "vue";
 
 /**
- * Gap-based display threshold for analysis tabs.
+ * Display threshold for analysis tabs.
  *
  * The backend ranks items using participation-dampened scoring:
  *   weighted_score = raw_score × totalVotes / GREATEST(totalVotes + participantCount × 0.1, 1)
  * (see services/api/src/utils/sqlLogic.ts — participationWeight)
  *
- * The frontend uses **gap detection** on the raw scores to find the natural cutoff.
- * We deliberately do NOT re-apply participation dampening here — the backend already
- * handles ranking quality. Applying the same dampening again ("double dampening")
- * creates an artificial cliff between well-voted and poorly-voted items.
- *
- * Additionally, items below an absolute minimum score (`minScore`) are excluded before
- * gap detection. This ensures tabs can be empty when no item has a strong enough signal
+ * Items below an absolute minimum score (`minScore`) are excluded.
+ * This ensures tabs can be empty when no item has a strong enough signal
  * (e.g., no genuine cross-group disagreement exists).
  *
- * ## Why gap detection?
- *
- * A fixed count cap (e.g., "always show 10") doesn't adapt to the data.
- * A percentage threshold (e.g., "show items above 20% of max") requires an arbitrary
- * tuning parameter. Gap detection is self-calibrating: it finds natural breaks in the
- * score distribution where meaningful items end and noise begins.
- *
- * References:
- * - Meilisearch dynamic thresholding: https://github.com/orgs/meilisearch/discussions/788
- * - "Where to Stop Reading a Ranked List?" (Arampatzis & Robertson, SIGIR 2009)
- *
- * ## The algorithm
- *
- * 1. Filter items below minScore (absolute quality bar)
- * 2. Extract raw scores for remaining items (in backend-sorted order)
- * 3. Compute consecutive gaps: gap[i] = score[i] - score[i+1]
- * 4. Find the first gap > GAP_SIGNIFICANCE × mean_positive_gap
- * 5. Show items up to that position, bounded by MAX_COUNT
- *
- * Note: Raw scores won't be monotonically decreasing (backend sorts by dampened score,
- * not raw score). Negative gaps (score increases) are filtered out — only downward drops
- * are considered significant.
+ * For consensus tabs, the geometric mean scores from reddwarf have clear
+ * semantic meaning: >0.5 = more likely than not genuine cross-group consensus.
+ * A minScore of 0.6 filters out borderline items while showing all genuinely
+ * strong consensus statements up to MAX_COUNT.
  */
 
 const MAX_COUNT = 15;
-const GAP_SIGNIFICANCE = 2.0;
-
-/**
- * Computes how many items to display by default using gap detection.
- * Items are expected in backend-ranked order (highest weighted score first).
- * Uses raw scores (not participation-dampened) because the backend already
- * applies participation dampening in its ORDER BY.
- */
-function computeDefaultDisplayCount<T>({
-  items,
-  getRawScore,
-}: {
-  items: T[];
-  getRawScore: (item: T) => number;
-}): number {
-  if (items.length === 0) return 0;
-
-  const scores = items.map((item) => getRawScore(item));
-
-  // Compute consecutive gaps
-  const gaps: number[] = [];
-  for (let i = 0; i < scores.length - 1; i++) {
-    gaps.push(scores[i] - scores[i + 1]);
-  }
-
-  // Mean of non-zero gaps (zero gaps mean identical scores — not informative)
-  const nonZeroGaps = gaps.filter((g) => g > 0);
-  if (nonZeroGaps.length === 0) return Math.min(items.length, MAX_COUNT);
-  const meanGap =
-    nonZeroGaps.reduce((a, b) => a + b, 0) / nonZeroGaps.length;
-
-  // Find first significant gap
-  for (let i = 0; i < gaps.length; i++) {
-    if (gaps[i] > meanGap * GAP_SIGNIFICANCE) {
-      return i + 1;
-    }
-  }
-
-  // No significant gap → show up to MAX_COUNT
-  return Math.min(items.length, MAX_COUNT);
-}
 
 const COMPACT_COUNT = 3;
 
 /**
- * Composable for analysis tab display logic with gap-based smart threshold.
- * Encapsulates the shared pattern: qualifiedItems → defaultCount → displayedItems,
+ * Composable for analysis tab display logic with score-based threshold.
+ * Encapsulates the shared pattern: qualifiedItems → displayedItems,
  * plus load-more state management.
  *
  * @param minScore — absolute minimum raw score. Items below this are excluded
  *   from default display (but revealed when the user clicks "Load More").
- *   For consensus probabilities (0-1), use 0.5 ("more likely than not").
+ *   For consensus probabilities (0-1), use 0.6 (strong cross-group signal).
  */
 export function useAnalysisDisplayList<T>({
   items,
@@ -114,13 +50,10 @@ export function useAnalysisDisplayList<T>({
   );
 
   const defaultCount = computed(() =>
-    computeDefaultDisplayCount({
-      items: qualifiedItems.value,
-      getRawScore,
-    })
+    Math.min(qualifiedItems.value.length, MAX_COUNT)
   );
 
-  // Items within the gap-detection cutoff — shown by default
+  // Items above the score threshold — shown by default
   const representativeItems = computed(() => {
     const count = compactMode.value
       ? Math.min(COMPACT_COUNT, defaultCount.value)


### PR DESCRIPTION
## Summary

- Remove gap detection algorithm from `statisticalRelevance.ts` — it was hiding strong consensus statements (e.g., 0.84 geometric mean) when top scores were tightly clustered
- Show all items above `minScore` up to `MAX_COUNT=15` instead
- Raise consensus `minScore` from 0.5 to 0.6 (with geometric mean from reddwarf, 0.6 means genuinely strong cross-group signal)
- DivisiveTab unchanged (different score scale, default `minScore=0`)

Follows up on #636 (geometric mean fix in reddwarf).

## Test plan

- [ ] Verify consensus tabs show all statements with score >= 0.6 without hiding behind divider
- [ ] Verify "Load more" still reveals items below 0.6
- [ ] Verify compact mode still caps at 3 items
- [ ] Verify DivisiveTab behavior unchanged

Deploy: agora