### PR TITLE
fix(api): prevent startup cleanup from crashing server on DB failure

### DIFF
--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -452,64 +452,71 @@ log.info(
 // Cleanup stuck imports/exports from previous server session
 // This runs once on startup to handle jobs that were interrupted by server restart
 const performStartupCleanup = async (): Promise<void> => {
-    // Cleanup stuck imports and send notifications
-    const importCleanupResult = await cleanupStuckImportsOnStartup({
-        db,
-    });
+    try {
+        // Cleanup stuck imports and send notifications
+        const importCleanupResult = await cleanupStuckImportsOnStartup({
+            db,
+        });
 
-    if (importCleanupResult.cleanedCount > 0) {
-        log.info(
-            `[Startup] Cleaned up ${String(importCleanupResult.cleanedCount)} stuck imports`,
-        );
+        if (importCleanupResult.cleanedCount > 0) {
+            log.info(
+                `[Startup] Cleaned up ${String(importCleanupResult.cleanedCount)} stuck imports`,
+            );
 
-        // Send notifications for failed imports
-        for (const stuckImport of importCleanupResult.stuckImports) {
-            try {
-                await createImportNotification({
-                    db,
-                    userId: stuckImport.userId,
-                    importId: stuckImport.id,
-                    conversationId: null,
-                    type: "import_failed",
-                    notificationSSEManager,
-                });
-            } catch (notificationError: unknown) {
-                log.error(
-                    notificationError,
-                    `[Startup] Failed to create import notification for import ${stuckImport.slugId}`,
-                );
+            // Send notifications for failed imports
+            for (const stuckImport of importCleanupResult.stuckImports) {
+                try {
+                    await createImportNotification({
+                        db,
+                        userId: stuckImport.userId,
+                        importId: stuckImport.id,
+                        conversationId: null,
+                        type: "import_failed",
+                        notificationSSEManager,
+                    });
+                } catch (notificationError: unknown) {
+                    log.error(
+                        notificationError,
+                        `[Startup] Failed to create import notification for import ${stuckImport.slugId}`,
+                    );
+                }
             }
         }
-    }
 
-    // Cleanup stuck exports and send notifications
-    const exportCleanupResult = await cleanupStuckExportsOnStartup({
-        db,
-    });
+        // Cleanup stuck exports and send notifications
+        const exportCleanupResult = await cleanupStuckExportsOnStartup({
+            db,
+        });
 
-    if (exportCleanupResult.cleanedCount > 0) {
-        log.info(
-            `[Startup] Cleaned up ${String(exportCleanupResult.cleanedCount)} stuck exports`,
-        );
+        if (exportCleanupResult.cleanedCount > 0) {
+            log.info(
+                `[Startup] Cleaned up ${String(exportCleanupResult.cleanedCount)} stuck exports`,
+            );
 
-        // Send notifications for failed exports
-        for (const stuckExport of exportCleanupResult.stuckExports) {
-            try {
-                await createExportNotification({
-                    db,
-                    userId: stuckExport.userId,
-                    exportId: stuckExport.id,
-                    conversationId: stuckExport.conversationId,
-                    type: "export_failed",
-                    notificationSSEManager,
-                });
-            } catch (notificationError: unknown) {
-                log.error(
-                    notificationError,
-                    `[Startup] Failed to create export notification for export ${stuckExport.slugId}`,
-                );
+            // Send notifications for failed exports
+            for (const stuckExport of exportCleanupResult.stuckExports) {
+                try {
+                    await createExportNotification({
+                        db,
+                        userId: stuckExport.userId,
+                        exportId: stuckExport.id,
+                        conversationId: stuckExport.conversationId,
+                        type: "export_failed",
+                        notificationSSEManager,
+                    });
+                } catch (notificationError: unknown) {
+                    log.error(
+                        notificationError,
+                        `[Startup] Failed to create export notification for export ${stuckExport.slugId}`,
+                    );
+                }
             }
         }
+    } catch (error: unknown) {
+        log.error(
+            error,
+            "[Startup] Failed to perform startup cleanup - will retry on next restart",
+        );
     }
 };
 


### PR DESCRIPTION
## Summary
- `performStartupCleanup` is a fire-and-forget async call that queries the DB for stuck imports/exports on server start
- If the database is unavailable (e.g., read replica on port 5433 not running), the unhandled promise rejection crashes the Node.js process
- Wrap the cleanup body in a top-level try-catch so failures are logged instead of crashing the server

## Test plan
- [ ] Stop local database, run `make dev-api` — server should start and log an error instead of crashing
- [ ] Start database, run `make dev-api` — cleanup should work as before (no behavior change on happy path)