### PR TITLE
fix(api): qualify maxdiff dedupe migration

### DIFF
--- a/services/api/database/flyway/V0053.1__dedup_active_maxdiff_comparisons.sql
+++ b/services/api/database/flyway/V0053.1__dedup_active_maxdiff_comparisons.sql
@@ -14,7 +14,7 @@ WITH duplicate_active_comparisons AS (
     FROM duplicate_active_comparisons
     WHERE maxdiff_comparison.id = duplicate_active_comparisons.id
       AND duplicate_active_comparisons.row_number > 1
-    RETURNING maxdiff_result_id
+    RETURNING maxdiff_comparison.maxdiff_result_id AS maxdiff_result_id
 ), touched_results AS (
     UPDATE maxdiff_result
     SET updated_at = NOW()::timestamp(0)


### PR DESCRIPTION
## Summary
- qualify the `maxdiff_result_id` returned from the `V0053.1__dedup_active_maxdiff_comparisons.sql` update CTE
- fix Flyway application of the pre-index MaxDiff dedupe migration after the legacy ranking repair merged to `main`

## Testing
- not run (SQL-only migration fix)