### PR TITLE
fix(agora): fix mobile drawer background color and reduce width

### DIFF
--- a/services/agora/src/layouts/PersistentLayout.vue
+++ b/services/agora/src/layouts/PersistentLayout.vue
@@ -98,6 +98,7 @@ function captureHeaderReveal(reveal: boolean) {
 .scrollContainer {
   width: 100%;
   height: 100%;
+  background-color: $app-background-color;
 }
 
 #page-header {

--- a/services/agora/src/stores/navigation.ts
+++ b/services/agora/src/stores/navigation.ts
@@ -27,7 +27,7 @@ export const useNavigationStore = defineStore("navigation", () => {
   // Small sidebar at 555–960px, large sidebar at >960px
   // Mobile overlay (≤554px): 300px — doesn't compete with feed
   const drawerWidth = computed(() => {
-    if (drawerBehavior.value === "mobile") return 300;
+    if (drawerBehavior.value === "mobile") return 280;
     return $q.screen.gt.sm ? 273 : 200;
   });
 


### PR DESCRIPTION
## Summary
- Set `background-color: $app-background-color` on the drawer's scroll container so the mobile drawer matches the desktop sidebar background (#f6f5f8) instead of white
- Reduce mobile drawer width from 300px to 280px per Material Design M1/M2 guidelines (5 × 56dp standard increment), leaving more visible content behind the overlay on small screens

## Test plan
- [ ] Open hamburger menu at mobile width → background should be light gray, not white
- [ ] Drawer width should be noticeably narrower, leaving more content visible behind it
- [ ] Desktop sidebar appearance unchanged