### PR TITLE
fix(api): handle nullable importMethod in API response

### DIFF
--- a/services/api/src/service/common.ts
+++ b/services/api/src/service/common.ts
@@ -310,7 +310,7 @@ export function useCommonPost() {
                     postItem.importAuthor !== null ||
                     postItem.importCreatedAt !== null
                         ? {
-                              method: postItem.importMethod,
+                              method: postItem.importMethod ?? "url",
                               sourceUrl: toUnionUndefined(postItem.importUrl),
                               conversationUrl: toUnionUndefined(
                                   postItem.importConversationUrl,


### PR DESCRIPTION
## Summary

Fix build error: `postItem.importMethod` is `"url" | "csv" | null` from the DB, but the `importInfo` Zod type requires non-null `method: "url" | "csv"`. Default to `"url"` when null, matching the DB column default.

## Test plan
- [x] `pnpm lint` passes
- [ ] `pnpm build` succeeds (was failing with TS2322)

Deploy: api