### PR TITLE
fix(agora): add deferred mode to SpaLink for feed/profile navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,16 @@ Agora Citizen Network is a privacy-preserving social platform using zero-knowled
 
 The landing page is embedded in the app (not a separate static site) because features like "Explore Conversations" will need database access via SSR.
 
+### UX Philosophy: Native-Like Experience
+
+The main frontend (`services/agora`) is a web app that should **feel like a native mobile app**. Every interaction should feel instant and responsive:
+
+- **Instant page loads**: Use caching (TanStack Query), optimistic updates, and preloaded data so page transitions feel immediate. Show skeleton loaders or spinners only when data genuinely isn't available yet.
+- **SPA navigation everywhere**: Never cause full page reloads. Use `SpaLink` (not plain `<a>`, `<RouterLink>`, or `<button>`) for all internal navigation links. See the "SpaLink for Internal Navigation" section under Important Patterns.
+- **KeepAlive for scroll preservation**: Pages wrapped in `<KeepAlive>` preserve scroll position and component state when navigating back. Don't reset state unnecessarily on re-activation.
+- **Background data refresh**: Refresh stale data silently in the background. Don't show loading states when cached data is available — show the cache immediately, refresh behind the scenes.
+- **No jank**: Avoid layout shifts, flash of empty content, or unnecessary re-renders. Use `min-height`, skeleton placeholders, or `PageLoadingSpinner` to hold space while content loads.
+
 ### Terminology: Comment / Opinion / Statement
 
 The codebase uses `comment` and `opinion` interchangeably in variable names, database columns, and API endpoints for historical reasons. **Conceptually, comment = opinion = statement.** They all refer to the same thing: a user-submitted proposition that others vote on.
@@ -629,6 +639,27 @@ log.debug(`Processing started`); // ❌ Don't use this
 ```
 
 ## Important Patterns
+
+### SpaLink for Internal Navigation
+
+**Always use `SpaLink`** for internal navigation links in `services/agora`. Never use plain `<a>`, `<RouterLink>`, or `<button>` for navigation.
+
+**Why `SpaLink` and not `<button>` or `<RouterLink>`:**
+- Renders a real `<a href>` for accessibility, SEO, right-click "Open in new tab", and middle-click/Ctrl+click support
+- Fixes a Vue 3.5 event delegation bug (`vuejs/core#11765`) that races with the browser's native `<a href>` link following, causing intermittent full page reloads. `SpaLink` + a global capture-phase interceptor (`boot/spaLinkInterceptor.ts`) eliminate the race.
+
+**Two modes** (controlled by the `deferred` prop):
+
+- **Default** (`deferred=false`): The interceptor handles `e.preventDefault()` + `router.push()`. Use for: feed cards, profile statements, notifications, banners — any link where the interceptor can handle navigation.
+- **Deferred** (`deferred=true`): The interceptor only does `e.preventDefault()`. The component handles navigation itself. Use for: analysis/comment tabs that need custom history management (`canGoBackToComment`, `router.back()`) which would conflict with the interceptor's `router.push()`.
+
+**Files:**
+- `services/agora/src/components/ui-library/SpaLink.vue` — the component
+- `services/agora/src/boot/spaLinkInterceptor.ts` — the global interceptor
+
+**References:**
+- Vue 3.5 event delegation: https://github.com/vuejs/core/pull/11765
+- RouterLink reload bug: https://github.com/vuejs/router/issues/846
 
 ### Testing Frontend Components
 

--- a/services/agora/src/boot/spaLinkInterceptor.ts
+++ b/services/agora/src/boot/spaLinkInterceptor.ts
@@ -47,11 +47,20 @@ export default defineBoot(({ router }) => {
     if (!(anchor instanceof HTMLAnchorElement)) return;
     if (anchor.target === "_blank" || anchor.hasAttribute("download")) return;
     if (!anchor.href.startsWith(window.location.origin)) return;
+    // Skip entirely if click target is an interactive element inside the <a>.
+    // These elements have their own @click.stop handlers (e.g., share, vote count,
+    // hamburger menu). We must not call e.preventDefault() here — that would
+    // interfere with Vue's event delegation for the button handlers.
+    // Browsers give priority to inner interactive elements over the outer <a>.
+    const target = e.target as HTMLElement;
+    const interactive = target.closest("button, [role='button'], input, select, textarea");
+    if (interactive && anchor.contains(interactive)) return;
     e.preventDefault();
-    // SpaLink components handle their own navigation — only push for plain <a> tags
-    if (!anchor.hasAttribute("data-spa-handled")) {
-      const url = new URL(anchor.href);
-      void router.push(url.pathname + url.search + url.hash);
-    }
+    // Deferred SpaLinks (data-spa-handled) handle their own navigation —
+    // used by analysis/comment tabs that need custom history management.
+    // See SpaLink.vue for the two-mode explanation.
+    if (anchor.hasAttribute("data-spa-handled")) return;
+    const url = new URL(anchor.href);
+    void router.push(url.pathname + url.search + url.hash);
   }, true);
 });

--- a/services/agora/src/components/post/interactionBar/InteractionTab.vue
+++ b/services/agora/src/components/post/interactionBar/InteractionTab.vue
@@ -1,5 +1,9 @@
 <template>
   <div>
+    <!-- Analysis/comment tabs use deferred SpaLink navigation (not the global
+         interceptor) because they need custom history management:
+         canGoBackToComment + router.back() would conflict with the interceptor's
+         router.push(). See SpaLink.vue for the two-mode explanation. -->
     <div class="container">
       <ZKTab
         :icon-code="props.conversationType === 'maxdiff' ? 'mdi:sort-numeric-ascending' : 'meteor-icons:comment'"
