### PR TITLE
perf(python-bridge): relax aggregation error from 1e-5 to 1e-3

### DIFF
--- a/services/python-bridge/main.py
+++ b/services/python-bridge/main.py
@@ -620,7 +620,7 @@ from entity_mapping import EntityIdMapper, map_pairwise_wins_to_solidago, map_sc
 
 from solidago.pipeline import Pipeline
 from solidago.trust_propagation import TrustPropagation
-from solidago.preference_learning import UniformGBT
+from solidago.preference_learning import LBFGSUniformGBT
 from solidago.voting_rights import AffineOvertrust
 from solidago.scaling import NoScaling
 from solidago.aggregation import EntitywiseQrQuantile
@@ -684,7 +684,7 @@ class RankingScoreRequest(BaseModel):
 
 
 def _warmup_solidago() -> None:
-    """Trigger Numba JIT compilation at import time with a tiny dummy dataset."""
+    """Warmup LBFGS solver with a tiny dummy dataset."""
     dummy_df = pd.DataFrame({
         "user_id": [0, 0],
         "entity_a": [0, 1],
@@ -692,9 +692,9 @@ def _warmup_solidago() -> None:
         "comparison": [1.0, 1.0],
         "comparison_max": [1.0, 1.0],
     })
-    gbt = UniformGBT(prior_std_dev=7.0, convergence_error=1e-5)
+    gbt = LBFGSUniformGBT(prior_std_dev=7.0, convergence_error=1e-5)
     gbt.comparison_learning(dummy_df)
-    logger.info("Solidago JIT warmup complete")
+    logger.info("Solidago LBFGS warmup complete")
 
 
 _warmup_solidago()
@@ -796,11 +796,9 @@ def score_conversation(payload: RankingScoreRequest) -> dict[str, object]:
     # Configure Solidago pipeline (production-tested defaults)
     pipeline = Pipeline(
         trust_propagation=IdentityTrustPropagation(),
-        preference_learning=UniformGBT(
+        preference_learning=LBFGSUniformGBT(
             prior_std_dev=7.0,
             convergence_error=1e-5,
-            cumulant_generating_function_error=1e-5,
-            high_likelihood_range_threshold=0.25,
         ),
         voting_rights=AffineOvertrust(
             privacy_penalty=0.5,

--- a/services/python-bridge/pyproject.toml
+++ b/services/python-bridge/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 	# Solidago scoring (from Tournesol project)
 	# Generalized Bradley-Terry, per-user models, aggregation pipeline
 	# https://pypi.org/project/solidago/
-	"solidago==0.5.0",
+	"solidago[torch]==0.5.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- LBFGS (#867) produces wider uncertainty bounds, causing `EntitywiseQrQuantile`'s brentq root-finding to converge very slowly at `1e-5` tolerance (Phase 5: 0s -> 7s)
- Relax aggregation `error` from `1e-5` to `1e-3` -- more than sufficient since scores are normalized to [0,1]
- Preserves real uncertainty computation for correct per-user weighting at scale

## Test plan
- [ ] Deploy, vote on MaxDiff
- [ ] `Pipeline 2` stays ~0.7s (LBFGS)
- [ ] `Pipeline 5` drops from 7s to ~0s
- [ ] Rankings correct in Results tab

Deploy: python-bridge