### PR TITLE
fix(api): keep optional survey answers valid

### DIFF
--- a/services/api/src/service/survey.test.ts
+++ b/services/api/src/service/survey.test.ts
@@ -163,6 +163,38 @@ describe("deriveSurveyRouteResolution", () => {
     });
 });
 
+describe("deriveSurveyQuestionFormItem", () => {
+    it("does not require updates for optional answers after semantic changes", async () => {
+        const { deriveSurveyQuestionFormItem } = await surveyModulePromise;
+        const optionalQuestion = {
+            ...createFreeTextQuestion({
+                id: 1,
+                slugId: "optional-question",
+                isRequired: false,
+                displayOrder: 0,
+            }),
+            currentSemanticVersion: 2,
+        };
+
+        const formItem = deriveSurveyQuestionFormItem({
+            question: optionalQuestion,
+            storedAnswer: {
+                answerId: 10,
+                answeredQuestionSemanticVersion: 1,
+                textValueHtml: "Saved answer",
+                optionSlugIds: [],
+            },
+        });
+
+        expect(formItem.isStale).toBe(false);
+        expect(formItem.isCurrentAnswerValid).toBe(true);
+        expect(formItem.currentAnswer).toEqual({
+            questionType: "free_text",
+            textValueHtml: "Saved answer",
+        });
+    });
+});
+
 describe("saveSurveyAnswer", () => {
     beforeEach(() => {
         checkConversationParticipationMock.mockReset();

--- a/services/api/src/service/survey.ts
+++ b/services/api/src/service/survey.ts
@@ -575,6 +575,7 @@ export function deriveSurveyQuestionFormItem({
         storedAnswer !== undefined &&
         isStoredSurveyAnswerPassed({ question, storedAnswer });
     const isStale =
+        question.isRequired &&
         storedAnswer !== undefined &&
         !isPassed &&
         candidateAnswer !== undefined &&
@@ -1712,13 +1713,13 @@ async function replaceSurveyConfigById({
             if (question.isRequired) {
                 didSemanticChange = true;
             }
-                await insertSurveyQuestion({
-                    db,
-                    surveyConfigId,
-                    conversationId: surveyConfigRow.conversationId,
-                    question,
-                    now,
-                });
+            await insertSurveyQuestion({
+                db,
+                surveyConfigId,
+                conversationId: surveyConfigRow.conversationId,
+                question,
+                now,
+            });
             continue;
         }
 
@@ -1748,13 +1749,19 @@ async function replaceSurveyConfigById({
         });
         if (
             existingQuestion.questionType !== question.questionType ||
-            existingQuestion.isRequired !== question.isRequired ||
             constraintsChanged
         ) {
             semanticChanged = true;
             if (questionAffectsEligibility) {
                 didSemanticChange = true;
             }
+        }
+
+        if (
+            existingQuestion.isRequired !== question.isRequired &&
+            questionAffectsEligibility
+        ) {
+            didSemanticChange = true;
         }
 
         const questionTextChanged =

--- a/services/api/src/service/surveyAnalysis.test.ts
+++ b/services/api/src/service/surveyAnalysis.test.ts
@@ -173,6 +173,31 @@ describe("deriveSurveyGateStatusForAnalysis", () => {
             }),
         ).toBe("complete_valid");
     });
+
+    it("does not require updates for stale optional answers", () => {
+        expect(
+            deriveSurveyGateStatusForAnalysis({
+                hasSurvey: true,
+                questions: [
+                    {
+                        ...optionalChoiceQuestion,
+                        currentSemanticVersion: 2,
+                    },
+                ],
+                answersByQuestionId: new Map([
+                    [
+                        optionalChoiceQuestion.questionId,
+                        {
+                            answeredQuestionSemanticVersion: 1,
+                            textValueHtml: null,
+                            optionSlugIds: ["a"],
+                        },
+                    ],
+                ]),
+                withdrawnAt: null,
+            }),
+        ).toBe("complete_valid");
+    });
 });
 
 describe("analysis eligibility helpers", () => {

--- a/services/api/src/shared-backend/surveyAnalysis.ts
+++ b/services/api/src/shared-backend/surveyAnalysis.ts
@@ -99,7 +99,9 @@ export function isSurveyQuestionCompletedForAnalysis({
 
     return (
         isSurveyAnswerPassedForAnalysis({ question, answer }) ||
-        validateSurveyAnswerForAnalysis({ question, answer })
+        (question.isRequired
+            ? validateSurveyAnswerForAnalysis({ question, answer })
+            : validateSurveyAnswerContentForAnalysis({ question, answer }))
     );
 }
 
@@ -130,6 +132,16 @@ export function validateSurveyAnswerForAnalysis({
         return false;
     }
 
+    return validateSurveyAnswerContentForAnalysis({ question, answer });
+}
+
+function validateSurveyAnswerContentForAnalysis({
+    question,
+    answer,
+}: {
+    question: SurveyQuestionAnalysisRecord;
+    answer: SurveyStoredAnswerAnalysisRecord;
+}): boolean {
     switch (question.questionType) {
         case "free_text": {
             if (question.constraints.type !== "free_text") {

--- a/services/math-updater/src/shared-backend/surveyAnalysis.ts
+++ b/services/math-updater/src/shared-backend/surveyAnalysis.ts
@@ -99,7 +99,9 @@ export function isSurveyQuestionCompletedForAnalysis({
 
     return (
         isSurveyAnswerPassedForAnalysis({ question, answer }) ||
-        validateSurveyAnswerForAnalysis({ question, answer })
+        (question.isRequired
+            ? validateSurveyAnswerForAnalysis({ question, answer })
+            : validateSurveyAnswerContentForAnalysis({ question, answer }))
     );
 }
 
@@ -130,6 +132,16 @@ export function validateSurveyAnswerForAnalysis({
         return false;
     }
 
+    return validateSurveyAnswerContentForAnalysis({ question, answer });
+}
+
+function validateSurveyAnswerContentForAnalysis({
+    question,
+    answer,
+}: {
+    question: SurveyQuestionAnalysisRecord;
+    answer: SurveyStoredAnswerAnalysisRecord;
+}): boolean {
     switch (question.questionType) {
         case "free_text": {
             if (question.constraints.type !== "free_text") {

--- a/services/shared-backend/src/surveyAnalysis.ts
+++ b/services/shared-backend/src/surveyAnalysis.ts
@@ -98,7 +98,9 @@ export function isSurveyQuestionCompletedForAnalysis({
 
     return (
         isSurveyAnswerPassedForAnalysis({ question, answer }) ||
-        validateSurveyAnswerForAnalysis({ question, answer })
+        (question.isRequired
+            ? validateSurveyAnswerForAnalysis({ question, answer })
+            : validateSurveyAnswerContentForAnalysis({ question, answer }))
     );
 }
 
@@ -129,6 +131,16 @@ export function validateSurveyAnswerForAnalysis({
         return false;
     }
 
+    return validateSurveyAnswerContentForAnalysis({ question, answer });
+}
+
+function validateSurveyAnswerContentForAnalysis({
+    question,
+    answer,
+}: {
+    question: SurveyQuestionAnalysisRecord;
+    answer: SurveyStoredAnswerAnalysisRecord;
+}): boolean {
     switch (question.questionType) {
         case "free_text": {
             if (question.constraints.type !== "free_text") {


### PR DESCRIPTION
## Summary
- Keep optional survey answers valid after semantic question changes instead of forcing users to update them.
- Preserve stale-answer handling for required questions that affect survey eligibility.
- Add regression tests for survey form state and analysis status.

## Tests
- pnpm vitest src/service/survey.test.ts src/service/surveyAnalysis.test.ts
- pnpm exec eslint src/service/survey.ts src/service/survey.test.ts src/service/surveyAnalysis.test.ts src/shared-backend/surveyAnalysis.ts
- pnpm exec eslint src/shared-backend/surveyAnalysis.ts (math-updater)

Deploy: api, math-updater