### PR TITLE
fix(api): drop 6 redundant database indexes

### DIFF
--- a/services/api/database/flyway/V0043__outgoing_living_tribunal.sql
+++ b/services/api/database/flyway/V0043__outgoing_living_tribunal.sql
@@ -11,10 +11,14 @@ CREATE TABLE "maxdiff_result" (
 	CONSTRAINT "maxdiff_result_participant_id_conversation_id_unique" UNIQUE("participant_id","conversation_id")
 );
 --> statement-breakpoint
+DROP INDEX "conversation_createdAt_idx";--> statement-breakpoint
+DROP INDEX "conversation_authorId_idx";--> statement-breakpoint
+DROP INDEX "opinion_conversationId_idx";--> statement-breakpoint
+DROP INDEX "polis_cluster_translation_lookup_idx";--> statement-breakpoint
+DROP INDEX "vote_opinionId_idx";--> statement-breakpoint
 ALTER TABLE "conversation" ADD COLUMN "conversation_type" "conversation_type" DEFAULT 'polis' NOT NULL;--> statement-breakpoint
 ALTER TABLE "maxdiff_result" ADD CONSTRAINT "maxdiff_result_participant_id_user_id_fk" FOREIGN KEY ("participant_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "maxdiff_result" ADD CONSTRAINT "maxdiff_result_conversation_id_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversation"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "maxdiff_result_conversation_idx" ON "maxdiff_result" USING btree ("conversation_id");--> statement-breakpoint
 CREATE INDEX "maxdiff_result_complete_idx" ON "maxdiff_result" USING btree ("conversation_id","is_complete");--> statement-breakpoint
 CREATE INDEX "conversation_feed_idx" ON "conversation" USING btree ("created_at") WHERE "conversation"."is_indexed" = true AND "conversation"."is_importing" = false;--> statement-breakpoint
 CREATE INDEX "conversation_type_importing_idx" ON "conversation" USING btree ("is_importing","conversation_type");--> statement-breakpoint

--- a/services/api/drizzle/0042_outgoing_living_tribunal.sql
+++ b/services/api/drizzle/0042_outgoing_living_tribunal.sql
@@ -11,10 +11,14 @@ CREATE TABLE "maxdiff_result" (
 	CONSTRAINT "maxdiff_result_participant_id_conversation_id_unique" UNIQUE("participant_id","conversation_id")
 );
 --> statement-breakpoint
+DROP INDEX "conversation_createdAt_idx";--> statement-breakpoint
+DROP INDEX "conversation_authorId_idx";--> statement-breakpoint
+DROP INDEX "opinion_conversationId_idx";--> statement-breakpoint
+DROP INDEX "polis_cluster_translation_lookup_idx";--> statement-breakpoint
+DROP INDEX "vote_opinionId_idx";--> statement-breakpoint
 ALTER TABLE "conversation" ADD COLUMN "conversation_type" "conversation_type" DEFAULT 'polis' NOT NULL;--> statement-breakpoint
 ALTER TABLE "maxdiff_result" ADD CONSTRAINT "maxdiff_result_participant_id_user_id_fk" FOREIGN KEY ("participant_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "maxdiff_result" ADD CONSTRAINT "maxdiff_result_conversation_id_conversation_id_fk" FOREIGN KEY ("conversation_id") REFERENCES "public"."conversation"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "maxdiff_result_conversation_idx" ON "maxdiff_result" USING btree ("conversation_id");--> statement-breakpoint
 CREATE INDEX "maxdiff_result_complete_idx" ON "maxdiff_result" USING btree ("conversation_id","is_complete");--> statement-breakpoint
 CREATE INDEX "conversation_feed_idx" ON "conversation" USING btree ("created_at") WHERE "conversation"."is_indexed" = true AND "conversation"."is_importing" = false;--> statement-breakpoint
 CREATE INDEX "conversation_type_importing_idx" ON "conversation" USING btree ("is_importing","conversation_type");--> statement-breakpoint

--- a/services/api/drizzle/meta/0042_snapshot.json
+++ b/services/api/drizzle/meta/0042_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "02779c59-1b33-4ce4-89b6-d7fa68802145",
+  "id": "c3e0767f-f836-4635-87b2-11678182b60e",
   "prevId": "a03b8946-7e00-4e12-a374-d9293b2fb042",
   "version": "7",
   "dialect": "postgresql",
@@ -1412,36 +1412,6 @@
         }
       },
       "indexes": {
-        "conversation_createdAt_idx": {
-          "name": "conversation_createdAt_idx",
-          "columns": [
-            {
-              "expression": "created_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "conversation_authorId_idx": {
-          "name": "conversation_authorId_idx",
-          "columns": [
-            {
-              "expression": "author_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "conversation_feed_idx": {
           "name": "conversation_feed_idx",
           "columns": [
@@ -2400,21 +2370,6 @@
         }
       },
       "indexes": {
-        "maxdiff_result_conversation_idx": {
-          "name": "maxdiff_result_conversation_idx",
-          "columns": [
-            {
-              "expression": "conversation_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "maxdiff_result_complete_idx": {
           "name": "maxdiff_result_complete_idx",
           "columns": [
@@ -3732,21 +3687,6 @@
           "method": "btree",
           "with": {}
         },
-        "opinion_conversationId_idx": {
-          "name": "opinion_conversationId_idx",
-          "columns": [
-            {
-              "expression": "conversation_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "opinion_authorId_idx": {
           "name": "opinion_authorId_idx",
           "columns": [
@@ -4466,29 +4406,7 @@
           "default": "now()"
         }
       },
-      "indexes": {
-        "polis_cluster_translation_lookup_idx": {
-          "name": "polis_cluster_translation_lookup_idx",
-          "columns": [
-            {
-              "expression": "polis_cluster_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "language_code",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
+      "indexes": {},
       "foreignKeys": {
         "polis_cluster_translation_polis_cluster_id_polis_cluster_id_fk": {
           "name": "polis_cluster_translation_polis_cluster_id_polis_cluster_id_fk",
@@ -6008,21 +5926,6 @@
         }
       },
       "indexes": {
-        "vote_opinionId_idx": {
-          "name": "vote_opinionId_idx",
-          "columns": [
-            {
-              "expression": "opinion_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
         "vote_authorId_idx": {
           "name": "vote_authorId_idx",
           "columns": [

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -299,8 +299,8 @@
     {
       "idx": 42,
       "version": "7",
-      "when": 1773424636440,
-      "tag": "0042_young_madripoor",
+      "when": 1773449591696,
+      "tag": "0042_outgoing_living_tribunal",
       "breakpoints": true
     }
   ]

--- a/services/api/src/shared-backend/schema.ts
+++ b/services/api/src/shared-backend/schema.ts
@@ -1328,8 +1328,6 @@ export const conversationTable = pgTable(
             .notNull(),
     },
     (table) => [
-        index("conversation_createdAt_idx").on(table.createdAt),
-        index("conversation_authorId_idx").on(table.authorId),
         // Partial index for feed query: filters isIndexed=true + isImporting=false, sorts by createdAt
         index("conversation_feed_idx")
             .on(table.createdAt)
@@ -1528,7 +1526,6 @@ export const opinionTable = pgTable(
     (table) => [
         index("opinion_createdAt_idx").on(table.createdAt),
         index("opinion_slugId_idx").on(table.slugId),
-        index("opinion_conversationId_idx").on(table.conversationId),
         index("opinion_authorId_idx").on(table.authorId),
         // Composite for counter reconciliation: filters conversationId + non-deleted (currentContentId IS NOT NULL)
         index("opinion_conversation_active_idx").on(
@@ -1610,7 +1607,6 @@ export const voteTable = pgTable(
     },
     (t) => [
         unique().on(t.authorId, t.opinionId),
-        index("vote_opinionId_idx").on(t.opinionId),
         index("vote_authorId_idx").on(t.authorId),
         // Composite for counter reconciliation: filters opinionId + non-deleted (currentContentId IS NOT NULL)
         index("vote_opinion_active_idx").on(
@@ -1996,10 +1992,6 @@ export const polisClusterTranslationTable = pgTable(
     },
     (t) => [
         unique("unique_cluster_language").on(t.polisClusterId, t.languageCode),
-        index("polis_cluster_translation_lookup_idx").on(
-            t.polisClusterId,
-            t.languageCode,
-        ),
     ],
 );
 
@@ -2257,7 +2249,6 @@ export const maxdiffResultTable = pgTable(
     },
     (t) => [
         unique().on(t.participantId, t.conversationId),
-        index("maxdiff_result_conversation_idx").on(t.conversationId),
         // Composite for aggregated results query: filters conversationId + isComplete
         index("maxdiff_result_complete_idx").on(
             t.conversationId,

--- a/services/math-updater/src/shared-backend/schema.ts
+++ b/services/math-updater/src/shared-backend/schema.ts
@@ -1328,8 +1328,6 @@ export const conversationTable = pgTable(
             .notNull(),
     },
     (table) => [
-        index("conversation_createdAt_idx").on(table.createdAt),
-        index("conversation_authorId_idx").on(table.authorId),
         // Partial index for feed query: filters isIndexed=true + isImporting=false, sorts by createdAt
         index("conversation_feed_idx")
             .on(table.createdAt)
@@ -1528,7 +1526,6 @@ export const opinionTable = pgTable(
     (table) => [
         index("opinion_createdAt_idx").on(table.createdAt),
         index("opinion_slugId_idx").on(table.slugId),
-        index("opinion_conversationId_idx").on(table.conversationId),
         index("opinion_authorId_idx").on(table.authorId),
         // Composite for counter reconciliation: filters conversationId + non-deleted (currentContentId IS NOT NULL)
         index("opinion_conversation_active_idx").on(
@@ -1610,7 +1607,6 @@ export const voteTable = pgTable(
     },
     (t) => [
         unique().on(t.authorId, t.opinionId),
-        index("vote_opinionId_idx").on(t.opinionId),
         index("vote_authorId_idx").on(t.authorId),
         // Composite for counter reconciliation: filters opinionId + non-deleted (currentContentId IS NOT NULL)
         index("vote_opinion_active_idx").on(
@@ -1996,10 +1992,6 @@ export const polisClusterTranslationTable = pgTable(
     },
     (t) => [
         unique("unique_cluster_language").on(t.polisClusterId, t.languageCode),
-        index("polis_cluster_translation_lookup_idx").on(
-            t.polisClusterId,
-            t.languageCode,
-        ),
     ],
 );
 
@@ -2257,7 +2249,6 @@ export const maxdiffResultTable = pgTable(
     },
     (t) => [
         unique().on(t.participantId, t.conversationId),
-        index("maxdiff_result_conversation_idx").on(t.conversationId),
         // Composite for aggregated results query: filters conversationId + isComplete
         index("maxdiff_result_complete_idx").on(
             t.conversationId,

--- a/services/shared-backend/src/schema.ts
+++ b/services/shared-backend/src/schema.ts
@@ -1327,8 +1327,6 @@ export const conversationTable = pgTable(
             .notNull(),
     },
     (table) => [
-        index("conversation_createdAt_idx").on(table.createdAt),
-        index("conversation_authorId_idx").on(table.authorId),
         // Partial index for feed query: filters isIndexed=true + isImporting=false, sorts by createdAt
         index("conversation_feed_idx")
             .on(table.createdAt)
@@ -1527,7 +1525,6 @@ export const opinionTable = pgTable(
     (table) => [
         index("opinion_createdAt_idx").on(table.createdAt),
         index("opinion_slugId_idx").on(table.slugId),
-        index("opinion_conversationId_idx").on(table.conversationId),
         index("opinion_authorId_idx").on(table.authorId),
         // Composite for counter reconciliation: filters conversationId + non-deleted (currentContentId IS NOT NULL)
         index("opinion_conversation_active_idx").on(
@@ -1609,7 +1606,6 @@ export const voteTable = pgTable(
     },
     (t) => [
         unique().on(t.authorId, t.opinionId),
-        index("vote_opinionId_idx").on(t.opinionId),
         index("vote_authorId_idx").on(t.authorId),
         // Composite for counter reconciliation: filters opinionId + non-deleted (currentContentId IS NOT NULL)
         index("vote_opinion_active_idx").on(
@@ -1995,10 +1991,6 @@ export const polisClusterTranslationTable = pgTable(
     },
     (t) => [
         unique("unique_cluster_language").on(t.polisClusterId, t.languageCode),
-        index("polis_cluster_translation_lookup_idx").on(
-            t.polisClusterId,
-            t.languageCode,
-        ),
     ],
 );
 
@@ -2256,7 +2248,6 @@ export const maxdiffResultTable = pgTable(
     },
     (t) => [
         unique().on(t.participantId, t.conversationId),
-        index("maxdiff_result_conversation_idx").on(t.conversationId),
         // Composite for aggregated results query: filters conversationId + isComplete
         index("maxdiff_result_complete_idx").on(
             t.conversationId,


### PR DESCRIPTION
## Summary

- Drop 6 database indexes that are fully redundant with composite indexes or unique constraints
- Regenerate MaxDiff migration (0042) to include DROP INDEX statements alongside table creation

### Indexes removed

| Redundant Index | Covered By |
|---|---|
| `conversation_createdAt_idx` | `conversation_feed_idx` (partial) + `conversation_author_timeline_idx` |
| `conversation_authorId_idx` | `conversation_author_timeline_idx` leading column |
| `opinion_conversationId_idx` | `opinion_conversation_active_idx` leading column |
| `vote_opinionId_idx` | `vote_opinion_active_idx` leading column |
| `maxdiff_result_conversation_idx` | `maxdiff_result_complete_idx` leading column |
| `polis_cluster_translation_lookup_idx` | `unique_cluster_language` unique constraint (same columns) |

PostgreSQL can use a composite index for queries filtering on its leading column(s), making single-column indexes on those same columns dead weight that slows writes and wastes disk.

## Test plan

- [ ] Verify migration applies cleanly on dev database
- [ ] Run `pnpm test` in `services/api` and `services/math-updater`
- [ ] Spot-check feed, user timeline, and maxdiff results queries with `EXPLAIN ANALYZE`

Deploy: api