### PR TITLE
fix(agora): prevent report header stats from overflowing container

### DIFF
--- a/services/agora/src/components/post/report/AnalysisReport.vue
+++ b/services/agora/src/components/post/report/AnalysisReport.vue
@@ -398,7 +398,7 @@ defineExpose({
 
 <style lang="scss" scoped>
 .report-container {
-  width: 210mm;
+  width: 260mm;
   max-width: 100%;
   margin: 0 auto;
   background: white;
@@ -412,7 +412,7 @@ defineExpose({
 }
 
 .report-section-block {
-  padding: 6mm;
+  padding: 6mm 4mm;
   background: white;
 }
 

--- a/services/agora/src/components/post/report/ReportHeader.vue
+++ b/services/agora/src/components/post/report/ReportHeader.vue
@@ -104,6 +104,8 @@ const formattedDate = computed(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1.5rem;
   margin-bottom: 1.25rem;
 }
 
@@ -134,30 +136,26 @@ const formattedDate = computed(() => {
 
 .stats-row {
   display: flex;
-  gap: 2.5rem;
+  gap: 1.5rem;
 }
 
 .stat-item {
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-width: 5rem;
+  white-space: nowrap;
 }
 
 .stat-value {
-  position: relative;
+  display: inline-flex;
+  align-items: baseline;
   font-size: 1rem;
   font-weight: var(--font-weight-semibold);
   color: #333238;
 }
 
 .stat-of {
-  position: absolute;
-  left: 100%;
-  top: 50%;
-  transform: translateY(-50%);
-  margin-left: 0.3em;
-  white-space: nowrap;
+  margin-left: 0.25em;
   font-size: 0.8rem;
   font-weight: var(--font-weight-regular);
   color: #b8b5bf;

--- a/services/agora/src/pages/dev/analysis-report-test.i18n.ts
+++ b/services/agora/src/pages/dev/analysis-report-test.i18n.ts
@@ -21,6 +21,10 @@ export interface AnalysisReportTestTranslations {
   emptySectionsAgreements: string;
   emptySectionsDisagreements: string;
   emptySectionsDivisive: string;
+  numberScaleLabel: string;
+  numberScaleNormal: string;
+  numberScaleLarge: string;
+  numberScaleVeryLarge: string;
   downloadImagesZip: string;
   downloadPdf: string;
   generating: string;
@@ -51,6 +55,10 @@ export const analysisReportTestTranslations: Record<
     emptySectionsAgreements: "No agreements",
     emptySectionsDisagreements: "No disagreements",
     emptySectionsDivisive: "No divisive",
+    numberScaleLabel: "Number Scale",
+    numberScaleNormal: "Normal (~4K)",
+    numberScaleLarge: "Large (300K)",
+    numberScaleVeryLarge: "Very Large (300M)",
     downloadImagesZip: "Download Images (ZIP)",
     downloadPdf: "Download PDF",
     generating: "Generating...",
@@ -76,6 +84,10 @@ export const analysisReportTestTranslations: Record<
     emptySectionsAgreements: "لا توجد مقترحات معتمدة",
     emptySectionsDisagreements: "لا توجد مقترحات مرفوضة",
     emptySectionsDivisive: "لا توجد مقترحات مثيرة للجدل",
+    numberScaleLabel: "حجم الأرقام",
+    numberScaleNormal: "عادي (~4 آلاف)",
+    numberScaleLarge: "كبير (300 ألف)",
+    numberScaleVeryLarge: "كبير جداً (300 مليون)",
     downloadImagesZip: "تحميل الصور (ZIP)",
     downloadPdf: "تحميل PDF",
     generating: "جارٍ الإنشاء...",
@@ -101,6 +113,10 @@ export const analysisReportTestTranslations: Record<
     emptySectionsAgreements: "Sin proposiciones aprobadas",
     emptySectionsDisagreements: "Sin proposiciones rechazadas",
     emptySectionsDivisive: "Sin proposiciones divisivas",
+    numberScaleLabel: "Escala Numérica",
+    numberScaleNormal: "Normal (~4K)",
+    numberScaleLarge: "Grande (300K)",
+    numberScaleVeryLarge: "Muy Grande (300M)",
     downloadImagesZip: "Descargar Imágenes (ZIP)",
     downloadPdf: "Descargar PDF",
     generating: "Generando...",
@@ -126,6 +142,10 @@ export const analysisReportTestTranslations: Record<
     emptySectionsAgreements: "Aucune proposition approuvée",
     emptySectionsDisagreements: "Aucune proposition rejetée",
     emptySectionsDivisive: "Aucune proposition controversée",
+    numberScaleLabel: "Échelle Numérique",
+    numberScaleNormal: "Normal (~4K)",
+    numberScaleLarge: "Grand (300K)",
+    numberScaleVeryLarge: "Très Grand (300M)",
     downloadImagesZip: "Télécharger les Images (ZIP)",
     downloadPdf: "Télécharger le PDF",
     generating: "Génération...",
@@ -151,6 +171,10 @@ export const analysisReportTestTranslations: Record<
     emptySectionsAgreements: "无通过的观点",
     emptySectionsDisagreements: "无否决的观点",
     emptySectionsDivisive: "无分歧的观点",
+    numberScaleLabel: "数字规模",
+    numberScaleNormal: "普通 (~4K)",
+    numberScaleLarge: "大 (300K)",
+    numberScaleVeryLarge: "超大 (300M)",
     downloadImagesZip: "下载图片 (ZIP)",
     downloadPdf: "下载 PDF",
     generating: "生成中...",
@@ -176,6 +200,10 @@ export const analysisReportTestTranslations: Record<
     emptySectionsAgreements: "無通過的觀點",
     emptySectionsDisagreements: "無否決的觀點",
     emptySectionsDivisive: "無分歧的觀點",
+    numberScaleLabel: "數字規模",
+    numberScaleNormal: "普通 (~4K)",
+    numberScaleLarge: "大 (300K)",
+    numberScaleVeryLarge: "超大 (300M)",
     downloadImagesZip: "下載圖片 (ZIP)",
     downloadPdf: "下載 PDF",
     generating: "產生中...",
@@ -201,6 +229,10 @@ export const analysisReportTestTranslations: Record<
     emptySectionsAgreements: "承認された意見なし",
     emptySectionsDisagreements: "否決された意見なし",
     emptySectionsDivisive: "分断的な意見なし",
+    numberScaleLabel: "数値スケール",
+    numberScaleNormal: "通常 (~4K)",
+    numberScaleLarge: "大 (300K)",
+    numberScaleVeryLarge: "超大 (300M)",
     downloadImagesZip: "画像をダウンロード (ZIP)",
     downloadPdf: "PDFをダウンロード",
     generating: "生成中...",

--- a/services/agora/src/pages/dev/analysis-report-test.vue
+++ b/services/agora/src/pages/dev/analysis-report-test.vue
@@ -64,6 +64,19 @@
                 class="control-select"
               />
             </div>
+            <div class="control-item">
+              <label for="number-scale" class="control-label">
+                {{ t("numberScaleLabel") }}
+              </label>
+              <PrimeSelect
+                id="number-scale"
+                v-model="numberScale"
+                :options="numberScaleOptions"
+                option-label="label"
+                option-value="value"
+                class="control-select"
+              />
+            </div>
           </div>
         </template>
       </PrimeCard>
@@ -86,7 +99,7 @@
       <div class="report-preview">
         <AnalysisReport
           ref="analysisReportRef"
-          :key="`${selectedClusterCount}-${useAiLabels}-${emptySectionsMode}`"
+          :key="`${selectedClusterCount}-${useAiLabels}-${emptySectionsMode}-${numberScale}`"
           :items-per-page="itemsPerPage"
           :conversation-slug-id="mockConversationSlugId"
           :conversation-title="mockConversationTitle"
@@ -95,9 +108,9 @@
           :participant-count="totalParticipantCount"
           :opinion-count="mockOpinionCount"
           :vote-count="mockVoteCount"
-          :total-participant-count="totalParticipantCount + 12"
-          :total-opinion-count="mockOpinionCount + 2"
-          :total-vote-count="mockVoteCount + 50"
+          :total-participant-count="Math.ceil(totalParticipantCount * 1.1)"
+          :total-opinion-count="Math.ceil(mockOpinionCount * 1.1)"
+          :total-vote-count="Math.ceil(mockVoteCount * 1.1)"
           :clusters="mockClusters"
           :agreement-items="mockAgreementItems"
           :disagreement-items="mockDisagreementItems"
@@ -146,14 +159,22 @@ const { t } = useComponentI18n<AnalysisReportTestTranslations>(
 const selectedClusterCount = ref(3);
 const useAiLabels = ref(true);
 const emptySectionsMode = ref<"none" | "all" | "agreements" | "disagreements" | "divisive">("none");
+const numberScale = ref<"normal" | "large" | "veryLarge">("large");
 
 const mockConversationSlugId = "dev-test-report";
 const mockConversationTitle =
   "Comment améliorer la gouvernance participative et renforcer l'engagement citoyen dans les décisions budgétaires et urbanistiques de notre commune ?";
 const mockAuthorUsername = "test-user";
 const mockCreatedAt = new Date("2025-11-15");
-const mockOpinionCount = 187;
-const mockVoteCount = 4280;
+
+const scaleFactors = {
+  normal: { opinions: 187, votes: 4280 },
+  large: { opinions: 300_000, votes: 300_000 },
+  veryLarge: { opinions: 300_000_000, votes: 300_000_000 },
+} as const;
+
+const mockOpinionCount = computed(() => scaleFactors[numberScale.value].opinions);
+const mockVoteCount = computed(() => scaleFactors[numberScale.value].votes);
 
 const clusterCountOptions = computed(() => [
   { label: t("clusterCount0"), value: 0 },
@@ -168,6 +189,12 @@ const clusterCountOptions = computed(() => [
 const aiLabelOptions = computed(() => [
   { label: t("withAiLabels"), value: true },
   { label: t("withoutAiLabels"), value: false },
+]);
+
+const numberScaleOptions = computed(() => [
+  { label: t("numberScaleNormal"), value: "normal" as const },
+  { label: t("numberScaleLarge"), value: "large" as const },
+  { label: t("numberScaleVeryLarge"), value: "veryLarge" as const },
 ]);
 
 const emptySectionsOptions = computed(() => [
@@ -271,7 +298,8 @@ const mockClusters = computed<Partial<PolisClusters>>(() => {
   if (selectedClusterCount.value === 0) return {};
 
   const clusters: Partial<PolisClusters> = {};
-  const baseSizes = [145, 112, 87, 63, 48, 35];
+  const scaleMultiplier = numberScale.value === "veryLarge" ? 600_000 : numberScale.value === "large" ? 600 : 1;
+  const baseSizes = [145, 112, 87, 63, 48, 35].map((s) => s * scaleMultiplier);
 
   for (let i = 0; i < selectedClusterCount.value; i++) {
     const key = polisKeys[i];


### PR DESCRIPTION
## Summary

- Fix stats row (PARTICIPANTS, STATEMENTS, VOTES) overflowing beyond the report container on the right side
- The "of X*" suffix text used `position: absolute; left: 100%` which placed it outside the element's box — now inline
- Proper vertical alignment between numbers and "of X*" suffixes using inline-flex baseline alignment
- Wider report container (210mm → 260mm) with reduced horizontal padding (6mm → 4mm) to use more screen space
- Added number scale control (Normal/300K/300M) to the dev test page for verifying layout with large numbers

## Test plan

- [ ] Navigate to `/dev/analysis-report-test` and switch between Normal/Large/Very Large number scales
- [ ] Verify stats don't overflow on any scale, including with "of X*" suffixes
- [ ] Verify "of X*" text is baseline-aligned with the main number
- [ ] Verify branding is left-aligned and stats are right-aligned with no overflow
- [ ] Test with the real Arabic conversation report page
- [ ] Test PDF and ZIP export still work correctly