### PR TITLE
fix(api): use ReacherIsReachable enum type for emailReachability

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -68,7 +68,10 @@ import {
     getUserProfile,
 } from "./service/user.js";
 import axios, { type AxiosInstance } from "axios";
-import { checkEmailDeliverability } from "./service/emailVerification.js";
+import {
+    checkEmailDeliverability,
+    type ReacherIsReachable,
+} from "./service/emailVerification.js";
 import {
     generateVerificationLink,
     verifyUserStatusAndAuthenticate,
@@ -982,7 +985,7 @@ server.after(() => {
                         reason: "already_has_credential",
                     };
                 }
-                let emailReachability: string | null = null;
+                let emailReachability: ReacherIsReachable | null = null;
                 if (axiosReacher !== undefined) {
                     const deliverability = await checkEmailDeliverability({
                         axiosReacher,

--- a/services/api/src/service/auth.ts
+++ b/services/api/src/service/auth.ts
@@ -6,6 +6,7 @@ import {
     otpCodesEqual,
 } from "@/crypto.js";
 import { determineAuthType } from "./auth/core/stateHelpers.js";
+import type { ReacherIsReachable } from "@/service/emailVerification.js";
 import type { CredentialAuthState, AuthResult } from "./auth/core/types.js";
 import {
     authAttemptPhoneTable,
@@ -1793,7 +1794,7 @@ interface AuthenticateEmailAttemptProps {
     throttleEmailSecondsInterval: number;
     testCode: number;
     doUseTestCode: boolean;
-    emailReachability: string | null;
+    emailReachability: ReacherIsReachable | null;
 }
 
 export async function authenticateEmailAttempt({
@@ -1903,7 +1904,7 @@ interface InsertEmailAuthAttemptCodeProps {
     throttleEmailSecondsInterval: number;
     testCode: number;
     doUseTestCode: boolean;
-    emailReachability: string | null;
+    emailReachability: ReacherIsReachable | null;
 }
 
 async function insertEmailAuthAttemptCode({
@@ -1976,7 +1977,7 @@ interface UpdateEmailAuthAttemptCodeProps {
     throttleEmailSecondsInterval: number;
     testCode: number;
     doUseTestCode: boolean;
-    emailReachability: string | null;
+    emailReachability: ReacherIsReachable | null;
 }
 
 async function updateEmailAuthAttemptCode({
@@ -2125,7 +2126,7 @@ interface RegisterWithEmailProps {
     userAgent: string;
     userId: string;
     sessionExpiry: Date;
-    emailReachability: string | null;
+    emailReachability: ReacherIsReachable | null;
 }
 
 // WARN: we assume the OTP was verified AND EXPIRED at registerOrLoginWithEmail entry point
@@ -2192,7 +2193,7 @@ interface RegisterOrLoginWithEmailBaseProps {
     userAgent: string;
     now: Date;
     sessionLifetimeDays: number;
-    emailReachability: string | null;
+    emailReachability: ReacherIsReachable | null;
 }
 
 type RegisterOrLoginWithEmailProps =


### PR DESCRIPTION
## Summary
- Fix TypeScript build errors (TS2769, TS2322) caused by `emailReachability` being typed as `string | null` instead of the `ReacherIsReachable` enum type expected by the Drizzle database schema
- Use the existing `ReacherIsReachable` type (`"safe" | "risky" | "invalid" | "unknown"`) from `emailVerification.ts` in all 5 interface definitions and 1 variable declaration

## Test plan
- [x] `pnpm build` in `services/api` passes with no type errors