### PR TITLE
fix(api): include all items in backfill scoring set

### DIFF
--- a/services/api/src/service/maxdiffBackfill.ts
+++ b/services/api/src/service/maxdiffBackfill.ts
@@ -69,22 +69,18 @@ export async function backfillMaxdiffSnapshots({
 
     for (const [conversationId, conversationItems] of byConversation) {
         try {
-            // Fetch active items + all results ONCE per conversation
-            const activeItems = await db
+            // Fetch ALL items (including completed/canceled) + all results ONCE per conversation
+            const allItems = await db
                 .select({ slugId: maxdiffItemTable.slugId })
                 .from(maxdiffItemTable)
                 .where(
                     and(
                         eq(maxdiffItemTable.conversationId, conversationId),
                         isNotNull(maxdiffItemTable.currentContentId),
-                        inArray(maxdiffItemTable.lifecycleStatus, [
-                            "active",
-                            "in_progress",
-                        ]),
                     ),
                 );
 
-            const items = activeItems.map((r) => r.slugId);
+            const items = allItems.map((r) => r.slugId);
             if (items.length < 2) continue;
 
             const allResults = await db


### PR DESCRIPTION
## Summary

The `maxdiffBackfill` startup job was silently doing nothing — it computed scores using only active/in_progress items, then tried to find completed/canceled items in those scores. Since completed items are never in the active set, the lookup always returned `undefined` and every item was skipped.

**Fix**: Remove the `lifecycleStatus` filter so all items with content are included in the Bradley-Terry MLE scoring set. Completed/canceled items now appear in the scored results and get their snapshot scores written.

No new migration needed — items still have NULL snapshots from V0048.2 and will be picked up on next API startup.

## Test plan

- [x] `cd services/api && pnpm build` — passes
- [x] `cd services/api && pnpm test` — 141 tests pass
- [ ] Deploy API and verify logs show `[MaxDiff Backfill] Complete: N succeeded, 0 failed` (N > 0)
- [ ] Check completed/canceled items in Results tab show non-zero scores

Deploy: api