### PR TITLE
fix(agora): prevent popstate cascade and restore chunk error recovery

### DIFF
--- a/services/agora/src/layouts/PersistentLayout.vue
+++ b/services/agora/src/layouts/PersistentLayout.vue
@@ -64,6 +64,7 @@ const { reveal: revealHeader } = storeToRefs(useLayoutHeaderStore());
 
 useNotificationRefresher();
 
+
 // Header reveal — one-time init, not per-navigation
 const enableHeaderReveal = ref(false);
 setTimeout(() => {

--- a/services/agora/src/pages/index.vue
+++ b/services/agora/src/pages/index.vue
@@ -12,10 +12,6 @@
       </HomeMenuBar>
 
       <WidthWrapper :enable="true">
-        <FeaturedConversationBanner />
-      </WidthWrapper>
-
-      <WidthWrapper :enable="true">
         <div class="tabCluster">
           <div class="tabItem" @click="selectedTab('following')">
             <ZKBadge
@@ -45,6 +41,10 @@
         </div>
       </WidthWrapper>
     </Teleport>
+
+    <WidthWrapper :enable="true">
+      <FeaturedConversationBanner />
+    </WidthWrapper>
 
     <div class="container">
       <CompactPostList />

--- a/services/agora/src/router/index.ts
+++ b/services/agora/src/router/index.ts
@@ -1,3 +1,4 @@
+import { isChunkLoadError, reloadForChunkError } from "src/utils/error/chunkError";
 import { useRouterGuard } from "src/utils/router/guard";
 import {
   createMemoryHistory,
@@ -133,6 +134,12 @@ export default defineRouter(function (/* { store, ssrContext } */) {
     const target = conversationGuard(to.name, from.name);
     if (target == "home") {
       return { name: "/" };
+    }
+  });
+
+  Router.onError((error, to) => {
+    if (isChunkLoadError(error)) {
+      reloadForChunkError({ navigateTo: to.fullPath });
     }
   });
 


### PR DESCRIPTION
## Summary

- Move `FeaturedConversationBanner` out of Teleport header to prevent unmount/remount on every keep-alive activate cycle — each remount triggered `useMaxDiffHistoryUndo` cleanup (`history.go(-N)`), creating a popstate cascade that eventually caused full page reloads
- Restore `Router.onError` chunk error handler (accidentally removed during centralization) — navigates to target URL instead of reloading current page, preserving better UX on deployment chunk errors
- Clean up temporary diagnostic logging from PersistentLayout

## Test plan

- [ ] Navigate feed → conversation → feed → conversation repeatedly — no full page reloads, no popstate cascades
- [ ] Only 1 maxdiff/load call per app startup (not per activate cycle)
- [ ] `cd services/agora && pnpm test` passes

Deploy: agora