@@ -8,6 +12,7 @@
         :should-underline-on-highlight="true"
         :is-loading="isLoading && model === 'comment'"
         :to="model === 'comment' ? (compactMode ? undefined : { name: commentRouteName, params: { postSlugId: conversationSlugId } }) : undefined"
+        :deferred="true"
         @click="handleCommentClick"
       />
       <ZKTab
@@ -18,6 +23,7 @@
         :should-underline-on-highlight="true"
         :is-loading="isLoading && model === 'analysis'"
         :to="model === 'analysis' ? undefined : { name: analysisRouteName, params: { postSlugId: conversationSlugId } }"
+        :deferred="true"
         @click="handleAnalysisClick"
       />
     </div>

--- a/services/agora/src/components/ui-library/SpaLink.vue
+++ b/services/agora/src/components/ui-library/SpaLink.vue
@@ -2,19 +2,39 @@
   <!--
     SpaLink: Reliable internal navigation link.
 
-    Renders an <a> with the correct href for accessibility, SEO, and
-    middle-click support. The global capture-phase interceptor in
-    boot/spaLinkInterceptor.ts calls e.preventDefault() to prevent the
-    Vue 3.5 event delegation race with native <a href> following.
+    WHY THIS EXISTS:
+    Vue 3.5 introduced event delegation (vuejs/core#11765) where click
+    handlers are NOT attached directly to DOM elements. For <a> tags, this
+    races with the browser's native link following, causing intermittent
+    full page reloads instead of SPA navigation.
+    - Vue 3.5 event delegation: https://github.com/vuejs/core/pull/11765
+    - RouterLink reload bug: https://github.com/vuejs/router/issues/846
+    - RouterLink click event: https://github.com/vuejs/router/issues/856
+    See boot/spaLinkInterceptor.ts for the full root cause analysis.
 
-    Navigation is handled here (not by the interceptor) via handleClick.
-    When a parent passes @click through $attrs, SpaLink defers to the
-    parent's handler — the parent is responsible for calling router.push().
+    TWO MODES (controlled by the `deferred` prop):
+
+    Default (deferred=false): The global capture-phase interceptor in
+    boot/spaLinkInterceptor.ts handles both e.preventDefault() and
+    router.push(). @click="navigate" is a belt-and-suspenders fallback.
+    Use for: feed cards, profile statements, notifications, banners.
+
+    Deferred (deferred=true): The interceptor only does e.preventDefault()
+    (via data-spa-handled). Navigation is handled here via handleClick,
+    or by a parent's @click handler (detected via $attrs). Use for:
+    analysis/comment tabs that need custom history management
+    (canGoBackToComment, router.back()) which would conflict with the
+    interceptor's router.push().
 
     Use instead of <RouterLink> for critical navigation links.
   -->
-  <RouterLink v-slot="{ href }" :to="to" custom>
-    <a ref="anchorRef" :href="href" v-bind="$attrs" @click="handleClick">
+  <RouterLink v-slot="{ href, navigate }" :to="to" custom>
+    <a
+      ref="anchorRef"
+      :href="href"
+      v-bind="$attrs"
+      @click="deferred ? handleClick($event) : navigate($event)"
+    >
       <slot />
     </a>
   </RouterLink>
@@ -26,9 +46,12 @@ import { type RouteLocationRaw, useRouter } from "vue-router";
 
 defineOptions({ inheritAttrs: false });
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   to: RouteLocationRaw;
-}>();
+  deferred?: boolean;
+}>(), {
+  deferred: false,
+});
 
 const router = useRouter();
 const attrs = useAttrs();
@@ -36,7 +59,9 @@ const anchorRef = ref<HTMLAnchorElement | null>(null);
 
 // Set data attribute via DOM to avoid vue-tsc rejecting custom data-* on <a>
 onMounted(() => {
-  anchorRef.value?.setAttribute("data-spa-handled", "");
+  if (props.deferred) {
+    anchorRef.value?.setAttribute("data-spa-handled", "");
+  }
 });
 
 function handleClick(e: MouseEvent): void {

--- a/services/agora/src/components/ui-library/ZKTab.vue
+++ b/services/agora/src/components/ui-library/ZKTab.vue
@@ -2,6 +2,7 @@
   <SpaLink
     v-if="to"
     :to="to"
+    :deferred="deferred"
     class="tabStyle"
     :class="{
       highlightTab: isHighlighted,
@@ -70,6 +71,7 @@ defineProps<{
   shouldUnderlineOnHighlight: boolean;
   isLoading?: boolean;
   to?: RouteLocationRaw;
+  deferred?: boolean;
 }>();
 
 const emit = defineEmits<{


### PR DESCRIPTION
## Summary

- The split commit (0cd59839) made ALL SpaLinks set `data-spa-handled`, causing the interceptor to skip `router.push()`. SpaLink's Vue template `@click` is unreliable due to Vue 3.5 event delegation — breaking feed cards, profile statements, and notification clicks.
- Add `deferred` prop to SpaLink: default mode lets the interceptor navigate (feed, profile, notifications), deferred mode lets the component handle navigation (analysis/comment tabs with custom history management).
- Interceptor now skips interactive elements (`<button>`, etc.) inside `<a>` tags so feed buttons (share, counts, hamburger) keep working.
- CLAUDE.md: add native-like UX philosophy and SpaLink usage guidelines.

## Test plan

- [ ] Feed: click compact post body → navigates to conversation
- [ ] Feed: click share/hamburger/counts → opens dialog (no navigation)
- [ ] Profile: click statement → navigates to conversation
- [ ] Notifications: click notification → navigates
- [ ] Conversation page: comment/analysis tabs switch correctly
- [ ] Conversation page: back button after analysis → returns to comment tab
- [ ] Middle-click / Ctrl+click → opens in new tab
- [ ] No full page reloads on any navigation