### PR TITLE
fix(agora): prevent back-button deadloop after verification

### DIFF
--- a/services/agora/src/composables/verification/useVerificationComplete.ts
+++ b/services/agora/src/composables/verification/useVerificationComplete.ts
@@ -18,7 +18,7 @@ export function useVerificationComplete() {
     if (onboardingMode == "LOGIN") {
       await routeUserAfterLogin();
     } else {
-      await router.push({ name: "/onboarding/step4-username/" });
+      await router.replace({ name: "/onboarding/step4-username/" });
     }
   }
 

--- a/services/agora/src/stores/loginIntention.ts
+++ b/services/agora/src/stores/loginIntention.ts
@@ -172,10 +172,10 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
 
     switch (activeUserIntention.value) {
       case "none":
-        await router.push({ name: "/" });
+        await router.replace({ name: "/" });
         break;
       case "agreement":
-        await router.push({
+        await router.replace({
           name: opinionAgreementIntention.isEmbedView
             ? "/conversation/[postSlugId].embed"
             : "/conversation/[postSlugId]/",
@@ -184,16 +184,16 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
         });
         break;
       case "newConversation":
-        await router.push({ name: "/conversation/new/create/" });
+        await router.replace({ name: "/conversation/new/create/" });
         break;
       case "newOpinion":
-        await router.push({
+        await router.replace({
           name: "/conversation/[postSlugId]/",
           params: { postSlugId: newOpinionIntention.conversationSlugId },
         });
         break;
       case "voting":
-        await router.push({
+        await router.replace({
           name: votingIntention.isEmbedView
             ? "/conversation/[postSlugId].embed"
             : "/conversation/[postSlugId]/",
@@ -201,7 +201,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
         });
         break;
       case "reportUserContent":
-        await router.push({
+        await router.replace({
           name: reportUserContentIntention.isEmbedView
             ? "/conversation/[postSlugId].embed"
             : "/conversation/[postSlugId]/",
@@ -210,7 +210,7 @@ export const useLoginIntentionStore = defineStore("loginIntention", () => {
         });
         break;
       case "settings":
-        await router.push({ name: "/settings/" });
+        await router.replace({ name: "/settings/" });
         break;
       default:
         console.error("Unknown intention");


### PR DESCRIPTION
## Summary

- After completing email/phone/Rarimo verification from settings, pressing the browser back button created an infinite redirect loop: settings → back → verify page (auto-detects credential) → redirects to settings → back → loop forever
- Changed all `router.push()` to `router.replace()` in `routeUserAfterLogin()` and the SIGNUP branch of `completeVerification()`, so verification pages are replaced in browser history instead of added — they no longer appear when pressing back

## Test plan

- [ ] From settings, add an email → complete OTP → land on settings → press back → should NOT loop back to verification
- [ ] Repeat for phone verification
- [ ] Repeat for Rarimo verification  
- [ ] Test signup (onboarding) flow: verification → username step → home, back button should not return to verification pages
- [ ] Verify `pnpm lint:fix` passes