### PR TITLE
chore(api): move deferred migration to flyway

### DIFF
--- a/services/api/database/flyway/V0038.2__drop_is_login_required.sql
+++ b/services/api/database/flyway/V0038.2__drop_is_login_required.sql
@@ -1,0 +1,3 @@
+-- Drop the old is_login_required column from conversation table
+-- All services are now deployed with participation_mode support
+ALTER TABLE "conversation" DROP COLUMN IF EXISTS "is_login_required";

--- a/services/api/database/post_migration/V0037.3__drop_is_login_required.sql
+++ b/services/api/database/post_migration/V0037.3__drop_is_login_required.sql
@@ -1,3 +1,0 @@
--- Deferred: Drop the old is_login_required column from conversation table
--- Move this file to database/flyway/ when all services are deployed with participation_mode support
-ALTER TABLE "conversation" DROP COLUMN IF EXISTS "is_login_required";


### PR DESCRIPTION
## Summary
- Move `drop_is_login_required` migration from `post_migration/` to `flyway/` now that all services are deployed with participation_mode support
- Renamed from `V0037.3` to `V0038.2` to avoid flyway out-of-order validation error (no `outOfOrder` config)

## Test plan
- [ ] Run `pnpm db:migrate` — flyway should pick up and execute `V0038.2`
- [ ] Verify `is_login_required` column is dropped from `conversation` table