### PR TITLE
fix(api): fix TypeScript build errors in authUtil and email

### DIFF
--- a/services/api/src/service/authUtil.ts
+++ b/services/api/src/service/authUtil.ts
@@ -307,8 +307,12 @@ export async function getDeviceStatus({
                       countryCallingCode: device.phoneCountryCallingCode,
                   }
                 : null,
+        // TODO: handle more gracefully when nullifier exists but citizenship/sex is missing.
+        // We should return whatever fields we have (partial data), and only allow
+        // the user to click on "ID Verified" when info beyond the nullifier is present.
         rarimo:
-            device.zkPassportCitizenship !== null
+            device.zkPassportCitizenship !== null &&
+            device.zkPassportSex !== null
                 ? { citizenship: device.zkPassportCitizenship, sex: device.zkPassportSex }
                 : null,
     };

--- a/services/api/src/service/email.ts
+++ b/services/api/src/service/email.ts
@@ -9,11 +9,11 @@ let transporter: nodemailer.Transporter | undefined;
 
 function getTransporter(): nodemailer.Transporter {
     if (transporter === undefined) {
-        const ses = new SESv2Client({
+        const sesClient = new SESv2Client({
             region: config.AWS_SES_REGION,
         });
         transporter = nodemailer.createTransport({
-            SES: { ses, aws: { SendEmailCommand } },
+            SES: { sesClient, SendEmailCommand },
         });
     }
     return transporter;


### PR DESCRIPTION
## Summary

- **authUtil.ts**: Add explicit null check on `zkPassportSex` alongside `zkPassportCitizenship` to fix TypeScript narrowing error from leftJoin nullable columns. Added TODO for gracefully handling partial rarimo data.
- **email.ts**: Update SES transport from old nodemailer v5/v6 pattern (`{ ses, aws: { SendEmailCommand } }`) to nodemailer 8.x pattern (`{ sesClient, SendEmailCommand }`). Fixes both a type error and a runtime bug.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (44/44)
- [ ] `pnpm image:build` succeeds (Docker build)

Deploy: api