### PR TITLE
feat(deploy): add MaxDiff and GitHub integration config to production

### DIFF
--- a/script/docker-compose-production.yml
+++ b/script/docker-compose-production.yml
@@ -32,6 +32,16 @@ services:
       TWILIO_SERVICE_SID: "CHANGEME"
       SERVER_DID_PROD: "did:web:agoracitizen.app"
       GOOGLE_APPLICATION_CREDENTIALS: "/secrets/service-account.json"
+      # MaxDiff
+      MAXDIFF_ENABLED: "true"
+      IS_MAXDIFF_ORG_ONLY: "true"
+      MAXDIFF_ALLOWED_ORGS: "Agora"
+      # MaxDiff GitHub integration
+      MAXDIFF_GITHUB_ENABLED: "true"
+      IS_MAXDIFF_GITHUB_ORG_ONLY: "true"
+      MAXDIFF_GITHUB_ALLOWED_ORGS: "Agora"
+      GITHUB_WEBHOOK_SECRET: "CHANGEME"
+      GITHUB_ACCESS_TOKEN: "CHANGEME"
     volumes:
       - ./<name of service account>.json:/secrets/service-account.json:ro
     expose:


### PR DESCRIPTION
## Summary
- Add MaxDiff and GitHub integration environment variables to the `api` service in `docker-compose-production.yml`
- Both features restricted to org-only mode with "Agora" as the allowed org
- `GITHUB_WEBHOOK_SECRET` and `GITHUB_ACCESS_TOKEN` use `CHANGEME` placeholders

## Frontend companion
Add these to `services/agora/.env.production`:
```
VITE_MAXDIFF_ENABLED=true
VITE_IS_MAXDIFF_ORG_ONLY=true
VITE_MAXDIFF_ALLOWED_ORGS=Agora
VITE_MAXDIFF_GITHUB_ENABLED=true
VITE_IS_MAXDIFF_GITHUB_ORG_ONLY=true
VITE_MAXDIFF_GITHUB_ALLOWED_ORGS=Agora
```

## GitHub webhook config
- **URL**: `https://www.agoracitizen.app/api/v1/webhook/github`
- **Content type**: `application/json`
- **SSL verification**: enabled
- **Events**: Issues (opened, edited, closed, reopened, labeled, unlabeled, deleted)

## Test plan
- [ ] Replace `CHANGEME` placeholders with real secrets on the server
- [ ] Add frontend env vars to `.env.production` and rebuild agora
- [ ] Configure GitHub webhook on the target repo
- [ ] Verify webhook delivery succeeds in GitHub settings