### PR TITLE
fix(math-updater,python-bridge): fix empty representative opinions for clusters

### DIFF
--- a/services/math-updater/src/services/polisMathUpdater.ts
+++ b/services/math-updater/src/services/polisMathUpdater.ts
@@ -234,7 +234,7 @@ async function phase1CreateClusterStructure({
     > = {} as Record<PolisKey, GroupCommentStats[string]>;
 
     for (let clusterKey = 0; clusterKey < minNumberOfClusters; clusterKey++) {
-        const repnessEntry = polisMathResults.repness[clusterKey];
+        const repnessEntry = polisMathResults.repness[clusterKey] ?? [];
         const groupCommentStatsEntry =
             polisMathResults.group_comment_stats[clusterKey];
         const participants = polisMathResults.participants_df.filter(

--- a/services/python-bridge/pyproject.toml
+++ b/services/python-bridge/pyproject.toml
@@ -70,5 +70,5 @@ dependencies = [
 	"urllib3==2.6.3",
 	"Werkzeug==3.1.6",
 	"gunicorn==23.0.0",
-	"red-dwarf @ git+https://github.com/nicobao/red-dwarf.git@b8660dd0c1a31d169ab1309022dacaf2883d361e",
+	"red-dwarf @ git+https://github.com/nicobao/red-dwarf.git@e63c771cbd0bdd131c84d24f17f9663557bd7a55",
 ]


### PR DESCRIPTION
## Summary
- The reddwarf fallback in `select_representative_statements()` was producing malformed output (raw pandas Series columns instead of formatted `PolisRepnessStatement` dicts), causing Zod validation to reject the **entire** math update result. This left conversations with stale cluster data where some opinion groups had 0 representative statements.
- Bumps red-dwarf pin to [`e63c771`](https://github.com/nicobao/red-dwarf/commit/e63c771cbd0bdd131c84d24f17f9663557bd7a55) which formats the fallback output through `format_comment_stats()` and handles `best_overall=None`
- Adds `?? []` fallback in math-updater for missing repness cluster keys (defense-in-depth)

## Test plan
- [ ] Deploy python-bridge with updated red-dwarf dependency
- [ ] Deploy math-updater
- [ ] Trigger math update for affected conversation and verify all groups get representative statements
- [ ] Check logs for absence of "Failed to get valid math results" warnings