### PR TITLE
fix(api): make V0046 migration idempotent

### DIFF
--- a/services/api/database/flyway/V0046__organic_sasquatch.sql
+++ b/services/api/database/flyway/V0046__organic_sasquatch.sql
@@ -1,2 +1,4 @@
-DROP INDEX "maxdiff_external_source_dedup_idx";--> statement-breakpoint
-CREATE INDEX "maxdiff_external_source_external_id_idx" ON "maxdiff_item_external_source" USING btree ("external_id");
+-- No-op: these changes were already applied by V0045.4 (fix_maxdiff_github_sync_dedup).
+-- Keeping guarded statements for safety in case V0045.4 was skipped in some environment.
+DROP INDEX IF EXISTS "maxdiff_external_source_dedup_idx";
+CREATE INDEX IF NOT EXISTS "maxdiff_external_source_external_id_idx" ON "maxdiff_item_external_source" USING btree ("external_id");


### PR DESCRIPTION
## Summary

- V0045.4 already dropped `maxdiff_external_source_dedup_idx` and created `maxdiff_external_source_external_id_idx`
- V0046 (Drizzle-generated) tried the same operations without `IF EXISTS` guards, failing in production
- Added `IF EXISTS` / `IF NOT EXISTS` guards so V0046 is idempotent

## Test plan

- [ ] Run `pnpm db:migrate` locally to confirm migration succeeds
- [ ] Deploy to prod and verify V0046 applies cleanly