### PR TITLE
fix(agora): global SPA link interceptor for Vue 3.5 event delegation bug

### DIFF
--- a/services/agora/quasar.config.ts
+++ b/services/agora/quasar.config.ts
@@ -28,7 +28,7 @@ export default defineConfig((ctx) => {
     boot.push("sentry");
   }
   boot.push(
-    ...["i18n", "axios", "primevue", "vue-query", "embeddedBrowserGuard", "maz-ui"]
+    ...["i18n", "axios", "primevue", "vue-query", "embeddedBrowserGuard", "maz-ui", "spaLinkInterceptor"]
   );
 
   if (process.env.NODE_ENV) {

--- a/services/agora/src/boot/spaLinkInterceptor.ts
+++ b/services/agora/src/boot/spaLinkInterceptor.ts
@@ -1,0 +1,54 @@
+import { defineBoot } from "#q-app/wrappers";
+
+/**
+ * Global SPA link interceptor (capture phase).
+ *
+ * BUG: Vue 3.5 introduced event delegation (vuejs/core#11765) where click
+ * handlers are NOT attached directly to DOM elements (__vei is empty).
+ * Instead, they're managed by Vue's runtime on a parent element. For <a>
+ * tags, this creates a race condition: the browser can follow the native
+ * <a href> link BEFORE Vue's delegated click handler calls preventDefault.
+ *
+ * SYMPTOMS:
+ * - Intermittent full page reloads when clicking <RouterLink> or <a> tags
+ * - App restarts from scratch (SSE reconnects, auth re-initializes)
+ * - Browser history corrupted (back button goes to wrong page)
+ * - Affects all browsers, dev and production
+ * - Timing-dependent: sometimes SPA works, sometimes full reload
+ *
+ * CONFIRMED VIA PLAYWRIGHT:
+ * - __vei is empty on ALL elements (Vue 3.5 event delegation)
+ * - Vnode props DO have onClick (Vue knows about the handler internally)
+ * - Synthetic dispatchEvent works (Vue intercepts synchronously)
+ * - Real browser clicks intermittently bypass Vue's delegated handler
+ * - Only capture-phase document listener fires; bubble-phase never fires
+ *   because the browser already started native navigation
+ *
+ * FIX: A single capture-phase click listener on document. Capture phase
+ * fires BEFORE any element-level or delegated handlers, and BEFORE the
+ * browser can follow the native link. This is the same pattern used by
+ * Angular's LocationStrategy and SvelteKit's link handling.
+ *
+ * PRESERVES:
+ * - <a href> for accessibility, SEO, right-click "Open in new tab"
+ * - Middle-click / Ctrl+click / Cmd+click open in new tab
+ * - External links (different origin) are not intercepted
+ * - target="_blank" and download links are not intercepted
+ *
+ * REFERENCES:
+ * - Vue 3.5 event delegation: https://github.com/vuejs/core/pull/11765
+ * - RouterLink reload bug: https://github.com/vuejs/router/issues/846
+ * - RouterLink click event: https://github.com/vuejs/router/issues/856
+ */
+export default defineBoot(({ router }) => {
+  document.addEventListener("click", (e: MouseEvent) => {
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    const anchor = (e.target as HTMLElement).closest?.("a[href]");
+    if (!(anchor instanceof HTMLAnchorElement)) return;
+    if (anchor.target === "_blank" || anchor.hasAttribute("download")) return;
+    if (!anchor.href.startsWith(window.location.origin)) return;
+    e.preventDefault();
+    const url = new URL(anchor.href);
+    void router.push(url.pathname + url.search + url.hash);
+  }, true);
+});

--- a/services/agora/src/components/feed/FeaturedConversationBanner.vue
+++ b/services/agora/src/components/feed/FeaturedConversationBanner.vue
@@ -5,9 +5,9 @@
       size="1.25rem"
       color="#6b4eff"
     />
-    <router-link :to="conversationUrl" class="banner-link">
+    <SpaLink :to="conversationUrl" class="banner-link">
       {{ t("message") }}
-    </router-link>
+    </SpaLink>
     <button class="dismiss-button" @click="dismiss">
       <ZKIcon name="mdi:close" size="1rem" color="#836bff" />
     </button>
@@ -19,6 +19,7 @@ import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { useFeaturedBannerVisibility } from "src/composables/useFeaturedBannerVisibility";
 import { processEnv } from "src/utils/processEnv";
 
+import SpaLink from "../ui-library/SpaLink.vue";
 import ZKIcon from "../ui-library/ZKIcon.vue";
 import {
   type FeaturedConversationBannerTranslations,

--- a/services/agora/src/components/ui-library/SpaLink.vue
+++ b/services/agora/src/components/ui-library/SpaLink.vue
@@ -1,86 +1,28 @@
 <template>
   <!--
-    SpaLink: A RouterLink wrapper that guarantees SPA navigation.
+    SpaLink: Reliable internal navigation link.
 
-    WHY THIS EXISTS:
-    Vue 3.5+ (version 3.5.29 confirmed) uses event delegation for ALL event
-    handlers, including @click. Event handlers are NOT attached directly to DOM
-    elements (no __vei entries). Instead, they're managed internally by Vue's
-    runtime via a delegated handler on a parent element.
+    Renders an <a> with the correct href for accessibility, SEO, and
+    middle-click support. SPA navigation is guaranteed by the global
+    capture-phase click interceptor in boot/spaLinkInterceptor.ts
+    (workaround for Vue 3.5 event delegation racing with native
+    <a href> link following — see vuejs/router#846).
 
-    For <a href="..."> tags, this creates a race condition with the browser's
-    native link-following behavior:
-    1. User clicks the <a> tag
-    2. Browser sees a trusted click on an <a> with an href
-    3. Vue's delegated click handler needs to call preventDefault()
-    4. If the browser processes the native link BEFORE Vue's delegated handler
-       fires → full page reload instead of SPA navigation
-
-    This is intermittent and timing-dependent. It was confirmed via Playwright
-    testing and manual browser testing across Chrome, Safari, and production.
-    It affects ALL <a>-based RouterLinks in Vue 3.5+ apps.
-
-    EVIDENCE (from Playwright investigation):
-    - __vei is empty on ALL elements in the DOM (Vue 3.5 event delegation)
-    - Vnode props DO have onClick (Vue knows about the handler internally)
-    - dispatchEvent() synthetic clicks work (Vue intercepts synchronously)
-    - Real browser clicks intermittently bypass Vue's delegated handler
-    - Only the capture-phase document listener fires; the bubble-phase listener
-      never fires because the browser already started native navigation
-
-    THE FIX:
-    This component uses a raw addEventListener('click', ...) attached DIRECTLY
-    to the <a> DOM element, bypassing Vue's event delegation entirely. This
-    ensures preventDefault() is called immediately when the click fires on
-    the element, before the browser can follow the native link.
-
-    WHAT IT PRESERVES:
-    - <a href="..."> for accessibility, SEO, right-click "Open in new tab"
-    - Middle-click / Ctrl+click / Cmd+click open in new tab (modifier key check)
-    - RouterLink's computed href resolution (via custom v-slot)
-    - SPA navigation via router.push()
-
-    KNOWN ISSUE / REFERENCES:
-    - Vue 3.5 event delegation: https://github.com/vuejs/core/pull/11765
-    - Vue Router issues #846, #856: RouterLink + @click causes full page reload
-    - Similar to React 17's event delegation issues with <a> tags
-    - Search: "vue 3.5 event delegation RouterLink click full page reload"
-
-    USE THIS COMPONENT instead of <RouterLink> for any navigation link
-    that must guarantee SPA behavior. Standard <RouterLink> may intermittently
-    cause full page reloads in Vue 3.5+.
+    Use instead of <RouterLink> for critical navigation links.
   -->
-  <a ref="linkEl" :href="resolvedHref" :class="linkClass">
-    <slot />
-  </a>
+  <RouterLink v-slot="{ href, navigate }" :to="to" custom>
+    <a :href="href" @click="navigate">
+      <slot />
+    </a>
+  </RouterLink>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
-import { type RouteLocationRaw, useRouter } from "vue-router";
+import type { RouteLocationRaw } from "vue-router";
 
-const props = defineProps<{
+defineProps<{
   to: RouteLocationRaw;
-  linkClass?: string;
 }>();
-
-const router = useRouter();
-
-const resolvedHref = computed(() => router.resolve(props.to).href);
-
-const linkEl = ref<HTMLAnchorElement | null>(null);
-
-onMounted(() => {
-  if (!linkEl.value) return;
-  linkEl.value.addEventListener("click", (e: MouseEvent) => {
-    // Allow modifier-key clicks to open in new tab (standard browser behavior)
-    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
-      return;
-    }
-    e.preventDefault();
-    void router.push(props.to);
-  });
-});
 </script>
 
 <style scoped lang="scss">

--- a/services/agora/src/pages/notification/index.vue
+++ b/services/agora/src/pages/notification/index.vue
@@ -26,11 +26,10 @@
       >
         <div class="widthConstraint">
           <div class="notificaitonListFlexStyle">
-            <router-link
+            <SpaLink
               v-for="notificationItem in notificationList"
               :key="notificationItem.slugId"
               :to="getRouteFromTarget(notificationItem.routeTarget) ?? {}"
-              class="notificationLink"
             >
               <ZKHoverEffect
                 :enable-hover="true"
@@ -78,7 +77,7 @@
                   </div>
                 </div>
               </ZKHoverEffect>
-            </router-link>
+            </SpaLink>
           </div>
         </div>
 
@@ -100,6 +99,7 @@ import UserAvatar from "src/components/account/UserAvatar.vue";
 import { HomeMenuBar } from "src/components/navigation/header/variants";
 import ErrorRetryBlock from "src/components/ui/ErrorRetryBlock.vue";
 import PageLoadingSpinner from "src/components/ui/PageLoadingSpinner.vue";
+import SpaLink from "src/components/ui-library/SpaLink.vue";
 import ZKHoverEffect from "src/components/ui-library/ZKHoverEffect.vue";
 import ZKHtmlContent from "src/components/ui-library/ZKHtmlContent.vue";
 import ZKIcon from "src/components/ui-library/ZKIcon.vue";

--- a/services/agora/src/utils/nav/goBackButton.ts
+++ b/services/agora/src/utils/nav/goBackButton.ts
@@ -21,7 +21,9 @@ export function useGoBackButtonHandler() {
     // Vue Router 4 stores the previous path in window.history.state.back.
     // It is null when the current page is the first in the session (direct
     // URL entry, page refresh, or app opened via link).
-    if (window.history.state?.back != null) {
+    // Also try history.length > 1 as a fallback — history.state.back can
+    // be lost after a full page reload even when there IS history to go to.
+    if (window.history.state?.back != null || window.history.length > 1) {
       router.go(-1);
     } else {
       await router.replace(fallbackRoute);


### PR DESCRIPTION
## Summary

Fixes intermittent full page reloads when clicking internal links (RouterLink, SpaLink). Root cause: Vue 3.5's event delegation (`vuejs/core#11765`) races with the browser's native `<a href>` link following.

### The bug

Vue 3.5 introduced event delegation where click handlers are NOT attached directly to DOM elements (`__vei` is empty on ALL elements). Instead, they're managed by Vue's runtime on a parent element. For `<a>` tags, the browser can follow the native link BEFORE Vue's delegated handler calls `preventDefault()`.

**Symptoms:**
- Intermittent full page reloads when clicking conversation/notification links
- App restarts from scratch (SSE reconnects, auth re-initializes)
- Browser history corrupted (back button goes to wrong page)
- Affects all browsers, dev and production
- Timing-dependent: sometimes SPA works, sometimes full reload

**Confirmed via Playwright investigation:**
- `__vei` is empty on ALL elements (Vue 3.5 event delegation)
- Vnode props DO have `onClick` (Vue knows about the handler internally)
- Synthetic `dispatchEvent` clicks work (Vue intercepts synchronously)
- Real browser clicks intermittently bypass Vue's delegated handler

### The fix

Global capture-phase click listener on `document` in `boot/spaLinkInterceptor.ts`. Capture phase fires BEFORE any element-level or delegated handlers, and BEFORE the browser can follow the native link. Same pattern used by Angular's `LocationStrategy` and SvelteKit's link handling.

**Also:**
- Simplify `SpaLink` to use RouterLink `custom` v-slot with `navigate(event)`
- Apply `SpaLink` to notification page and `FeaturedConversationBanner`
- Improve `safeNavigateBack` fallback when `history.state.back` is null

### References
- [vuejs/core#11765 — Event delegation](https://github.com/vuejs/core/pull/11765)
- [vuejs/router#846 — RouterLink reloads app](https://github.com/vuejs/router/issues/846)
- [vuejs/router#856 — RouterLink click event](https://github.com/vuejs/router/issues/856)

## Test plan

- [x] Click feed items → SPA navigation (no full page reload)
- [x] Click notification links → SPA navigation
- [x] Middle-click → opens in new tab
- [x] Back button goes to previous page (not always feed)
- [x] External links still work normally
- [x] `cd services/agora && pnpm lint:fix && pnpm test` passes

Deploy: agora