### PR TITLE
fix(api,agora): allow non-logged-in users to view MaxDiff conversations

### DIFF
--- a/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.i18n.ts
+++ b/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.i18n.ts
@@ -20,6 +20,7 @@ export interface MaxDiffVotingTabTranslations {
   cancelSelection: string;
   undoLastVote: string;
   undoError: string;
+  retryButton: string;
 }
 
 export const maxDiffVotingTabTranslations: Record<
@@ -46,6 +47,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "Cancel selection",
     undoLastVote: "Undo",
     undoError: "Failed to undo. Please try again.",
+    retryButton: "Try again",
   },
   ar: {
     title: "رتّب العبارات حسب الأولوية",
@@ -67,6 +69,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "إلغاء الاختيار",
     undoLastVote: "تراجع",
     undoError: "فشل التراجع. يرجى المحاولة مرة أخرى.",
+    retryButton: "حاول مرة أخرى",
   },
   es: {
     title: "Priorizar declaraciones",
@@ -88,6 +91,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "Cancelar selección",
     undoLastVote: "Deshacer",
     undoError: "Error al deshacer. Inténtalo de nuevo.",
+    retryButton: "Intentar de nuevo",
   },
   fa: {
     title: "اولویت‌بندی گزاره‌ها",
@@ -109,6 +113,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "لغو انتخاب",
     undoLastVote: "بازگردانی",
     undoError: "بازگردانی ناموفق بود. لطفاً دوباره تلاش کنید.",
+    retryButton: "دوباره تلاش کنید",
   },
   he: {
     title: "תעדוף הצהרות",
@@ -130,6 +135,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "ביטול בחירה",
     undoLastVote: "ביטול",
     undoError: "הביטול נכשל. אנא נסו שוב.",
+    retryButton: "נסו שוב",
   },
   fr: {
     title: "Hiérarchiser les propositions",
@@ -151,6 +157,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "Annuler la sélection",
     undoLastVote: "Annuler",
     undoError: "Échec de l'annulation. Veuillez réessayer.",
+    retryButton: "Réessayer",
   },
   "zh-Hans": {
     title: "优先排列陈述",
@@ -172,6 +179,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "取消选择",
     undoLastVote: "撤销",
     undoError: "撤销失败，请重试。",
+    retryButton: "重试",
   },
   "zh-Hant": {
     title: "優先排列陳述",
@@ -193,6 +201,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "取消選擇",
     undoLastVote: "復原",
     undoError: "復原失敗，請重試。",
+    retryButton: "重試",
   },
   ja: {
     title: "ステートメントの優先順位付け",
@@ -214,6 +223,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "選択を取り消す",
     undoLastVote: "元に戻す",
     undoError: "元に戻せませんでした。もう一度お試しください。",
+    retryButton: "再試行",
   },
   ky: {
     title: "Билдирүүлөрдү артыкчылыктуу кылуу",
@@ -235,6 +245,7 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "Тандоону жокко чыгаруу",
     undoLastVote: "Артка кайтаруу",
     undoError: "Артка кайтаруу ишке ашкан жок. Кайра аракет кылыңыз.",
+    retryButton: "Кайра аракет кылуу",
   },
   ru: {
     title: "Расставьте приоритеты",
@@ -256,5 +267,6 @@ export const maxDiffVotingTabTranslations: Record<
     cancelSelection: "Отменить выбор",
     undoLastVote: "Отменить",
     undoError: "Не удалось отменить. Попробуйте ещё раз.",
+    retryButton: "Попробовать ещё раз",
   },
 };

--- a/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.vue
+++ b/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.vue
@@ -8,6 +8,15 @@
       {{ t("loadingError") }}
     </div>
 
+    <!-- Initialization error (e.g. failed to load saved state or route buffer) -->
+    <ErrorRetryBlock
+      v-else-if="initError"
+      :title="t('loadingError')"
+      :retry-label="t('retryButton')"
+      compact
+      @retry="retryInitialize"
+    />
+
     <!-- Completed ranking (check before statement count so users with saved rankings still see them) -->
     <div v-else-if="isComplete && finalRanking.length > 0" class="ranking-section">
       <div class="section-header">{{ t("complete") }}</div>
@@ -155,6 +164,7 @@
 import { storeToRefs } from "pinia";
 import { useQuasar } from "quasar";
 import PreLoginIntentionDialog from "src/components/authentication/intention/PreLoginIntentionDialog.vue";
+import ErrorRetryBlock from "src/components/ui/ErrorRetryBlock.vue";
 import PageLoadingSpinner from "src/components/ui/PageLoadingSpinner.vue";
 import ZKHtmlContent from "src/components/ui-library/ZKHtmlContent.vue";
 import { useConversationLoginIntentions } from "src/composables/auth/useConversationLoginIntentions";
