### PR TITLE
feat(api): translate OTP email into all display languages

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -984,6 +984,12 @@ server.after(() => {
                 const userAgent =
                     request.headers["user-agent"] ?? "Unknown device";
 
+                const parsedLang = ZodSupportedDisplayLanguageCodes.safeParse(
+                    request.headers["accept-language"],
+                );
+                const headerLanguageCode: SupportedDisplayLanguageCodes =
+                    parsedLang.success ? parsedLang.data : "en";
+
                 return await authService.authenticateEmailAttempt({
                     db,
                     axiosReacher,
@@ -1001,6 +1007,7 @@ server.after(() => {
                         ),
                     testCode: config.TEST_CODE,
                     userAgent: userAgent,
+                    headerLanguageCode,
                 });
             }
             return await doAuthenticateEmail();

--- a/services/api/src/service/auth.ts
+++ b/services/api/src/service/auth.ts
@@ -20,6 +20,7 @@ import {
     zkPassportTable,
     phoneTable,
     userTable,
+    userDisplayLanguageTable,
 } from "@/shared-backend/schema.js";
 import { nowZeroMs } from "@/shared/util.js";
 import type {
@@ -44,6 +45,10 @@ import { isPhoneNumberTypeSupported } from "@/shared-app-api/phone.js";
 import { base64Decode, base64Encode } from "@/shared-app-api/base64.js";
 import { mergeGuestIntoVerifiedUser } from "./merge.js";
 import { sendOtpEmail } from "./email.js";
+import {
+    type SupportedDisplayLanguageCodes,
+    ZodSupportedDisplayLanguageCodes,
+} from "@/shared/languages.js";
 
 interface VerifyOtpProps {
     db: PostgresDatabase;
@@ -1799,6 +1804,7 @@ interface AuthenticateEmailAttemptProps {
     throttleEmailSecondsInterval: number;
     testCode: number;
     doUseTestCode: boolean;
+    headerLanguageCode?: SupportedDisplayLanguageCodes;
 }
 
 export async function authenticateEmailAttempt({
@@ -1812,6 +1818,7 @@ export async function authenticateEmailAttempt({
     throttleEmailSecondsInterval,
     testCode,
     doUseTestCode,
+    headerLanguageCode = "en",
 }: AuthenticateEmailAttemptProps): Promise<AuthenticateEmailResponse> {
     const now = nowZeroMs();
     const authResult = await getEmailAuthType({
@@ -1845,6 +1852,31 @@ export async function authenticateEmailAttempt({
     const userId =
         authResult.type === "merge" ? authResult.toUserId : authResult.userId;
     const type = authResult.type;
+
+    // Resolve email language: for existing users (login/merge), prefer stored display language;
+    // for registration, the user has no preferences yet so use Accept-Language header
+    let emailLanguageCode: SupportedDisplayLanguageCodes = headerLanguageCode;
+    if (type !== "register") {
+        const storedDisplayLanguage = await db
+            .select({ languageCode: userDisplayLanguageTable.languageCode })
+            .from(userDisplayLanguageTable)
+            .where(
+                and(
+                    eq(userDisplayLanguageTable.userId, userId),
+                    eq(userDisplayLanguageTable.isDeleted, false),
+                ),
+            )
+            .limit(1);
+        if (storedDisplayLanguage.length > 0) {
+            const parsed = ZodSupportedDisplayLanguageCodes.safeParse(
+                storedDisplayLanguage[0].languageCode,
+            );
+            if (parsed.success) {
+                emailLanguageCode = parsed.data;
+            }
+        }
+    }
+
     const resultHasAttempted = await db
         .select({
             codeExpiry: authAttemptEmailTable.codeExpiry,
@@ -1867,6 +1899,7 @@ export async function authenticateEmailAttempt({
             doUseTestCode,
             testCode,
             emailReachability,
+            languageCode: emailLanguageCode,
         });
     } else if (isRequestingNewCode) {
         // user wants to regenerate new code (if possible according to throttling)
@@ -1882,6 +1915,7 @@ export async function authenticateEmailAttempt({
             doUseTestCode,
             testCode,
             emailReachability,
+            languageCode: emailLanguageCode,
         });
     } else if (resultHasAttempted[0].codeExpiry > now) {
         // code hasn't expired
@@ -1925,6 +1959,7 @@ interface InsertEmailAuthAttemptCodeProps {
     testCode: number;
     doUseTestCode: boolean;
     emailReachability: ReacherIsReachable | null;
+    languageCode: SupportedDisplayLanguageCodes;
 }
 
 async function insertEmailAuthAttemptCode({
@@ -1940,6 +1975,7 @@ async function insertEmailAuthAttemptCode({
     doUseTestCode,
     testCode,
     emailReachability,
+    languageCode,
 }: InsertEmailAuthAttemptCodeProps): Promise<AuthenticateEmailResponse> {
     const isThrottled = await isThrottledByEmail({
         db,
@@ -1960,7 +1996,7 @@ async function insertEmailAuthAttemptCode({
     );
     const mustSendActualEmail = config.NODE_ENV === "production";
     if (mustSendActualEmail) {
-        await sendOtpEmail({ email, otp: oneTimeCode });
+        await sendOtpEmail({ email, otp: oneTimeCode, languageCode });
     } else {
         console.log("\n\nCode:", codeToString(oneTimeCode), codeExpiry, "\n\n");
     }
@@ -1998,6 +2034,7 @@ interface UpdateEmailAuthAttemptCodeProps {
     testCode: number;
     doUseTestCode: boolean;
     emailReachability: ReacherIsReachable | null;
+    languageCode: SupportedDisplayLanguageCodes;
 }
 
 async function updateEmailAuthAttemptCode({
@@ -2012,6 +2049,7 @@ async function updateEmailAuthAttemptCode({
     doUseTestCode,
     testCode,
     emailReachability,
+    languageCode,
 }: UpdateEmailAuthAttemptCodeProps): Promise<AuthenticateEmailResponse> {
     const isThrottled = await isThrottledByEmail({
         db,
@@ -2032,7 +2070,7 @@ async function updateEmailAuthAttemptCode({
     );
     const mustSendActualEmail = config.NODE_ENV === "production";
     if (mustSendActualEmail) {
-        await sendOtpEmail({ email, otp: oneTimeCode });
+        await sendOtpEmail({ email, otp: oneTimeCode, languageCode });
     } else {
         console.log("\n\nCode:", codeToString(oneTimeCode), codeExpiry, "\n\n");
     }

--- a/services/api/src/service/email.ts
+++ b/services/api/src/service/email.ts
@@ -2,6 +2,7 @@ import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import nodemailer from "nodemailer";
 import { config, log } from "@/app.js";
 import { codeToString } from "@/crypto.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 
 // Lazy-initialized: only created when actually sending emails (production)
 // This avoids crashing in development where SES is not configured
@@ -42,19 +43,68 @@ export async function sendEmail({
     log.info("[Email] Email sent successfully");
 }
 
+interface OtpEmailTranslation {
+    subject: string;
+    text: (code: string) => string;
+}
+
+const otpEmailTranslations: Record<
+    SupportedDisplayLanguageCodes,
+    OtpEmailTranslation
+> = {
+    en: {
+        subject: "Your Agora confirmation code",
+        text: (code) =>
+            `Your confirmation code is ${code}\n\nEnter it shortly in the same browser/device that you used for your authentication request.\n\nIf you didn't request this email, there's nothing to worry about: you can safely ignore it.`,
+    },
+    es: {
+        subject: "Su código de confirmación de Agora",
+        text: (code) =>
+            `Su código de confirmación es ${code}\n\nIntrodúzcalo pronto en el mismo navegador/dispositivo que utilizó para su solicitud de autenticación.\n\nSi no solicitó este correo electrónico, no se preocupe: puede ignorarlo con tranquilidad.`,
+    },
+    fr: {
+        subject: "Votre code de confirmation Agora",
+        text: (code) =>
+            `Votre code de confirmation est ${code}\n\nSaisissez-le rapidement dans le même navigateur/appareil que celui utilisé pour votre demande d'authentification.\n\nSi vous n'avez pas demandé cet e-mail, ne vous inquiétez pas : vous pouvez l'ignorer en toute sécurité.`,
+    },
+    "zh-Hans": {
+        subject: "您的 Agora 确认码",
+        text: (code) =>
+            `您的确认码是 ${code}\n\n请尽快在您发起身份验证请求的同一浏览器/设备上输入此确认码。\n\n如果您没有请求此邮件，无需担心，请放心忽略。`,
+    },
+    "zh-Hant": {
+        subject: "您的 Agora 確認碼",
+        text: (code) =>
+            `您的確認碼是 ${code}\n\n請儘快在您發起身份驗證請求的同一瀏覽器/裝置上輸入此確認碼。\n\n如果您沒有請求此郵件，無需擔心，請放心忽略。`,
+    },
+    ja: {
+        subject: "Agora 認証コード",
+        text: (code) =>
+            `認証コードは ${code} です\n\n認証リクエストを行ったブラウザ/デバイスで速やかにご入力ください。\n\nこのメールに心当たりがない場合は、無視していただいて問題ありません。`,
+    },
+    ar: {
+        subject: "رمز التأكيد الخاص بك في Agora",
+        text: (code) =>
+            `رمز التأكيد الخاص بك هو ${code}\n\nأدخله في أقرب وقت في نفس المتصفح/الجهاز الذي استخدمته لطلب المصادقة.\n\nإذا لم تطلب هذا البريد الإلكتروني، فلا داعي للقلق: يمكنك تجاهله بأمان.`,
+    },
+};
+
 interface SendOtpEmailProps {
     email: string;
     otp: number;
+    languageCode: SupportedDisplayLanguageCodes;
 }
 
 export async function sendOtpEmail({
     email,
     otp,
+    languageCode,
 }: SendOtpEmailProps): Promise<void> {
     const code = codeToString(otp);
+    const translation = otpEmailTranslations[languageCode];
     await sendEmail({
         to: email,
-        subject: "Your Agora confirmation code",
-        text: `Your confirmation code is ${code}\n\nEnter it shortly in the same browser/device that you used for your authentication request.\n\nIf you didn't request this email, there's nothing to worry about: you can safely ignore it.`,
+        subject: translation.subject,
+        text: translation.text(code),
     });
 }


### PR DESCRIPTION
## Summary

- Translate the OTP confirmation code email (subject + body) into all 7 supported display languages: English, Spanish, French, Simplified Chinese, Traditional Chinese, Japanese, and Arabic
- Language resolution: stored user preference (DB) → Accept-Language header → English fallback
- DB lookup is skipped for registration (new users have no preferences yet)

## Test plan

- [ ] Start dev API, trigger email auth — verify OTP code is logged to console (dev mode skips actual email send)
- [ ] In production, verify email is sent in the correct language based on user's stored display language
- [ ] Verify Accept-Language header fallback works for new registrations
- [ ] Verify English fallback when no language info is available