### PR TITLE
fix(agora): improve MaxDiff voting UX and error handling

### DIFF
--- a/services/agora/src/components/post/maxdiff/MaxDiffResultsTab.i18n.ts
+++ b/services/agora/src/components/post/maxdiff/MaxDiffResultsTab.i18n.ts
@@ -7,6 +7,7 @@ export interface MaxDiffResultsTabTranslations {
   subtitle: string;
   score: string;
   loadingError: string;
+  retryButton: string;
   communityLearnMoreHow: string;
   communityLearnMoreDiversity: string;
   communityLearnMoreFair: string;
@@ -43,6 +44,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "Aggregated from all participants' votes",
     score: "Score: {score}",
     loadingError: "Failed to load results.",
+    retryButton: "Try again",
     communityLearnMoreHow: "Individual preferences are learned from each participant's comparisons, then aggregated into a community ranking using Solidago, an open-source algorithm from the Tournesol project. Votes count immediately.",
     communityLearnMoreDiversity: "The system accounts for user trust levels and uses opinion group information to ensure diverse perspectives are fairly represented, drawing on research from the Plurality framework.",
     communityLearnMoreFair: "Groups are selected to prioritize items needing more data, with randomized order to prevent position bias. Indirect comparisons are inferred (if A > B and B > C, then A > C) to minimize rounds.",
@@ -73,6 +75,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "مجمّع من أصوات جميع المشاركين",
     score: "النتيجة: {score}",
     loadingError: "فشل تحميل النتائج.",
+    retryButton: "حاول مرة أخرى",
     communityLearnMoreHow: "يتم تعلّم تفضيلات كل مشارك من مقارناته، ثم تُجمع في ترتيب مجتمعي باستخدام Solidago، خوارزمية مفتوحة المصدر من مشروع Tournesol. الأصوات تُحتسب فوراً.",
     communityLearnMoreDiversity: "يراعي النظام مستويات ثقة المستخدمين ويستخدم معلومات مجموعات الرأي لضمان تمثيل عادل للوجهات المتنوعة، استناداً إلى أبحاث إطار التعددية.",
     communityLearnMoreFair: "تُختار المجموعات لإعطاء الأولوية للعناصر التي تحتاج بيانات أكثر، مع ترتيب عشوائي لمنع التحيز الموضعي. تُستنتج المقارنات غير المباشرة (إذا أ > ب و ب > ج، فإن أ > ج) لتقليل الجولات.",
@@ -104,6 +107,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "Agregado a partir de los votos de todos los participantes",
     score: "Puntuación: {score}",
     loadingError: "Error al cargar los resultados.",
+    retryButton: "Intentar de nuevo",
     communityLearnMoreHow: "Las preferencias de cada participante se aprenden de sus comparaciones y se agregan en una clasificacion comunitaria usando Solidago, un algoritmo de codigo abierto del proyecto Tournesol. Los votos cuentan inmediatamente.",
     communityLearnMoreDiversity: "El sistema tiene en cuenta los niveles de confianza de los usuarios y utiliza informacion de grupos de opinion para garantizar una representacion justa de las perspectivas diversas, basandose en la investigacion del marco Plurality.",
     communityLearnMoreFair: "Los grupos se seleccionan priorizando elementos que necesitan mas datos, con orden aleatorio para evitar sesgo de posicion. Se infieren comparaciones indirectas (si A > B y B > C, entonces A > C) para minimizar rondas.",
@@ -136,6 +140,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "تجمیع شده از آرای همه شرکت‌کنندگان",
     score: "امتیاز: {score}",
     loadingError: "بارگذاری نتایج ناموفق بود.",
+    retryButton: "دوباره تلاش کنید",
     communityLearnMoreHow: "ترجیحات هر شرکت‌کننده از مقایسه‌هایش یاد گرفته شده و با الگوریتم Solidago، سیستم متن‌باز پروژه Tournesol، در رتبه‌بندی جمعی تجمیع می‌شوند. آرا فوراً محاسبه می‌شوند.",
     communityLearnMoreDiversity: "سیستم سطوح اعتماد کاربران را در نظر می‌گیرد و از اطلاعات گروه‌های نظری برای نمایندگی عادلانه دیدگاه‌های متنوع استفاده می‌کند، بر اساس تحقیقات چارچوب Plurality.",
     communityLearnMoreFair: "گروه‌ها برای اولویت‌دهی به گزاره‌هایی که داده بیشتری نیاز دارند انتخاب می‌شوند، با ترتیب تصادفی برای جلوگیری از تعصب موقعیتی. مقایسه‌های غیرمستقیم استنتاج می‌شوند (اگر الف > ب و ب > ج، پس الف > ج) تا دورها کمینه شوند.",
@@ -167,6 +172,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "מצטבר מהצבעות כל המשתתפים",
     score: "ציון: {score}",
     loadingError: "טעינת התוצאות נכשלה.",
+    retryButton: "נסו שוב",
     communityLearnMoreHow: "ההעדפות של כל משתתף נלמדות מההשוואות שביצע ומצטברות לדירוג קהילתי באמצעות Solidago, אלגוריתם בקוד פתוח מפרויקט Tournesol. ההצבעות נספרות מיידית.",
     communityLearnMoreDiversity: "המערכת מתחשבת ברמות האמון של המשתמשים ומשתמשת במידע על קבוצות דעה כדי להבטיח ייצוג הוגן של נקודות מבט מגוונות, בהתבסס על מחקר מסגרת Plurality.",
     communityLearnMoreFair: "קבוצות נבחרות כדי לתעדף פריטים שצריכים יותר נתונים, עם סדר אקראי למניעת הטיית מיקום. השוואות עקיפות מוסקות (אם א > ב ו-ב > ג, אז א > ג) כדי למזער סיבובים.",
@@ -197,6 +203,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "Agrégé à partir des votes de tous les participants",
     score: "Score : {score}",
     loadingError: "Échec du chargement des résultats.",
+    retryButton: "Réessayer",
     communityLearnMoreHow: "Les preferences de chaque participant sont apprises a partir de ses comparaisons, puis agregees en un classement communautaire via Solidago, un algorithme open source du projet Tournesol. Les votes comptent immediatement.",
     communityLearnMoreDiversity: "Le systeme tient compte des niveaux de confiance des utilisateurs et utilise les informations de groupes d'opinion pour garantir une representation equitable des perspectives diverses, s'appuyant sur les recherches du cadre Plurality.",
     communityLearnMoreFair: "Les groupes sont selectionnes pour prioriser les elements necessitant plus de donnees, avec un ordre aleatoire pour eviter le biais de position. Les comparaisons indirectes sont deduites (si A > B et B > C, alors A > C) pour minimiser les tours.",
@@ -228,6 +235,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "汇总所有参与者的投票",
     score: "得分：{score}",
     loadingError: "加载结果失败。",
+    retryButton: "重试",
     communityLearnMoreHow: "每位参与者的偏好从其比较中学习，然后使用 Solidago（Tournesol 项目的开源算法）汇总为社区排名。投票立即生效。",
     communityLearnMoreDiversity: "系统考虑用户信任级别，并利用意见群体信息确保多元视角的公平代表，借鉴 Plurality 框架的研究。",
     communityLearnMoreFair: "分组优先展示需要更多数据的项目，组内顺序随机化以防止位置偏差。间接比较会被推断（如果 A > B 且 B > C，则 A > C）以减少轮数。",
@@ -259,6 +267,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "匯總所有參與者的投票",
     score: "得分：{score}",
     loadingError: "載入結果失敗。",
+    retryButton: "重試",
     communityLearnMoreHow: "每位參與者的偏好從其比較中學習，然後使用 Solidago（Tournesol 項目的開源演算法）匯總為社區排名。投票立即生效。",
     communityLearnMoreDiversity: "系統考慮使用者信任級別，並利用意見群體資訊確保多元觀點的公平代表，借鑒 Plurality 框架的研究。",
     communityLearnMoreFair: "分組優先展示需要更多資料的項目，組內順序隨機化以防止位置偏差。間接比較會被推斷（如果 A > B 且 B > C，則 A > C）以減少輪數。",
@@ -290,6 +299,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "全参加者の投票を集計",
     score: "スコア：{score}",
     loadingError: "結果の読み込みに失敗しました。",
+    retryButton: "再試行",
     communityLearnMoreHow: "各参加者の好みは比較から個別に学習され、Solidago（Tournesolプロジェクトのオープンソースアルゴリズム）でコミュニティランキングに集約されます。投票は即座に反映されます。",
     communityLearnMoreDiversity: "システムはユーザーの信頼レベルを考慮し、意見グループの情報を活用して多様な視点の公正な代表を確保します（Pluralityフレームワークの研究に基づく）。",
     communityLearnMoreFair: "グループはデータが必要な項目を優先して選択され、位置バイアス防止のため順序はランダム化されます。間接比較も推論されます（A > B かつ B > C なら A > C）。",
@@ -321,6 +331,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "Бардык катышуучулардын добуштарынан топтолгон",
     score: "Упай: {score}",
     loadingError: "Натыйжаларды жүктөө ишке ашкан жок.",
+    retryButton: "Кайра аракет кылуу",
     communityLearnMoreHow: "Ар бир катышуучунун каалоолору анын салыштырууларынан үйрөнүлүп, Solidago (Tournesol долбоорунун ачык булак алгоритми) менен коомдук рейтингге бириктирилет. Добуштар дароо эсепке алынат.",
     communityLearnMoreDiversity: "Система колдонуучулардын ишеним деңгээлдерин эсепке алат жана ар түрдүү көз караштардын адилеттүү өкүлчүлүгүн камсыз кылуу үчүн пикир топторунун маалыматын колдонот (Plurality алкагынын изилдөөлөрүнө негизделген).",
     communityLearnMoreFair: "Топтор көбүрөөк маалымат керек болгон элементтерге артыкчылык берүү үчүн тандалат, позициялык калыстыксыздыкты алдын алуу үчүн кокустук тартип менен. Кыйыр салыштыруулар чыгарылат (А > Б жана Б > В болсо, анда А > В) раунддарды азайтуу үчүн.",
@@ -352,6 +363,7 @@ export const maxDiffResultsTabTranslations: Record<
     subtitle: "Агрегировано из голосов всех участников",
     score: "Оценка: {score}",
     loadingError: "Не удалось загрузить результаты.",
+    retryButton: "Попробовать ещё раз",
     communityLearnMoreHow: "Предпочтения каждого участника изучаются из его сравнений и агрегируются в общий рейтинг с помощью Solidago, алгоритма с открытым кодом от проекта Tournesol. Голоса учитываются сразу.",
     communityLearnMoreDiversity: "Система учитывает уровни доверия пользователей и использует информацию о группах мнений для справедливого представительства разных точек зрения, опираясь на исследования фреймворка Plurality.",
     communityLearnMoreFair: "Группы подбираются с приоритетом элементов, которым нужно больше данных, с рандомизированным порядком для предотвращения позиционного смещения. Косвенные сравнения выводятся автоматически (если А > Б и Б > В, то А > В) для минимизации раундов.",

--- a/services/agora/src/components/post/maxdiff/MaxDiffResultsTab.vue
+++ b/services/agora/src/components/post/maxdiff/MaxDiffResultsTab.vue
@@ -13,9 +13,12 @@
     <PageLoadingSpinner v-if="isInitialLoading" />
 
     <!-- Error -->
-    <div v-else-if="hasError" class="info-message">
-      {{ t("loadingError") }}
-    </div>
+    <ErrorRetryBlock
+      v-else-if="hasError"
+      :title="t('loadingError')"
+      :retry-label="t('retryButton')"
+      @retry="retryFetchResults"
+    />
 
     <template v-else>
       <!-- Me section (above community ranking in Summary) -->
@@ -155,6 +158,7 @@
 
 <script setup lang="ts">
 import ShortcutBar from "src/components/post/analysis/shortcutBar/ShortcutBar.vue";
+import ErrorRetryBlock from "src/components/ui/ErrorRetryBlock.vue";
 import PageLoadingSpinner from "src/components/ui/PageLoadingSpinner.vue";
 import ZKBottomDialogContainer from "src/components/ui-library/ZKBottomDialogContainer.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
@@ -371,6 +375,10 @@ async function fetchLifecycleItems({
   }
 }
 
+function retryFetchResults(): void {
+  void fetchResults({ showLoading: true });
+}
+
 async function fetchResults({ showLoading }: { showLoading: boolean }): Promise<void> {
   if (showLoading) {
     isInitialLoading.value = true;
@@ -472,13 +480,6 @@ watch(currentTab, async (newTab, oldTab) => {
 .tabComponent {
   border-radius: 12px;
   padding: 0.5rem;
-}
-
-.info-message {
-  text-align: center;
-  color: $color-text-weak;
-  padding: 2rem 1rem;
-  font-size: 0.95rem;
 }
 
 .learn-more-title {

--- a/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.vue
+++ b/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.vue
@@ -12,7 +12,7 @@
       @retry="retryInitialize"
     />
 
-    <!-- Initialization error (e.g. route buffer fetch failed) -->
+    <!-- Initialization error (e.g. candidate set fetch failed) -->
     <ErrorRetryBlock
       v-else-if="initError"
       :title="t('loadingError')"
@@ -117,36 +117,41 @@
         />
       </div>
 
-      <div class="candidates-grid" :class="{ 'candidates-transitioning': isTransitioning }">
-        <button
-          v-for="slugId in candidates"
-          :key="slugId"
-          class="candidate-card"
-          :class="{
-            'selected-best': selectedBest === slugId,
-            'selected-worst': selectedWorst === slugId,
-          }"
-          @click="handleCandidateClick(slugId)"
-        >
-          <div :ref="(el) => setContentRef(slugId, el)" class="candidate-content-wrapper">
-            <ZKHtmlContent
-              :html-body="itemContentMap.get(slugId) ?? slugId"
-              :compact-mode="false"
-              :enable-links="false"
-            />
-            <span v-if="itemBySlugId.get(slugId)?.body" class="candidate-body-inline">
-              — {{ stripHtml(itemBySlugId.get(slugId)?.body ?? "") }}
-            </span>
-          </div>
-          <div class="candidate-label">
-            <span v-if="selectedBest === slugId" class="label-best">
-              {{ t("mostImportant") }}
-            </span>
-            <span v-else-if="selectedWorst === slugId" class="label-worst">
-              {{ t("leastImportant") }}
-            </span>
-          </div>
-        </button>
+      <div class="candidates-grid-wrapper">
+        <div class="candidates-grid" :class="{ 'candidates-transitioning': isTransitioning }">
+          <button
+            v-for="slugId in candidates"
+            :key="slugId"
+            class="candidate-card"
+            :class="{
+              'selected-best': selectedBest === slugId,
+              'selected-worst': selectedWorst === slugId,
+            }"
+            @click="handleCandidateClick(slugId)"
+          >
+            <div :ref="(el) => setContentRef(slugId, el)" class="candidate-content-wrapper">
+              <ZKHtmlContent
+                :html-body="itemContentMap.get(slugId) ?? slugId"
+                :compact-mode="false"
+                :enable-links="false"
+              />
+              <span v-if="itemBySlugId.get(slugId)?.body" class="candidate-body-inline">
+                — {{ stripHtml(itemBySlugId.get(slugId)?.body ?? "") }}
+              </span>
+            </div>
+            <div class="candidate-label">
+              <span v-if="selectedBest === slugId" class="label-best">
+                {{ t("mostImportant") }}
+              </span>
+              <span v-else-if="selectedWorst === slugId" class="label-worst">
+                {{ t("leastImportant") }}
+              </span>
+            </div>
+          </button>
+        </div>
+        <div v-if="showTransitionSpinner" class="transition-spinner-overlay">
+          <q-spinner-dots color="primary" size="2.5rem" />
+        </div>
       </div>
     </div>
 
@@ -361,11 +366,7 @@ const saveMutation = useMaxDiffSaveMutation({
     isComplete.value = context.previousIsComplete;
     finalRanking.value = context.previousFinalRanking;
     candidates.value = context.previousCandidates;
-    candidateBuffer.value = context.previousCandidateBuffer;
-    if (transitionTimeout !== null) {
-      clearTimeout(transitionTimeout);
-      isTransitioning.value = false;
-    }
+    cancelTransition();
     consumeUndoEntry();
     showNotifyMessage({ message: t("savingError"), force: true });
   },
@@ -386,17 +387,30 @@ const candidates = ref<string[]>([]);
 const selectedBest = ref<string | null>(null);
 const selectedWorst = ref<string | null>(null);
 const isTransitioning = ref(false);
+const showTransitionSpinner = ref(false);
 let transitionTimeout: ReturnType<typeof setTimeout> | null = null;
+let transitionSpinnerTimeout: ReturnType<typeof setTimeout> | null = null;
+
+function clearTransitionSpinner(): void {
+  if (transitionSpinnerTimeout !== null) {
+    clearTimeout(transitionSpinnerTimeout);
+    transitionSpinnerTimeout = null;
+  }
+  showTransitionSpinner.value = false;
+}
+
+function cancelTransition(): void {
+  if (transitionTimeout !== null) {
+    clearTimeout(transitionTimeout);
+    transitionTimeout = null;
+  }
+  clearTransitionSpinner();
+  isTransitioning.value = false;
+}
 
 onBeforeUnmount(() => {
-  if (transitionTimeout !== null) clearTimeout(transitionTimeout);
+  cancelTransition();
 });
-
-// Prefetch buffer: server-generated candidate sets for instant display
-const candidateBuffer = ref<string[][]>([]);
-const BUFFER_REFILL_THRESHOLD = 1;
-const BUFFER_MAX_SIZE = 8;
-let isRefilling = false;
 
 // Statement dialog state
 const showStatementDialog = ref(false);
@@ -522,20 +536,16 @@ watch(
       finalRanking.value = [];
     }
 
-    // Fetch initial route buffer
-    await fetchRouteBuffer({
-      comparisons: instance.value.exportState().comparisons,
-      initialLoad: true,
-    });
-
-    if (candidateBuffer.value.length === 0 && !instance.value.complete) {
+    // Fetch initial candidate set
+    const initialResult = await fetchNextCandidateSet();
+    if (!("candidates" in initialResult) && !instance.value.complete) {
       initError.value = true;
       isInitializingEngine.value = false;
       engineInitialized.value = true;
       return;
     }
 
-    await updateCandidates();
+    candidates.value = "candidates" in initialResult ? initialResult.candidates : [];
     isInitializingEngine.value = false;
     engineInitialized.value = true;
   },
@@ -555,91 +565,35 @@ function retryInitialize(): void {
   void loadQuery.refetch();
 }
 
+async function fetchNextCandidateSet(): Promise<{ candidates: string[] } | { error: "network" } | { error: "empty" }> {
+  const comparisons = instance.value?.exportState().comparisons ?? [];
+  const response = await fetchMaxDiffRoute({
+    conversationSlugId: conversationSlugId.value,
+    comparisons,
+    bufferSize: 1,
+  });
+  if (response.status === "success" && response.data.candidateSets.length > 0) {
+    return { candidates: response.data.candidateSets[0] };
+  }
+  if (response.status === "success") {
+    return { error: "empty" };
+  }
+  return { error: "network" };
+}
+
 async function updateCandidates(): Promise<void> {
   if (!instance.value || instance.value.complete) {
     candidates.value = [];
     return;
   }
-  const validSet = consumeValidBufferedSet();
-  if (validSet !== undefined) {
-    candidates.value = validSet;
+  const result = await fetchNextCandidateSet();
+  if ("candidates" in result) {
+    candidates.value = result.candidates;
+  } else if (result.error === "network") {
+    showNotifyMessage({ message: t("loadingError"), force: true });
   } else {
-    // Buffer empty — fetch fresh sets with loading state
-    isInitializingEngine.value = true;
-    await fetchRouteBuffer({
-      comparisons: instance.value.exportState().comparisons,
-      initialLoad: false,
-    });
-    const fresh = consumeValidBufferedSet();
-    if (fresh !== undefined) {
-      candidates.value = fresh;
-    } else {
-      // No candidates available — voting is likely complete
-      isComplete.value = true;
-      candidates.value = [];
-    }
-    isInitializingEngine.value = false;
-    return;
-  }
-
-  // Refill buffer when running low (non-blocking)
-  if (
-    candidateBuffer.value.length <= BUFFER_REFILL_THRESHOLD &&
-    !isRefilling &&
-    instance.value !== null
-  ) {
-    void fetchRouteBuffer({
-      comparisons: instance.value.exportState().comparisons,
-      initialLoad: false,
-    });
-  }
-}
-
-/** Consume the next buffered set, skipping stale ones (items no longer active). */
-function consumeValidBufferedSet(): string[] | undefined {
-  const activeSlugIds = new Set(itemList.value.map((item) => item.slugId));
-  while (candidateBuffer.value.length > 0) {
-    const set = candidateBuffer.value.shift();
-    if (set === undefined) continue;
-    // Validate all items in the set still exist
-    if (set.length >= 2 && set.every((id) => activeSlugIds.has(id))) {
-      return set;
-    }
-    // Stale set — discard and try next
-  }
-  return undefined;
-}
-
-async function fetchRouteBuffer({
-  comparisons,
-  initialLoad,
-}: {
-  comparisons: MaxDiffComparison[];
-  initialLoad: boolean;
-}): Promise<void> {
-  if (isRefilling && !initialLoad) return; // Prevent concurrent refills
-  isRefilling = true;
-  try {
-    const currentBufferSize = candidateBuffer.value.length;
-    const requestSize = Math.min(
-      initialLoad ? 5 : 3,
-      BUFFER_MAX_SIZE - currentBufferSize,
-    );
-    if (requestSize <= 0) return;
-
-    const response = await fetchMaxDiffRoute({
-      conversationSlugId: conversationSlugId.value,
-      comparisons,
-      bufferSize: requestSize,
-    });
-    if (response.status === "success") {
-      // Respect cap
-      const spaceLeft = BUFFER_MAX_SIZE - candidateBuffer.value.length;
-      const toAdd = response.data.candidateSets.slice(0, spaceLeft);
-      candidateBuffer.value.push(...toAdd);
-    }
-  } finally {
-    isRefilling = false;
+    isComplete.value = true;
+    candidates.value = [];
   }
 }
 
@@ -699,7 +653,6 @@ function recordVote(): void {
     previousIsComplete: isComplete.value,
     previousFinalRanking: [...finalRanking.value],
     previousCandidates: [...candidates.value],
-    previousCandidateBuffer: [...candidateBuffer.value],
     isFirstVote: previousState.comparisons.length === 0,
   };
 
@@ -725,10 +678,16 @@ function recordVote(): void {
   selectedWorst.value = null;
   isTransitioning.value = true;
 
+  // Show spinner if fetch takes longer than 2s
+  clearTransitionSpinner();
+  transitionSpinnerTimeout = setTimeout(() => {
+    showTransitionSpinner.value = true;
+  }, 2000);
+
   transitionTimeout = setTimeout(() => {
     void (async () => {
       await updateCandidates();
-      isTransitioning.value = false;
+      cancelTransition();
     })();
   }, 400);
 
@@ -747,13 +706,15 @@ function undoLastVote(): void {
   const state = instance.value.exportState();
   if (state.comparisons.length === 0) return;
 
+  // Cancel any in-flight transition from the vote being undone
+  cancelTransition();
+
   // Snapshot for rollback (undo should be reversible on save failure)
   const context: MaxDiffSaveContext = {
     previousState: state,
     previousIsComplete: isComplete.value,
     previousFinalRanking: [...finalRanking.value],
     previousCandidates: [...candidates.value],
-    previousCandidateBuffer: [...candidateBuffer.value],
     isFirstVote: false,
   };
 
@@ -774,13 +735,6 @@ function undoLastVote(): void {
   selectedWorst.value = null;
 
   candidates.value = removedComparison.set;
-
-  // Clear stale buffer (comparison state changed) and refill
-  candidateBuffer.value = [];
-  void fetchRouteBuffer({
-    comparisons: restored.exportState().comparisons,
-    initialLoad: false,
-  });
 
   saveMutation.mutate({
     ranking: restored.result ?? null,
@@ -809,10 +763,10 @@ function handleRedoRanking(): void {
       previousIsComplete: isComplete.value,
       previousFinalRanking: [...finalRanking.value],
       previousCandidates: [...candidates.value],
-      previousCandidateBuffer: [...candidateBuffer.value],
       isFirstVote: false,
     };
 
+    cancelTransition();
     clearAllUndoEntries();
     const slugIds = itemList.value.map((item) => item.slugId);
     instance.value = createMaxDiff(slugIds);
@@ -856,13 +810,6 @@ function handleRedoRanking(): void {
   font-size: 1.1rem;
   font-weight: var(--font-weight-semibold);
   color: $color-text-strong;
-}
-
-.section-subheader {
-  font-size: 0.95rem;
-  font-weight: var(--font-weight-medium);
-  color: $color-text-weak;
-  margin-top: 0.5rem;
 }
 
 .step-indicator {
@@ -972,6 +919,10 @@ function handleRedoRanking(): void {
   transition: width 0.3s ease;
 }
 
+.candidates-grid-wrapper {
+  position: relative;
+}
+
 .candidates-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -982,6 +933,15 @@ function handleRedoRanking(): void {
     opacity: 0.3;
     pointer-events: none;
   }
+}
+
+.transition-spinner-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
 }
 
 .candidate-card {

--- a/services/agora/src/utils/api/maxdiff/useMaxDiffQueries.ts
+++ b/services/agora/src/utils/api/maxdiff/useMaxDiffQueries.ts
@@ -78,7 +78,6 @@ export interface MaxDiffSaveContext {
   previousIsComplete: boolean;
   previousFinalRanking: string[];
   previousCandidates: string[];
-  previousCandidateBuffer: string[][];
   isFirstVote: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Add retry button to MaxDiff results tab error state (uses `ErrorRetryBlock`, matching voting tab pattern)
- Remove pre-fetch route buffer that caused stale "worst" items to reappear; now fetches 1 fresh candidate set per vote
- Add loading spinner overlay on the faded candidates grid when fetch takes >2s
- Fix edge bugs where undo/redo during in-flight transitions could cause timer conflicts
- Clean up dead CSS (`.section-subheader`, `.info-message`)

## Test plan
- [ ] Navigate to MaxDiff analysis tab with network disconnected: verify `ErrorRetryBlock` appears with retry button
- [ ] Vote on MaxDiff set, mark an item as "worst": verify it does not reappear in the next set
- [ ] Throttle network to slow 3G, vote: verify spinner dots appear after ~2s on faded grid
- [ ] Vote then quickly undo: verify no timer conflicts or stale candidate overwrites
- [ ] Run `cd services/agora && pnpm lint:fix && pnpm test`