@@ -226,6 +236,7 @@ interface MaxDiffItemDisplay {
 const itemList = ref<MaxDiffItemDisplay[]>([]);
 const itemsFetched = ref(false);
 const itemsFetchError = ref(false);
+const initError = ref(false);
 
 const itemContentMap = computed(() => {
   const map = new Map<string, string>();
@@ -408,6 +419,7 @@ watch(candidates, () => {
 
 async function initializeMaxDiff(): Promise<void> {
   isLoading.value = true;
+  initError.value = false;
 
   const slugIds = itemList.value.map((item) => item.slugId);
 
@@ -440,8 +452,14 @@ async function initializeMaxDiff(): Promise<void> {
 
     // Don't push history entries for previously saved comparisons.
     // Browser back should only undo votes made in the current session.
+  } else if (loadResponse.status === "success") {
+    // No saved state — create fresh instance
+    const fresh = createMaxDiff(slugIds);
+    instance.value = fresh;
+    isComplete.value = false;
+    finalRanking.value = [];
   } else {
-    // Create fresh instance
+    // Load failed — create fresh instance anyway (treat as no saved state)
     const fresh = createMaxDiff(slugIds);
     instance.value = fresh;
     isComplete.value = false;
@@ -454,8 +472,19 @@ async function initializeMaxDiff(): Promise<void> {
     initialLoad: true,
   });
 
+  // If buffer is empty after initial fetch and voting isn't complete, show error
+  if (candidateBuffer.value.length === 0 && !instance.value.complete) {
+    initError.value = true;
+    isLoading.value = false;
+    return;
+  }
+
   await updateCandidates();
   isLoading.value = false;
+}
+
+function retryInitialize(): void {
+  void initializeMaxDiff();
 }
 
 const BUFFER_REFILL_THRESHOLD = 1;

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -864,6 +864,45 @@ async function verifyUcanAndDeviceStatus(
     };
 }
 
+// Validates the UCAN and gets device status without enforcing any status
+// requirements. Use for endpoints that serve both known and unknown devices
+// (e.g. public pages with optional personalization).
+// When no auth header is present, returns an unauthenticated response with
+// didWrite/encodedUcan undefined and isKnown: false.
+type VerifyUcanOptionalAuthReturn =
+    | {
+          didWrite: string;
+          encodedUcan: string;
+          deviceStatus: DeviceLoginStatusInternal;
+      }
+    | {
+          didWrite: undefined;
+          encodedUcan: undefined;
+          deviceStatus: Extract<DeviceLoginStatusInternal, { isKnown: false }>;
+      };
+
+async function verifyUcanOptionalAuth(
+    db: PostgresDatabase,
+    request: FastifyRequest,
+): Promise<VerifyUcanOptionalAuthReturn> {
+    const authHeader = request.headers.authorization;
+    if (authHeader === undefined || !authHeader.startsWith("Bearer ")) {
+        return {
+            didWrite: undefined,
+            encodedUcan: undefined,
+            deviceStatus: {
+                isKnown: false,
+                isLoggedIn: false,
+                isRegistered: false,
+                credentials: { email: null, phone: null, rarimo: null },
+            },
+        };
+    }
+    return await verifyUcanAndDeviceStatus(db, request, {
+        expectedDeviceStatus: undefined,
+    });
+}
+
 // always return userId !== undefined
 async function verifyUcanAndKnownDeviceStatus(
     db: PostgresDatabase,
@@ -1207,35 +1246,18 @@ server.after(() => {
             },
         },
         handler: async (request) => {
-            let isAuthenticatedRequest = false;
-            const authHeader = request.headers.authorization;
-            if (authHeader !== undefined) {
-                isAuthenticatedRequest = true;
-            } else {
-                isAuthenticatedRequest = false;
-            }
-            if (isAuthenticatedRequest) {
-                const { deviceStatus } = await verifyUcanAndKnownDeviceStatus(
-                    db,
-                    request,
-                    {
-                        expectedKnownDeviceStatus: { isGuestOrLoggedIn: true },
-                    },
-                );
-
-                return await feedService.fetchFeed({
-                    db: db,
-                    personalizationUserId: deviceStatus.userId,
-                    baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
-                    sortAlgorithm: request.body.sortAlgorithm,
-                });
-            } else {
-                return await feedService.fetchFeed({
-                    db: db,
-                    baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
-                    sortAlgorithm: request.body.sortAlgorithm,
-                });
-            }
+            const { deviceStatus } = await verifyUcanOptionalAuth(
+                db,
+                request,
+            );
+            return await feedService.fetchFeed({
+                db: db,
+                personalizationUserId: deviceStatus.isKnown
+                    ? deviceStatus.userId
+                    : undefined,
+                baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
+                sortAlgorithm: request.body.sortAlgorithm,
+            });
         },
     });
 
@@ -1750,10 +1772,17 @@ server.after(() => {
         },
         handler: async (request) => {
             checkMaxdiffEnabled();
-            const { deviceStatus } =
-                await verifyUcanAndKnownDeviceStatus(db, request, {
-                    expectedKnownDeviceStatus: { isGuestOrLoggedIn: true },
-                });
+            const { deviceStatus } = await verifyUcanOptionalAuth(
+                db,
+                request,
+            );
+            if (!deviceStatus.isKnown) {
+                return {
+                    ranking: null,
+                    comparisons: null,
+                    isComplete: false,
+                };
+            }
             return await loadMaxdiffResult({
                 db,
                 conversationSlugId: request.body.conversationSlugId,
@@ -1792,10 +1821,7 @@ server.after(() => {
         },
         handler: async (request) => {
             checkMaxdiffEnabled();
-            const { deviceStatus } =
-                await verifyUcanAndKnownDeviceStatus(db, request, {
-                    expectedKnownDeviceStatus: { isGuestOrLoggedIn: true },
-                });
+            await verifyUcanOptionalAuth(db, request);
             const { items, uncertainty } = await computeGlobalUncertainty({
                 db,
                 conversationSlugId: request.body.conversationSlugId,
@@ -2027,39 +2053,20 @@ server.after(() => {
             },
         },
         handler: async (request) => {
-            let isAuthenticatedRequest = false;
-            const authHeader = request.headers.authorization;
-            if (authHeader !== undefined) {
-                isAuthenticatedRequest = true;
-            } else {
-                isAuthenticatedRequest = false;
-            }
-            if (isAuthenticatedRequest) {
-                const { deviceStatus } = await verifyUcanAndKnownDeviceStatus(
-                    db,
-                    request,
-                    {
-                        expectedKnownDeviceStatus: { isGuestOrLoggedIn: true },
-                    },
-                );
-
-                const opinionItemsPerSlugId = await fetchOpinionsByPostSlugId({
-                    db: db,
-                    postSlugId: request.body.conversationSlugId,
-                    filterTarget: request.body.filter,
-                    personalizationUserId: deviceStatus.userId,
-                    limit: 3000,
-                });
-                return Array.from(opinionItemsPerSlugId.values());
-            } else {
-                const opinionItemsPerSlugId = await fetchOpinionsByPostSlugId({
-                    db: db,
-                    postSlugId: request.body.conversationSlugId,
-                    filterTarget: request.body.filter,
-                    limit: 3000,
-                });
-                return Array.from(opinionItemsPerSlugId.values());
-            }
+            const { deviceStatus } = await verifyUcanOptionalAuth(
+                db,
+                request,
+            );
+            const opinionItemsPerSlugId = await fetchOpinionsByPostSlugId({
+                db: db,
+                postSlugId: request.body.conversationSlugId,
+                filterTarget: request.body.filter,
+                personalizationUserId: deviceStatus.isKnown
+                    ? deviceStatus.userId
+                    : undefined,
+                limit: 3000,
+            });
+            return Array.from(opinionItemsPerSlugId.values());
         },
     });
 
@@ -2073,60 +2080,42 @@ server.after(() => {
             },
         },
         handler: async (request) => {
-            let isAuthenticatedRequest = false;
-            const authHeader = request.headers.authorization;
-            if (authHeader !== undefined) {
-                isAuthenticatedRequest = true;
-            } else {
-                isAuthenticatedRequest = false;
-            }
-            if (isAuthenticatedRequest) {
-                const { deviceStatus } = await verifyUcanAndKnownDeviceStatus(
-                    db,
-                    request,
-                    {
-                        expectedKnownDeviceStatus: { isGuestOrLoggedIn: true },
-                    },
+            const { deviceStatus } = await verifyUcanOptionalAuth(
+                db,
+                request,
+            );
+
+            // Get display language from validated header or use default "en"
+            const parsedHeaderDisplayLanguage =
+                ZodSupportedDisplayLanguageCodes.safeParse(
+                    request.headers["accept-language"],
                 );
+            const headerDisplayLanguage: SupportedDisplayLanguageCodes =
+                parsedHeaderDisplayLanguage.success
+                    ? parsedHeaderDisplayLanguage.data
+                    : "en";
 
-                // Get display language from validated header or use default "en"
-                const parsedHeaderDisplayLanguage =
-                    ZodSupportedDisplayLanguageCodes.safeParse(
-                        request.headers["accept-language"],
-                    );
-                const headerDisplayLanguage: SupportedDisplayLanguageCodes =
-                    parsedHeaderDisplayLanguage.success
-                        ? parsedHeaderDisplayLanguage.data
-                        : "en";
+            // Get user's display language from DB if known (falls back to header language)
+            const displayLanguage = deviceStatus.isKnown
+                ? await getLanguagePreferences({
+                      db,
+                      userId: deviceStatus.userId,
+                      request: {
+                          currentDisplayLanguage: headerDisplayLanguage,
+                      },
+                  }).then((prefs) => prefs.displayLanguage)
+                : headerDisplayLanguage;
 
-                // Get user's display language from DB (falls back to header language)
-                const displayLanguage = await getLanguagePreferences({
-                    db,
-                    userId: deviceStatus.userId,
-                    request: { currentDisplayLanguage: headerDisplayLanguage },
-                }).then((prefs) => prefs.displayLanguage);
-
-                const analysis = await fetchAnalysisByConversationSlugId({
-                    db: db,
-                    conversationSlugId: request.body.conversationSlugId,
-                    personalizationUserId: deviceStatus.userId,
-                    displayLanguage,
-                    googleCloudCredentials,
-                });
-                return analysis;
-            } else {
-                // Get display language from validated header or use default "en"
-                const displayLanguage =
-                    request.headers["accept-language"] ?? "en";
-
-                const analysis = await fetchAnalysisByConversationSlugId({
-                    db: db,
-                    conversationSlugId: request.body.conversationSlugId,
-                    displayLanguage,
-                    googleCloudCredentials,
-                });
-                return analysis;
-            }
+            const analysis = await fetchAnalysisByConversationSlugId({
+                db: db,
+                conversationSlugId: request.body.conversationSlugId,
+                personalizationUserId: deviceStatus.isKnown
+                    ? deviceStatus.userId
+                    : undefined,
+                displayLanguage,
+                googleCloudCredentials,
+            });
+            return analysis;
         },
     });
 
@@ -2615,45 +2604,23 @@ server.after(() => {
             },
         },
         handler: async (request) => {
-            let isAuthenticatedRequest = false;
-            const authHeader = request.headers.authorization;
-            if (authHeader !== undefined) {
-                isAuthenticatedRequest = true;
-            } else {
-                isAuthenticatedRequest = false;
-            }
-            if (isAuthenticatedRequest) {
-                const { deviceStatus } = await verifyUcanAndKnownDeviceStatus(
-                    db,
-                    request,
-                    {
-                        expectedKnownDeviceStatus: { isGuestOrLoggedIn: true },
-                    },
-                );
+            const { deviceStatus } = await verifyUcanOptionalAuth(
+                db,
+                request,
+            );
+            const postItem = await postService.fetchPostBySlugId({
+                db: db,
+                conversationSlugId: request.body.conversationSlugId,
+                personalizedUserId: deviceStatus.isKnown
+                    ? deviceStatus.userId
+                    : undefined,
+                baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
+            });
 
-                const postItem = await postService.fetchPostBySlugId({
-                    db: db,
-                    conversationSlugId: request.body.conversationSlugId,
-                    personalizedUserId: deviceStatus.userId,
-                    baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
-                });
-
-                const response: GetConversationResponse = {
-                    conversationData: postItem,
-                };
-                return response;
-            } else {
-                const postItem = await postService.fetchPostBySlugId({
-                    db: db,
-                    conversationSlugId: request.body.conversationSlugId,
-                    baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
-                });
-
-                const response: GetConversationResponse = {
-                    conversationData: postItem,
-                };
-                return response;
-            }
+            const response: GetConversationResponse = {
+                conversationData: postItem,
+            };
+            return response;
         },
     });
 


### PR DESCRIPTION
## Summary
- Non-logged-in users visiting a MaxDiff conversation (e.g. Product Roadmap) saw an infinite spinner because maxdiff/load and maxdiff/route required auth
- Add `verifyUcanOptionalAuth` helper with typesafe discriminated union return type
- Refactor 4 existing auth-optional endpoints to use it, replacing boilerplate
- Make maxdiff/load and maxdiff/route auth-optional
- Add ErrorRetryBlock to MaxDiffVotingTab for initialization failures
- Add retryButton i18n key across all 11 languages

Note: this branch also contains splash screen changes that overlap with #824. Merge #824 first, then this PR will only show the MaxDiff diff.

## Test plan
- [ ] Visit a MaxDiff conversation while logged out - should load (no spinner)
- [ ] Visit while logged in - should work as before with saved state
- [ ] MaxDiff initialization failure shows retry button
- [ ] `cd services/api && pnpm lint && pnpm test`
- [ ] `cd services/agora && pnpm lint`