### PR TITLE
fix(agora): normalize divisive scores for threshold filtering

### DIFF
--- a/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.vue
+++ b/services/agora/src/components/post/analysis/divisivenessTab/DivisiveTab.vue
@@ -154,6 +154,12 @@ const warningDescriptionParts = computed(() =>
   tWarning("description").split("{emphasis}")
 );
 
+// Normalize extremity to [0,1] so we can apply a minScore threshold.
+// Extremity (sqrt(x²+y²) in PCA space) is unbounded and varies per conversation.
+const maxDivisive = computed(() =>
+  Math.max(...props.itemList.map((item) => item.divisiveScore), 0)
+);
+
 const {
   representativeItems,
   additionalItems,
@@ -164,7 +170,9 @@ const {
 } = useAnalysisDisplayList({
   items: toRef(props, "itemList"),
   compactMode: toRef(props, "compactMode"),
-  getRawScore: (item) => item.divisiveScore,
+  getRawScore: (item) =>
+    maxDivisive.value > 0 ? item.divisiveScore / maxDivisive.value : 0,
+  minScore: 0.6,
 });
 
 function switchTab() {


### PR DESCRIPTION
## Summary

- Normalize extremity (divisiveScore) to [0,1] by dividing by the max score in the conversation
- Apply `minScore: 0.6` so only items with at least 60% of the top extremity are shown as representative
- Items below the threshold remain accessible via "Load more"

Follows up on #638 (gap detection removal). Extremity is `sqrt(x²+y²)` in PCA space — unbounded and conversation-dependent — so a fixed absolute threshold doesn't work. Normalizing first makes the threshold meaningful.

## Test plan

- [ ] Verify Divisive tab shows only top divisive items (not all 15)
- [ ] Verify "Load more" reveals remaining items
- [ ] Verify consensus tabs unchanged
- [ ] Verify empty state still works when no items are divisive enough

Deploy: agora