### PR TITLE
fix(agora): prevent blank flash between feed skeleton and content

### DIFF
--- a/services/agora/src/components/feed/CompactPostList.vue
+++ b/services/agora/src/components/feed/CompactPostList.vue
@@ -2,7 +2,7 @@
   <div>
     <WidthWrapper :enable="true">
       <q-pull-to-refresh @refresh="pullDownTriggered">
-        <FeedSkeleton v-if="!isAuthInitialized" />
+        <FeedSkeleton v-if="!isAuthInitialized || !initializedFeed" />
         <q-infinite-scroll
           v-else
           :offset="2000"


### PR DESCRIPTION
## Summary
- Keep feed skeleton visible until both auth and feed data are initialized
- Previously, `isAuthInitialized` becoming `true` hid the skeleton while `loadPostData()` was still in-flight, causing a blank flash before content appeared

## Test plan
- [ ] Load the home feed and confirm skeleton displays continuously until posts appear (no blank flash)
- [ ] Test pull-to-refresh still works
- [ ] Test tab switching between "following" and "new" still shows loading indicator