### PR TITLE
perf(python-bridge): switch Solidago from UniformGBT to LBFGSUniformGBT

### DIFF
--- a/services/python-bridge/main.py
+++ b/services/python-bridge/main.py
@@ -620,7 +620,7 @@ from entity_mapping import EntityIdMapper, map_pairwise_wins_to_solidago, map_sc
 
 from solidago.pipeline import Pipeline
 from solidago.trust_propagation import TrustPropagation
-from solidago.preference_learning import UniformGBT
+from solidago.preference_learning import LBFGSUniformGBT
 from solidago.voting_rights import AffineOvertrust
 from solidago.scaling import NoScaling
 from solidago.aggregation import EntitywiseQrQuantile
@@ -684,7 +684,7 @@ class RankingScoreRequest(BaseModel):
 
 
 def _warmup_solidago() -> None:
-    """Trigger Numba JIT compilation at import time with a tiny dummy dataset."""
+    """Warmup LBFGS solver with a tiny dummy dataset."""
     dummy_df = pd.DataFrame({
         "user_id": [0, 0],
         "entity_a": [0, 1],
@@ -692,9 +692,9 @@ def _warmup_solidago() -> None:
         "comparison": [1.0, 1.0],
         "comparison_max": [1.0, 1.0],
     })
-    gbt = UniformGBT(prior_std_dev=7.0, convergence_error=1e-5)
+    gbt = LBFGSUniformGBT(prior_std_dev=7.0, convergence_error=1e-5)
     gbt.comparison_learning(dummy_df)
-    logger.info("Solidago JIT warmup complete")
+    logger.info("Solidago LBFGS warmup complete")
 
 
 _warmup_solidago()
@@ -796,7 +796,7 @@ def score_conversation(payload: RankingScoreRequest) -> dict[str, object]:
     # Configure Solidago pipeline (production-tested defaults)
     pipeline = Pipeline(
         trust_propagation=IdentityTrustPropagation(),
-        preference_learning=UniformGBT(prior_std_dev=7.0, convergence_error=1e-5),
+        preference_learning=LBFGSUniformGBT(prior_std_dev=7.0, convergence_error=1e-5),
         voting_rights=AffineOvertrust(
             privacy_penalty=0.5,
             min_overtrust=2.0,

--- a/services/python-bridge/pyproject.toml
+++ b/services/python-bridge/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 	# Solidago scoring (from Tournesol project)
 	# Generalized Bradley-Terry, per-user models, aggregation pipeline
 	# https://pypi.org/project/solidago/
-	"solidago==0.5.0",
+	"solidago[torch]==0.5.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- Switch from `UniformGBT` (coordinate descent + Numba) to `LBFGSUniformGBT` (PyTorch LBFGS optimizer)
- Expected speedup: **4.2s -> ~0.7s** for MaxDiff scoring (44 entities, 273 comparisons, 5 users)
- Root cause: 90% of `UniformGBT` time is spent in uncertainty binary search (hard-coded `xtol=1e-2`, 88 searches x 20 iterations x 273 evaluations). LBFGS uses looser tolerance (`1e-1`) for uncertainty and faster optimizer for scores.
- Tournesol's own codebase has a `# TODO: use LBFGS (faster) implementation` comment
- Docker image grows ~700MB due to PyTorch dependency

## Test plan
- [ ] Build python-bridge Docker image successfully (torch installs)
- [ ] Deploy, vote on MaxDiff conversation
- [ ] Check `Pipeline 2. Terminated in X seconds` log -- should drop from ~4.2s to ~0.7s
- [ ] Verify scores are still computed (same rankings as before)
- [ ] Verify uncertainty values are present (not zeros)

Deploy: python-bridge