### PR TITLE
fix(api): add missing languageCode to expired email code path

### DIFF
--- a/services/api/src/service/auth.ts
+++ b/services/api/src/service/auth.ts
@@ -1942,6 +1942,7 @@ export async function authenticateEmailAttempt({
             doUseTestCode,
             testCode,
             emailReachability,
+            languageCode: emailLanguageCode,
         });
     }
 }


### PR DESCRIPTION
## Summary
- Adds the missing `languageCode: emailLanguageCode` parameter to the third call site of `updateEmailAuthAttemptCode()` in `auth.ts`
- This call site (the "code expired, regenerate new one" branch) was missed when `languageCode` was added as a required prop in PR #680
- Fixes the API build failure (`TS2345: Property 'languageCode' is missing`)

## Test plan
- [x] `pnpm build` passes in `services/api`

Deploy: api