### PR TITLE
perf(api): async batch scoring with per-conversation dedup

### DIFF
--- a/services/api/src/service/rankingComparisonBuffer.ts
+++ b/services/api/src/service/rankingComparisonBuffer.ts
@@ -297,7 +297,7 @@ async function writeScoringResult({
             groupSourcesSnapshot: null,
             userWeightsSnapshot: null,
             pipelineConfig: {
-                preferenceLearning: "LBFGSUniformGBT",
+                preferenceLearning: "UniformGBT",
                 votingRights: "AffineOvertrust",
                 aggregation: "EntitywiseQrQuantile(quantile=0.5)",
             },

--- a/services/python-bridge/main.py
+++ b/services/python-bridge/main.py
@@ -620,7 +620,7 @@ from entity_mapping import EntityIdMapper, map_pairwise_wins_to_solidago, map_sc
 
 from solidago.pipeline import Pipeline
 from solidago.trust_propagation import TrustPropagation
-from solidago.preference_learning import LBFGSUniformGBT
+from solidago.preference_learning import UniformGBT
 from solidago.voting_rights import AffineOvertrust
 from solidago.scaling import NoScaling
 from solidago.aggregation import EntitywiseQrQuantile
@@ -684,7 +684,7 @@ class RankingScoreRequest(BaseModel):
 
 
 def _warmup_solidago() -> None:
-    """Warmup LBFGS solver with a tiny dummy dataset."""
+    """Trigger Numba JIT compilation at import time with a tiny dummy dataset."""
     dummy_df = pd.DataFrame({
         "user_id": [0, 0],
         "entity_a": [0, 1],
@@ -692,9 +692,9 @@ def _warmup_solidago() -> None:
         "comparison": [1.0, 1.0],
         "comparison_max": [1.0, 1.0],
     })
-    gbt = LBFGSUniformGBT(prior_std_dev=7.0, convergence_error=1e-5)
+    gbt = UniformGBT(prior_std_dev=7.0, convergence_error=1e-5)
     gbt.comparison_learning(dummy_df)
-    logger.info("Solidago LBFGS warmup complete")
+    logger.info("Solidago JIT warmup complete")
 
 
 _warmup_solidago()
@@ -796,7 +796,12 @@ def score_conversation(payload: RankingScoreRequest) -> dict[str, object]:
     # Configure Solidago pipeline (production-tested defaults)
     pipeline = Pipeline(
         trust_propagation=IdentityTrustPropagation(),
-        preference_learning=LBFGSUniformGBT(prior_std_dev=7.0, convergence_error=1e-5),
+        preference_learning=UniformGBT(
+            prior_std_dev=7.0,
+            convergence_error=1e-5,
+            cumulant_generating_function_error=1e-5,
+            high_likelihood_range_threshold=0.25,
+        ),
         voting_rights=AffineOvertrust(
             privacy_penalty=0.5,
             min_overtrust=2.0,

--- a/services/python-bridge/pyproject.toml
+++ b/services/python-bridge/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 	# Solidago scoring (from Tournesol project)
 	# Generalized Bradley-Terry, per-user models, aggregation pipeline
 	# https://pypi.org/project/solidago/
-	"solidago[torch]==0.5.0",
+	"solidago==0.5.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- **Separate DB writes from scoring**: Flush writes to DB + cleans Valkey in ~100ms, then fires async scoring without blocking. Previously the flush blocked for ~0.7s x N conversations.
- **Batch endpoint**: Single `POST /ranking-score-batch` instead of N sequential `POST /ranking-score` calls. Python-bridge already supports this with ThreadPoolExecutor.
- **Dedup**: `isScoringRunning` flag prevents concurrent scoring runs. `while` loop drains new entries that arrive during scoring. `activeScoringPromise` tracked for clean shutdown.
- **Revert LBFGS, use Tournesol production settings**: LBFGS (#867) sped up Phase 2 from 4.2s to 0.7s but caused Phase 5 (aggregation) to regress from 0s to 7s. Reverts to UniformGBT with `high_likelihood_range_threshold=0.25` (Tournesol's production value, was 1.0 default). Also removes PyTorch dependency.

### Edge cases analyzed
- **Votes during scoring**: Written to DB by next flush, conversation re-added to `pendingScoring`, re-scored after current run completes (~0.7s stale window)
- **Scoring errors**: Logged, non-fatal. Conversation re-scored on next vote.
- **Shutdown**: Awaits `activeScoringPromise` after final flush.
- **No transactions**: Same as original. DB upserts are idempotent. Counter staleness self-corrects.

### Review fixes (from self-review)
- Removed dead `scoringInProgress` Set (`isScoringRunning` already prevents concurrent runs)
- Fixed `scoringPromise` overwrite bug: second flush would overwrite with resolved promise, making shutdown skip in-flight scoring. Now uses `activeScoringPromise ??=` pattern.

## Test plan
- [ ] `cd services/api && pnpm lint` passes
- [ ] Deploy, submit votes across multiple MaxDiff conversations
- [ ] Check logs: flush completes in ~100ms (`[RankingBuffer] Flushed...`)
- [ ] Check logs: batch scoring fires (`[RankingBuffer] Batch scoring N conversation(s)`)
- [ ] Check logs: `Pipeline 2. Terminated in X seconds` -- should improve from 4.2s with `high_likelihood_range_threshold=0.25`
- [ ] Check logs: `Pipeline 5. Terminated in X seconds` -- should stay ~0s (no LBFGS regression)
- [ ] Scores appear in Results tab (may have ~1s delay)
- [ ] No duplicate scoring logs for same conversation
- [ ] Docker image smaller (no PyTorch)

Deploy: api, python-bridge