### PR TITLE
fix(api,agora): fix notification count accuracy and prevent vote-change notifications

### DIFF
--- a/services/agora/src/composables/useNotificationSSE.ts
+++ b/services/agora/src/composables/useNotificationSSE.ts
@@ -25,7 +25,13 @@ export function useNotificationSSE() {
   let shouldReconnect = true;
 
   async function connect() {
+    console.log("[SSE] connect() called", {
+      isConnecting: isConnecting.value,
+      isConnected: isConnected.value,
+    });
+
     if (isConnecting.value || isConnected.value) {
+      console.log("[SSE] connect() blocked by guard — already connecting or connected");
       return;
     }
 
@@ -63,6 +69,7 @@ export function useNotificationSSE() {
 
       isConnected.value = true;
       isConnecting.value = false;
+      console.log("[SSE] Stream opened successfully");
 
       // Read and parse SSE stream
       const reader = response.body.getReader();
@@ -200,6 +207,7 @@ export function useNotificationSSE() {
   watch(
     () => authStore.isGuestOrLoggedIn,
     async (isAuthenticated, wasAuthenticated) => {
+      console.log("[SSE] Auth watcher fired", { isAuthenticated, wasAuthenticated });
       if (isAuthenticated && !wasAuthenticated) {
         // User became guest or logged in — connect to SSE
         shouldReconnect = true;

--- a/services/api/src/service/notification.ts
+++ b/services/api/src/service/notification.ts
@@ -16,7 +16,7 @@ import {
 import type { FetchNotificationsResponse } from "@/shared/types/dto.js";
 import type { NotificationItem } from "@/shared/types/zod.js";
 import { zodNotificationItem } from "@/shared/types/zod.js";
-import { and, desc, eq, lt } from "drizzle-orm";
+import { and, desc, eq, inArray, lt } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { useCommonPost } from "./common.js";
 import { httpErrors } from "@fastify/sensible";
@@ -96,14 +96,23 @@ export async function getNotifications({
         lastSlugId: lastSlugId,
     });
 
-    const whereClause = lastSlugId
-        ? and(
-              eq(notificationTable.userId, userId),
-              lt(notificationTable.createdAt, lastCreatedAt),
-          )
-        : eq(notificationTable.userId, userId);
-
     const orderByClause = desc(notificationTable.createdAt);
+
+    // Build per-type WHERE clauses to ensure LIMIT only counts rows of the
+    // correct notification type. Without a type filter, the LIMIT can be filled
+    // by wrong-type notifications (which are then skipped by NULL checks),
+    // causing valid notifications and their unread counts to be missed.
+    function buildWhereClause(
+        typeFilter: ReturnType<typeof eq>,
+    ) {
+        return lastSlugId
+            ? and(
+                  eq(notificationTable.userId, userId),
+                  lt(notificationTable.createdAt, lastCreatedAt),
+                  typeFilter,
+              )
+            : and(eq(notificationTable.userId, userId), typeFilter);
+    }
 
     {
         const notificationTableResponse = await db
@@ -143,7 +152,14 @@ export async function getNotifications({
                 userTable,
                 eq(userTable.id, notificationNewOpinionTable.authorId),
             )
-            .where(whereClause)
+            .where(
+                buildWhereClause(
+                    eq(
+                        notificationTable.notificationType,
+                        "new_opinion",
+                    ),
+                ),
+            )
             .orderBy(orderByClause)
             .limit(fetchLimit);
 
@@ -214,7 +230,14 @@ export async function getNotifications({
                     notificationOpinionVoteTable.conversationId,
                 ),
             )
-            .where(whereClause)
+            .where(
+                buildWhereClause(
+                    eq(
+                        notificationTable.notificationType,
+                        "opinion_vote",
+                    ),
+                ),
+            )
             .orderBy(orderByClause)
             .limit(fetchLimit);
 
@@ -295,7 +318,16 @@ export async function getNotifications({
                     conversationTable.currentContentId,
                 ),
             )
-            .where(whereClause)
+            .where(
+                buildWhereClause(
+                    inArray(notificationTable.notificationType, [
+                        "export_started",
+                        "export_completed",
+                        "export_failed",
+                        "export_cancelled",
+                    ]),
+                ),
+            )
             .orderBy(orderByClause)
             .limit(fetchLimit);
 
@@ -411,7 +443,15 @@ export async function getNotifications({
                     conversationTable.currentContentId,
                 ),
             )
-            .where(whereClause)
+            .where(
+                buildWhereClause(
+                    inArray(notificationTable.notificationType, [
+                        "import_started",
+                        "import_completed",
+                        "import_failed",
+                    ]),
+                ),
+            )
             .orderBy(orderByClause)
             .limit(fetchLimit);
 

--- a/services/api/src/service/voteBuffer.ts
+++ b/services/api/src/service/voteBuffer.ts
@@ -455,6 +455,14 @@ export function createVoteBuffer({
             `[VoteBuffer] Processing ${String(batch.length)} votes in ${String(batches.length)} transaction(s)`,
         );
 
+        // Track genuinely new voters per opinion across all transaction batches.
+        // Only first-time voters (no prior vote on the opinion) trigger notifications.
+        // Vote changes (agree→disagree) are excluded.
+        const newVotersPerOpinion = new Map<
+            number,
+            { voterIds: Set<string>; conversationId: number }
+        >();
+
         try {
             for (const [batchIndex, voteBatch] of batches.entries()) {
                 log.info(
@@ -1088,6 +1096,28 @@ export function createVoteBuffer({
                                 },
                             });
                     }
+
+                    // Track genuinely new voters for notification purposes.
+                    // A voter is "new" only if they had no prior vote on this opinion
+                    // (existingVotesMap has no entry). Vote changes are excluded.
+                    for (const vote of voteBatch) {
+                        if (vote.vote === "cancel") continue;
+                        const key = getVoteKey(vote.userId, vote.opinionId);
+                        const existingVoteData = existingVotesMap.get(key);
+                        if (existingVoteData === undefined) {
+                            const existing = newVotersPerOpinion.get(
+                                vote.opinionId,
+                            );
+                            if (existing) {
+                                existing.voterIds.add(vote.userId);
+                            } else {
+                                newVotersPerOpinion.set(vote.opinionId, {
+                                    voterIds: new Set([vote.userId]),
+                                    conversationId: vote.conversationId,
+                                });
+                            }
+                        }
+                    }
                 });
 
                 log.info(
@@ -1102,24 +1132,10 @@ export function createVoteBuffer({
             // Create vote notifications AFTER all transactions committed
             // Wrapped in try/catch to never fail the flush
             try {
-                // Group votes by opinionId → distinct voters per opinion
-                const votesPerOpinion = new Map<
-                    number,
-                    { voterIds: Set<string>; conversationId: number }
-                >();
-
-                for (const vote of batch) {
-                    if (vote.vote === "cancel") continue;
-                    const existing = votesPerOpinion.get(vote.opinionId);
-                    if (existing) {
-                        existing.voterIds.add(vote.userId);
-                    } else {
-                        votesPerOpinion.set(vote.opinionId, {
-                            voterIds: new Set([vote.userId]),
-                            conversationId: vote.conversationId,
-                        });
-                    }
-                }
+                // Use newVotersPerOpinion (collected during transactions) instead
+                // of re-scanning the batch. This ensures only genuinely first-time
+                // voters trigger notifications — vote changes are excluded.
+                const votesPerOpinion = newVotersPerOpinion;
 
                 if (votesPerOpinion.size > 0) {
                     // Batch query opinion metadata (authorId + isSeed)


### PR DESCRIPTION
## What

Two notification bugs fixed:

### 1. Notification count (numNewNotifications) was inaccurate

`getNotifications` in `notification.ts` runs 4 separate query blocks (new_opinion, opinion_vote, export, import), each with `LIMIT 20`. None had a `notificationType` filter in the WHERE clause, so the LIMIT could be filled entirely by wrong-type notifications. These were skipped by NULL checks but consumed LIMIT slots, causing valid notifications and their unread counts to be missed.

**Fix**: Added a `notificationType` filter to each query block via a `buildWhereClause` helper.

### 2. Vote changes triggered false notifications

When a user changed their vote (e.g., agree → disagree) on a statement, the author got a new notification even though the total vote count didn't change. The notification code grouped all non-cancel votes by opinionId without checking if the voter already had a prior vote.

**Fix**: Track genuinely new voters inside the transaction (using `existingVotesMap`) and only create notifications for first-time voters on each opinion. Vote changes, cancellations, and re-votes are excluded.

### 3. SSE debug logging

Added console.log statements to `useNotificationSSE.ts` at key points (auth watcher, connect() entry, guard blocks, stream open) to help diagnose real-time notification delivery issues.

## Files Changed

- `services/api/src/service/notification.ts` — notificationType filter on all 4 query blocks
- `services/api/src/service/voteBuffer.ts` — new voter tracking for notifications
- `services/agora/src/composables/useNotificationSSE.ts` — SSE debug logs

## Testing

- API lint: ✅
- Frontend lint: ✅
- API tests: 44/44 passed ✅

Deploy: agora, api