### PR TITLE
feat(survey): support optional surveys

### DIFF
--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -718,6 +718,7 @@ export const ApiV1ConversationCreatePostRequestExternalSourceConfigSourceTypeEnu
 export type ApiV1ConversationCreatePostRequestExternalSourceConfigSourceTypeEnum = typeof ApiV1ConversationCreatePostRequestExternalSourceConfigSourceTypeEnum[keyof typeof ApiV1ConversationCreatePostRequestExternalSourceConfigSourceTypeEnum];
 
 export interface ApiV1ConversationCreatePostRequestSurveyConfig {
+    'isOptional'?: boolean;
     'questions': Array<ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner>;
 }
 /**
@@ -1101,6 +1102,7 @@ export interface ApiV1ConversationFetchRecentPost200ResponseConversationDataList
 }
 export interface ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGate {
     'hasSurvey': boolean;
+    'isOptional': boolean;
     'canParticipate': boolean;
     'status': ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGateStatusEnum;
 }
@@ -1303,6 +1305,7 @@ export const ApiV1ConversationGetForEditPost200ResponseOneOf1ReasonEnum = {
 export type ApiV1ConversationGetForEditPost200ResponseOneOf1ReasonEnum = typeof ApiV1ConversationGetForEditPost200ResponseOneOf1ReasonEnum[keyof typeof ApiV1ConversationGetForEditPost200ResponseOneOf1ReasonEnum];
 
 export interface ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig {
+    'isOptional': boolean;
     'questions': Array<ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfigQuestionsInner>;
 }
 /**
@@ -2190,6 +2193,7 @@ export interface ApiV1SurveyConfigUpdatePostRequest {
     'surveyConfig': ApiV1SurveyConfigUpdatePostRequestSurveyConfig;
 }
 export interface ApiV1SurveyConfigUpdatePostRequestSurveyConfig {
+    'isOptional'?: boolean;
     'questions': Array<ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner>;
 }
 export interface ApiV1SurveyFormFetchPost200Response {

--- a/services/agora/src/api/docs/ApiV1ConversationCreatePostRequestSurveyConfig.md
+++ b/services/agora/src/api/docs/ApiV1ConversationCreatePostRequestSurveyConfig.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**isOptional** | **boolean** |  | [optional] [default to false]
 **questions** | [**Array&lt;ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner&gt;**](ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner.md) |  | [default to undefined]
 
 ## Example
@@ -13,6 +14,7 @@ Name | Type | Description | Notes
 import { ApiV1ConversationCreatePostRequestSurveyConfig } from './api';
 
 const instance: ApiV1ConversationCreatePostRequestSurveyConfig = {
+    isOptional,
     questions,
 };
 ```

--- a/services/agora/src/api/docs/ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGate.md
+++ b/services/agora/src/api/docs/ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGate.md
@@ -6,6 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **hasSurvey** | **boolean** |  | [default to undefined]
+**isOptional** | **boolean** |  | [default to undefined]
 **canParticipate** | **boolean** |  | [default to undefined]
 **status** | **string** |  | [default to undefined]
 
@@ -16,6 +17,7 @@ import { ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInt
 
 const instance: ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGate = {
     hasSurvey,
+    isOptional,
     canParticipate,
     status,
 };

--- a/services/agora/src/api/docs/ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig.md
+++ b/services/agora/src/api/docs/ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**isOptional** | **boolean** |  | [default to false]
 **questions** | [**Array&lt;ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfigQuestionsInner&gt;**](ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfigQuestionsInner.md) |  | [default to undefined]
 
 ## Example
@@ -13,6 +14,7 @@ Name | Type | Description | Notes
 import { ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig } from './api';
 
 const instance: ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig = {
+    isOptional,
     questions,
 };
 ```

--- a/services/agora/src/api/docs/ApiV1SurveyConfigUpdatePostRequestSurveyConfig.md
+++ b/services/agora/src/api/docs/ApiV1SurveyConfigUpdatePostRequestSurveyConfig.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**isOptional** | **boolean** |  | [optional] [default to false]
 **questions** | [**Array&lt;ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner&gt;**](ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner.md) |  | [default to undefined]
 
 ## Example
@@ -13,6 +14,7 @@ Name | Type | Description | Notes
 import { ApiV1SurveyConfigUpdatePostRequestSurveyConfig } from './api';
 
 const instance: ApiV1SurveyConfigUpdatePostRequestSurveyConfig = {
+    isOptional,
     questions,
 };
 ```

--- a/services/agora/src/components/post/ConversationRequirementBanner.vue
+++ b/services/agora/src/components/post/ConversationRequirementBanner.vue
@@ -161,6 +161,7 @@ const buttonColor = computed<"warning" | "primary" | "positive">(() => {
 const bannerCopy = computed(() => {
   return resolveRequirementBannerCopy({
     hasSurvey: hasSurvey.value,
+    isOptional: props.surveyGate.isOptional,
     needsAuth: needsAuth.value,
     needsTicket: needsTicket.value,
     surveyGateStatus: props.surveyGate.status,

--- a/services/agora/src/components/post/ConversationRequirementBanner.vue
+++ b/services/agora/src/components/post/ConversationRequirementBanner.vue
@@ -70,12 +70,16 @@ const {
 
 const isNavigating = ref(false);
 
-const hasSurvey = computed(() => props.surveyGate.hasSurvey);
-
-useSurveyStatusQuery({
+const surveyStatusQuery = useSurveyStatusQuery({
   conversationSlugId: computed(() => props.conversationSlugId),
-  enabled: computed(() => isAuthInitialized.value && hasSurvey.value),
+  enabled: computed(() => isAuthInitialized.value && props.surveyGate.hasSurvey),
 });
+
+const effectiveSurveyGate = computed(() => {
+  return surveyStatusQuery.data.value?.surveyGate ?? props.surveyGate;
+});
+
+const hasSurvey = computed(() => effectiveSurveyGate.value.hasSurvey);
 
 useSurveyFormQuery({
   conversationSlugId: computed(() => props.conversationSlugId),
@@ -105,13 +109,13 @@ const bannerClass = computed(() => {
     return "survey-banner--required";
   }
 
-  const status = props.surveyGate.status;
+  const status = effectiveSurveyGate.value.status;
   if (status === "complete_valid") {
     return "survey-banner--complete";
   }
 
   if (status === "in_progress" || status === "not_started") {
-    return props.surveyGate.canParticipate
+    return effectiveSurveyGate.value.canParticipate
       ? "survey-banner--progress"
       : "survey-banner--required";
   }
@@ -130,7 +134,7 @@ const bannerIcon = computed(() => {
     return "verified_user";
   }
 
-  switch (props.surveyGate.status) {
+  switch (effectiveSurveyGate.value.status) {
     case "complete_valid":
       return "check_circle";
     case "needs_update":
@@ -161,11 +165,11 @@ const buttonColor = computed<"warning" | "primary" | "positive">(() => {
 const bannerCopy = computed(() => {
   return resolveRequirementBannerCopy({
     hasSurvey: hasSurvey.value,
-    isOptional: props.surveyGate.isOptional,
+    isOptional: effectiveSurveyGate.value.isOptional,
     needsAuth: needsAuth.value,
     needsTicket: needsTicket.value,
-    surveyGateStatus: props.surveyGate.status,
-    canParticipate: props.surveyGate.canParticipate,
+    surveyGateStatus: effectiveSurveyGate.value.status,
+    canParticipate: effectiveSurveyGate.value.canParticipate,
   });
 });
 

--- a/services/agora/src/components/post/conversationRequirementBannerLogic.test.ts
+++ b/services/agora/src/components/post/conversationRequirementBannerLogic.test.ts
@@ -7,6 +7,7 @@ describe("resolveRequirementBannerCopy", () => {
     expect(
       resolveRequirementBannerCopy({
         hasSurvey: true,
+        isOptional: false,
         needsAuth: false,
         needsTicket: true,
         surveyGateStatus: "not_started",
@@ -23,6 +24,7 @@ describe("resolveRequirementBannerCopy", () => {
     expect(
       resolveRequirementBannerCopy({
         hasSurvey: true,
+        isOptional: false,
         needsAuth: true,
         needsTicket: false,
         surveyGateStatus: "not_started",
@@ -39,6 +41,7 @@ describe("resolveRequirementBannerCopy", () => {
     expect(
       resolveRequirementBannerCopy({
         hasSurvey: true,
+        isOptional: false,
         needsAuth: true,
         needsTicket: true,
         surveyGateStatus: "not_started",
@@ -48,6 +51,36 @@ describe("resolveRequirementBannerCopy", () => {
       titleKey: "requiredAccessTitle",
       messageKey: "requiredAccessMessage",
       buttonKey: "continueLabel",
+    });
+  });
+
+  it("uses optional survey copy only for survey-level optional surveys", () => {
+    expect(
+      resolveRequirementBannerCopy({
+        hasSurvey: true,
+        isOptional: true,
+        needsAuth: false,
+        needsTicket: false,
+        surveyGateStatus: "not_started",
+        canParticipate: true,
+      })
+    ).toMatchObject({
+      titleKey: "optionalSurveyTitle",
+      messageKey: "optionalSurveyMessage",
+    });
+
+    expect(
+      resolveRequirementBannerCopy({
+        hasSurvey: true,
+        isOptional: false,
+        needsAuth: false,
+        needsTicket: false,
+        surveyGateStatus: "not_started",
+        canParticipate: true,
+      })
+    ).toMatchObject({
+      titleKey: "surveyAvailableTitle",
+      messageKey: "openViaOnboardingMessage",
     });
   });
 });

--- a/services/agora/src/components/post/conversationRequirementBannerLogic.ts
+++ b/services/agora/src/components/post/conversationRequirementBannerLogic.ts
@@ -4,6 +4,7 @@ import type { ConversationRequirementBannerTranslations } from "./ConversationRe
 
 export interface RequirementBannerCopyState {
   hasSurvey: boolean;
+  isOptional: boolean;
   needsAuth: boolean;
   needsTicket: boolean;
   surveyGateStatus: SurveyGateStatus;
@@ -18,6 +19,7 @@ export interface RequirementBannerCopyKeys {
 
 export function resolveRequirementBannerCopy({
   hasSurvey,
+  isOptional,
   needsAuth,
   needsTicket,
   surveyGateStatus,
@@ -52,9 +54,17 @@ export function resolveRequirementBannerCopy({
 
   if (surveyGateStatus === "not_started") {
     return {
-      titleKey: canParticipate ? "optionalSurveyTitle" : "requiredSurveyTitle",
-      messageKey: canParticipate ? "optionalSurveyMessage" : "requiredSurveyMessage",
-      buttonKey: canParticipate ? "openSurveyLabel" : "startSurveyLabel",
+      titleKey: isOptional
+        ? "optionalSurveyTitle"
+        : canParticipate
+          ? "surveyAvailableTitle"
+          : "requiredSurveyTitle",
+      messageKey: isOptional
+        ? "optionalSurveyMessage"
+        : canParticipate
+          ? "openViaOnboardingMessage"
+          : "requiredSurveyMessage",
+      buttonKey: isOptional || canParticipate ? "openSurveyLabel" : "startSurveyLabel",
     };
   }
 

--- a/services/agora/src/components/post/display/PostContent.vue
+++ b/services/agora/src/components/post/display/PostContent.vue
@@ -40,6 +40,7 @@
           :survey-gate="
             extendedPostData.interaction.surveyGate ?? {
               hasSurvey: false,
+              isOptional: false,
               canParticipate: true,
               status: 'no_survey',
             }

--- a/services/agora/src/composables/conversation/useConversationSurveyState.test.ts
+++ b/services/agora/src/composables/conversation/useConversationSurveyState.test.ts
@@ -18,6 +18,7 @@ describe("shouldFetchSurveyForm", () => {
     const surveyStatus: SurveyStatusCheckResponse = {
       surveyGate: {
         hasSurvey: false,
+        isOptional: false,
         canParticipate: true,
         status: "no_survey",
       },
@@ -33,6 +34,7 @@ describe("shouldFetchSurveyForm", () => {
     const surveyStatus: SurveyStatusCheckResponse = {
       surveyGate: {
         hasSurvey: true,
+        isOptional: false,
         canParticipate: false,
         status: "not_started",
       },
@@ -50,6 +52,7 @@ describe("resolveSurveyForm", () => {
     const surveyStatus: SurveyStatusCheckResponse = {
       surveyGate: {
         hasSurvey: false,
+        isOptional: false,
         canParticipate: true,
         status: "no_survey",
       },
@@ -62,6 +65,7 @@ describe("resolveSurveyForm", () => {
       questions: [],
       surveyGate: {
         hasSurvey: true,
+        isOptional: false,
         canParticipate: true,
         status: "complete_valid",
       },

--- a/services/agora/src/composables/conversation/useParticipationGate.ts
+++ b/services/agora/src/composables/conversation/useParticipationGate.ts
@@ -34,6 +34,7 @@ function deriveSurveyBlocked({
 }): boolean {
   return (
     surveyGate?.hasSurvey === true &&
+    surveyGate.isOptional !== true &&
     !surveyGate.canParticipate &&
     !needsAuth &&
     !needsTicket

--- a/services/agora/src/pages/conversation/[conversationSlugId]/edit/survey/index.i18n.ts
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/edit/survey/index.i18n.ts
@@ -5,6 +5,9 @@ export interface EditSurveyTranslations {
   deleteButton: string;
   title: string;
   description: string;
+  optionalSurveyToggleLabel: string;
+  optionalSurveyToggleHint: string;
+  questionRequirementDisabledHint: string;
   loadError: string;
   validationError: string;
   saveError: string;
@@ -56,6 +59,11 @@ const en: EditSurveyTranslations = {
   deleteButton: "Delete survey",
   title: "Edit survey",
   description: "Update the conversation survey. Changes can affect which participant responses stay current.",
+  optionalSurveyToggleLabel: "Make survey optional",
+  optionalSurveyToggleHint:
+    "People can participate without answering. Question required settings are ignored until this is turned off.",
+  questionRequirementDisabledHint:
+    "Ignored because the whole survey is optional.",
   loadError: "Failed to load survey settings.",
   validationError: "Please complete all survey questions before saving.",
   saveError: "Failed to save survey settings.",
@@ -115,6 +123,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "حذف الاستبيان",
     title: "تعديل الاستبيان",
     description: "حدّث استبيان المحادثة. قد تؤثر التغييرات على بقاء ردود المشاركين محدثة.",
+    optionalSurveyToggleLabel: "اجعل الاستبيان اختياريًا",
+    optionalSurveyToggleHint:
+      "يمكن للأشخاص المشاركة دون الإجابة. يتم تجاهل إعدادات إلزامية الأسئلة حتى يتم إيقاف هذا الخيار.",
+    questionRequirementDisabledHint:
+      "يتم تجاهله لأن الاستبيان بأكمله اختياري.",
     loadError: "فشل تحميل إعدادات الاستبيان.",
     validationError: "يرجى إكمال جميع أسئلة الاستبيان قبل الحفظ.",
     saveError: "فشل حفظ إعدادات الاستبيان.",
@@ -166,6 +179,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "Eliminar encuesta",
     title: "Editar encuesta",
     description: "Actualiza la encuesta de la conversación. Los cambios pueden afectar qué respuestas de participantes siguen vigentes.",
+    optionalSurveyToggleLabel: "Hacer la encuesta opcional",
+    optionalSurveyToggleHint:
+      "Las personas pueden participar sin responder. Los ajustes obligatorios de las preguntas se ignoran hasta desactivar esto.",
+    questionRequirementDisabledHint:
+      "Se ignora porque toda la encuesta es opcional.",
     loadError: "No se pudo cargar la configuración de la encuesta.",
     validationError: "Completa todas las preguntas de la encuesta antes de guardar.",
     saveError: "No se pudo guardar la configuración de la encuesta.",
@@ -219,6 +237,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "حذف نظرسنجی",
     title: "ویرایش نظرسنجی",
     description: "نظرسنجی گفتگو را به‌روزرسانی کنید. این تغییرات ممکن است بر معتبر ماندن پاسخ‌های شرکت‌کنندگان اثر بگذارد.",
+    optionalSurveyToggleLabel: "اختیاری کردن کل نظرسنجی",
+    optionalSurveyToggleHint:
+      "افراد می‌توانند بدون پاسخ دادن مشارکت کنند. تنظیمات الزامی پرسش‌ها تا خاموش شدن این گزینه نادیده گرفته می‌شود.",
+    questionRequirementDisabledHint:
+      "نادیده گرفته می‌شود چون کل نظرسنجی اختیاری است.",
     loadError: "بارگیری تنظیمات نظرسنجی انجام نشد.",
     validationError: "پیش از ذخیره، همه پرسش‌های نظرسنجی را کامل کنید.",
     saveError: "ذخیره تنظیمات نظرسنجی انجام نشد.",
@@ -272,6 +295,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "Supprimer le questionnaire",
     title: "Modifier le questionnaire",
     description: "Mettez à jour le questionnaire de la conversation. Les changements peuvent affecter la validité actuelle des réponses des participants.",
+    optionalSurveyToggleLabel: "Rendre le questionnaire facultatif",
+    optionalSurveyToggleHint:
+      "Les personnes peuvent participer sans répondre. Les réglages obligatoires des questions sont ignorés jusqu'à désactivation.",
+    questionRequirementDisabledHint:
+      "Ignoré car tout le questionnaire est facultatif.",
     loadError: "Impossible de charger les paramètres du questionnaire.",
     validationError: "Veuillez compléter toutes les questions du questionnaire avant d'enregistrer.",
     saveError: "Impossible d'enregistrer les paramètres du questionnaire.",
@@ -325,6 +353,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "מחיקת סקר",
     title: "עריכת סקר",
     description: "עדכנו את סקר השיחה. שינויים עשויים להשפיע על אילו תשובות משתתפים נשארות עדכניות.",
+    optionalSurveyToggleLabel: "להפוך את הסקר לאופציונלי",
+    optionalSurveyToggleHint:
+      "אפשר להשתתף בלי לענות. הגדרות החובה של השאלות יזכו להתעלמות עד לכיבוי אפשרות זו.",
+    questionRequirementDisabledHint:
+      "מתעלמים מזה כי כל הסקר אופציונלי.",
     loadError: "טעינת הגדרות הסקר נכשלה.",
     validationError: "יש להשלים את כל שאלות הסקר לפני השמירה.",
     saveError: "שמירת הגדרות הסקר נכשלה.",
@@ -376,6 +409,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "アンケートを削除",
     title: "アンケートを編集",
     description: "会話アンケートを更新します。変更により参加者の回答が現在有効かどうかに影響することがあります。",
+    optionalSurveyToggleLabel: "アンケートを任意にする",
+    optionalSurveyToggleHint:
+      "回答しなくても参加できます。この設定をオフにするまで、質問の必須設定は無視されます。",
+    questionRequirementDisabledHint:
+      "アンケート全体が任意のため無視されます。",
     loadError: "アンケート設定を読み込めませんでした。",
     validationError: "保存前にアンケートの質問をすべて完成させてください。",
     saveError: "アンケート設定を保存できませんでした。",
@@ -427,6 +465,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "Сурамжылоону жок кылуу",
     title: "Сурамжылоону түзөтүү",
     description: "Сүйлөшүүнүн сурамжылоосун жаңыртыңыз. Өзгөрүүлөр катышуучулардын жоопторунун учурдагы жарактуулугуна таасир этиши мүмкүн.",
+    optionalSurveyToggleLabel: "Сурамжылоону ыктыярдуу кылуу",
+    optionalSurveyToggleHint:
+      "Адамдар жооп бербей эле катыша алат. Бул өчүрүлгөнчө суроолордун милдеттүү жөндөөлөрү эске алынбайт.",
+    questionRequirementDisabledHint:
+      "Сурамжылоонун баары ыктыярдуу болгондуктан эске алынбайт.",
     loadError: "Сурамжылоонун жөндөөлөрүн жүктөө ишке ашкан жок.",
     validationError: "Сактоодон мурун сурамжылоонун бардык суроолорун толтуруңуз.",
     saveError: "Сурамжылоонун жөндөөлөрүн сактоо ишке ашкан жок.",
@@ -478,6 +521,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "Удалить опрос",
     title: "Редактировать опрос",
     description: "Обновите опрос беседы. Изменения могут повлиять на то, какие ответы участников остаются актуальными.",
+    optionalSurveyToggleLabel: "Сделать опрос необязательным",
+    optionalSurveyToggleHint:
+      "Люди могут участвовать без ответов. Настройки обязательности вопросов игнорируются, пока этот режим включён.",
+    questionRequirementDisabledHint:
+      "Игнорируется, потому что весь опрос необязательный.",
     loadError: "Не удалось загрузить настройки опроса.",
     validationError: "Перед сохранением заполните все вопросы опроса.",
     saveError: "Не удалось сохранить настройки опроса.",
@@ -529,6 +577,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "删除问卷",
     title: "编辑问卷",
     description: "更新这场对话的问卷。更改可能影响哪些参与者回答仍然保持当前有效。",
+    optionalSurveyToggleLabel: "将问卷设为可选",
+    optionalSurveyToggleHint:
+      "用户无需回答也能参与。关闭此选项前，问题的必答设置会被忽略。",
+    questionRequirementDisabledHint:
+      "由于整个问卷是可选的，此设置会被忽略。",
     loadError: "无法加载问卷设置。",
     validationError: "保存前请完成所有问卷问题。",
     saveError: "无法保存问卷设置。",
@@ -580,6 +633,11 @@ export const editSurveyTranslations: Record<
     deleteButton: "刪除問卷",
     title: "編輯問卷",
     description: "更新這場對話的問卷。變更可能影響哪些參與者回答仍保持目前有效。",
+    optionalSurveyToggleLabel: "將問卷設為可選",
+    optionalSurveyToggleHint:
+      "使用者無需回答也能參與。關閉此選項前，問題的必答設定會被忽略。",
+    questionRequirementDisabledHint:
+      "由於整份問卷是可選的，此設定會被忽略。",
     loadError: "無法載入問卷設定。",
     validationError: "儲存前請完成所有問卷問題。",
     saveError: "無法儲存問卷設定。",

--- a/services/agora/src/pages/conversation/[conversationSlugId]/edit/survey/index.vue
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/edit/survey/index.vue
@@ -22,6 +22,14 @@
       <ZKCard padding="1rem" class="intro-card">
         <div class="intro-card__title">{{ t("title") }}</div>
         <div class="intro-card__description">{{ t("description") }}</div>
+        <q-toggle
+          :model-value="isSurveyOptional"
+          :label="t('optionalSurveyToggleLabel')"
+          @update:model-value="(value) => updateSurveyOptional({ isOptional: value })"
+        />
+        <div class="intro-card__description">
+          {{ t("optionalSurveyToggleHint") }}
+        </div>
       </ZKCard>
 
       <ZKCard padding="1rem" class="summary-card">
@@ -108,10 +116,14 @@
           </div>
 
           <q-toggle
-            :model-value="question.isRequired"
-            :label="question.isRequired ? t('requiredLabel') : t('optionalLabel')"
+            :model-value="isSurveyOptional ? false : question.isRequired"
+            :disable="isSurveyOptional"
+            :label="isSurveyOptional || !question.isRequired ? t('optionalLabel') : t('requiredLabel')"
             @update:model-value="(value) => updateQuestionRequired({ questionIndex, isRequired: value })"
           />
+          <div v-if="isSurveyOptional" class="semantic-change-block__hint">
+            {{ t("questionRequirementDisabledHint") }}
+          </div>
 
           <div v-if="question.questionType === 'choice'" class="constraints-grid">
             <q-input
@@ -188,8 +200,8 @@
           <div v-if="question.questionType !== 'free_text'" class="options-list">
             <div
               v-for="(option, optionIndex) in question.options ?? []"
-              :key="optionIndex"
               :id="getOptionInputId({ questionIndex, optionIndex })"
+              :key="optionIndex"
               class="option-editor"
               @keydown.enter="handleOptionEditorEnter({ event: $event, questionIndex })"
             >
@@ -367,6 +379,7 @@ const pendingRemoval = ref<PendingRemoval | null>(null);
 
 const surveyConfigValue = computed(() => surveyConfig.value);
 const surveyQuestions = computed(() => surveyConfig.value?.questions ?? []);
+const isSurveyOptional = computed(() => surveyConfig.value?.isOptional === true);
 const largeOptionWarningThreshold = SURVEY_LARGE_OPTION_WARNING_THRESHOLD;
 const completionCountsQuery = useSurveyCompletionCountsQuery({
   conversationSlugId: computed(() => conversationSlugId),
@@ -731,8 +744,17 @@ function updateOptionSemanticChange({
 
 function ensureSurveyConfig(): void {
   if (surveyConfig.value === null) {
-    surveyConfig.value = { questions: [] };
+    surveyConfig.value = { isOptional: false, questions: [] };
   }
+}
+
+function updateSurveyOptional({ isOptional }: { isOptional: boolean | null }): void {
+  ensureSurveyConfig();
+  if (surveyConfig.value === null) {
+    return;
+  }
+
+  surveyConfig.value.isOptional = isOptional === true;
 }
 
 function addQuestion(): void {

--- a/services/agora/src/pages/conversation/[conversationSlugId]/export.i18n.ts
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/export.i18n.ts
@@ -37,7 +37,7 @@ export const exportPageTranslations: Record<
     requestExportAriaLabel: "Request export of conversation data",
     errorActiveExportInProgress:
       "An export is already in progress. Please wait for it to complete.",
-    errorConversationNotFound: "Conversation not found.",
+    errorConversationNotFound: "Conversation not found",
     errorNoOpinions:
       "This conversation has no statements to export. Add some statements first.",
     exportFeatureDisabled: "Export feature is disabled",
@@ -56,7 +56,7 @@ export const exportPageTranslations: Record<
     requestExportAriaLabel: "طلب تصدير بيانات المحادثة",
     errorActiveExportInProgress:
       "التصدير قيد التقدم بالفعل. يرجى الانتظار حتى يكتمل.",
-    errorConversationNotFound: "المحادثة غير موجودة.",
+    errorConversationNotFound: "المحادثة غير موجودة",
     errorNoOpinions:
       "لا توجد مقترحات في هذه المحادثة للتصدير. أضف بعض المقترحات أولاً.",
     exportFeatureDisabled: "ميزة التصدير معطلة",
@@ -78,7 +78,7 @@ export const exportPageTranslations: Record<
     requestExportAriaLabel: "Solicitar exportación de datos de conversación",
     errorActiveExportInProgress:
       "Ya hay una exportación en progreso. Por favor, espera a que se complete.",
-    errorConversationNotFound: "Conversación no encontrada.",
+    errorConversationNotFound: "Conversación no encontrada",
     errorNoOpinions:
       "Esta conversación no tiene proposiciones para exportar. Añade algunas proposiciones primero.",
     exportFeatureDisabled: "La función de exportación está deshabilitada",
@@ -99,7 +99,7 @@ export const exportPageTranslations: Record<
     requestExportAriaLabel: "درخواست خروجی داده‌های گفتگو",
     errorActiveExportInProgress:
       "یک خروجی در حال انجام است. لطفاً تا تکمیل آن صبر کنید.",
-    errorConversationNotFound: "گفتگو یافت نشد.",
+    errorConversationNotFound: "گفتگو یافت نشد",
     errorNoOpinions:
       "این گفتگو گزاره‌ای برای خروجی ندارد. ابتدا چند گزاره اضافه کنید.",
     exportFeatureDisabled: "قابلیت خروجی غیرفعال است",
@@ -120,7 +120,7 @@ export const exportPageTranslations: Record<
     requestExportAriaLabel: "בקשת ייצוא נתוני שיחה",
     errorActiveExportInProgress:
       "ייצוא כבר מתבצע. אנא המתינו לסיומו.",
-    errorConversationNotFound: "השיחה לא נמצאה.",
+    errorConversationNotFound: "השיחה לא נמצאה",
     errorNoOpinions:
       "לשיחה זו אין הצהרות לייצוא. הוסיפו הצהרות תחילה.",
     exportFeatureDisabled: "תכונת הייצוא מושבתת",
@@ -143,7 +143,7 @@ export const exportPageTranslations: Record<
       "Demander l'export des données de conversation",
     errorActiveExportInProgress:
       "Un export est déjà en cours. Veuillez attendre qu'il soit terminé.",
-    errorConversationNotFound: "Conversation introuvable.",
+    errorConversationNotFound: "Conversation introuvable",
     errorNoOpinions:
       "Cette conversation n'a pas de propositions à exporter. Ajoutez d'abord quelques propositions.",
     exportFeatureDisabled: "La fonction d'export est désactivée",
@@ -160,7 +160,7 @@ export const exportPageTranslations: Record<
     viewConversation: "查看对话",
     requestExportAriaLabel: "请求导出对话数据",
     errorActiveExportInProgress: "导出正在进行中。请等待完成。",
-    errorConversationNotFound: "未找到对话。",
+    errorConversationNotFound: "未找到对话",
     errorNoOpinions: "此对话没有可导出的观点。请先添加一些观点。",
     exportFeatureDisabled: "导出功能已禁用",
   },
@@ -176,7 +176,7 @@ export const exportPageTranslations: Record<
     viewConversation: "檢視對話",
     requestExportAriaLabel: "請求匯出對話資料",
     errorActiveExportInProgress: "匯出正在進行中。請等待完成。",
-    errorConversationNotFound: "未找到對話。",
+    errorConversationNotFound: "未找到對話",
     errorNoOpinions: "此對話沒有可匯出的觀點。請先新增一些觀點。",
     exportFeatureDisabled: "匯出功能已停用",
   },
@@ -197,7 +197,7 @@ export const exportPageTranslations: Record<
     requestExportAriaLabel: "会話データのエクスポートをリクエスト",
     errorActiveExportInProgress:
       "エクスポートはすでに進行中です。完了するまでお待ちください。",
-    errorConversationNotFound: "会話が見つかりません。",
+    errorConversationNotFound: "会話が見つかりません",
     errorNoOpinions:
       "この会話にはエクスポートする主張がありません。まず主張を追加してください。",
     exportFeatureDisabled: "エクスポート機能は無効です",
@@ -218,7 +218,7 @@ export const exportPageTranslations: Record<
     requestExportAriaLabel: "Талкуу маалыматтарын экспорттоону суроо",
     errorActiveExportInProgress:
       "Экспорт мурунтан эле жүрүп жатат. Аяктаганча күтүңүз.",
-    errorConversationNotFound: "Талкуу табылган жок.",
+    errorConversationNotFound: "Талкуу табылган жок",
     errorNoOpinions:
       "Бул талкууда экспорттоого пикирлер жок. Алгач пикирлерди кошуңуз.",
     exportFeatureDisabled: "Экспорт функциясы өчүрүлгөн",
@@ -240,7 +240,7 @@ export const exportPageTranslations: Record<
     requestExportAriaLabel: "Запросить экспорт данных обсуждения",
     errorActiveExportInProgress:
       "Экспорт уже выполняется. Пожалуйста, дождитесь его завершения.",
-    errorConversationNotFound: "Обсуждение не найдено.",
+    errorConversationNotFound: "Обсуждение не найдено",
     errorNoOpinions:
       "В этом обсуждении нет высказываний для экспорта. Сначала добавьте высказывания.",
     exportFeatureDisabled: "Функция экспорта отключена",

--- a/services/agora/src/pages/conversation/[postSlugId].onboarding/question.[questionSlugId].vue
+++ b/services/agora/src/pages/conversation/[postSlugId].onboarding/question.[questionSlugId].vue
@@ -48,7 +48,7 @@
                 :label="t('needsUpdateLabel')"
               />
               <q-chip
-                v-else-if="question.isRequired"
+                v-else-if="isQuestionRequired"
                 dense
                 color="primary"
                 text-color="white"
@@ -71,7 +71,7 @@
               v-if="question.questionType === 'choice'"
               :choice-display="question.choiceDisplay"
               :is-multiple-selection="!isSingleSelectionQuestion"
-              :is-required="question.isRequired"
+              :is-required="isQuestionRequired"
               :options="choiceOptions"
               :selected-single-option-slug-id="selectedSingleOptionSlugId"
               :selected-multi-option-slug-ids="selectedMultiOptionSlugIds"
@@ -222,6 +222,14 @@ const question = computed<SurveyQuestionFormItem | undefined>(() => {
   return surveyForm.value?.questions[questionIndex.value];
 });
 
+const isSurveyOptional = computed(() => {
+  return surveyForm.value?.surveyGate.isOptional === true;
+});
+
+const isQuestionRequired = computed(() => {
+  return question.value?.isRequired === true && !isSurveyOptional.value;
+});
+
 const previousQuestionSlugId = computed(() => {
   if (questionIndex.value <= 0) {
     return undefined;
@@ -351,7 +359,7 @@ const hasDraftChanged = computed(() => {
 const shouldPersistPassOnLeave = computed(() => {
   const currentQuestion = question.value;
 
-  if (currentQuestion === undefined || currentQuestion.isRequired) {
+  if (currentQuestion === undefined || isQuestionRequired.value) {
     return false;
   }
 
@@ -369,7 +377,7 @@ const canNavigateForward = computed(() => {
     return false;
   }
   if (draftAnswer.value === undefined) {
-    return !currentQuestion.isRequired || currentQuestion.isCurrentAnswerValid;
+    return !isQuestionRequired.value || currentQuestion.isCurrentAnswerValid;
   }
 
   return isSurveyAnswerSubmittable({
@@ -405,12 +413,12 @@ const questionDescription = computed(() => {
   }
   if (currentQuestion.questionType === "choice") {
     if (isSingleSelectionChoiceQuestion({ question: currentQuestion })) {
-      return currentQuestion.isRequired
+      return isQuestionRequired.value
         ? t("chooseOneOptionDescription")
         : t("chooseZeroOrOneOptionDescription");
     }
 
-    if (!currentQuestion.isRequired) {
+    if (!isQuestionRequired.value) {
       if (currentQuestion.constraints.maxSelections !== undefined) {
         return t("optionalMultiChoiceBetweenDescription", {
           min: currentQuestion.constraints.minSelections,

--- a/services/agora/src/pages/conversation/[postSlugId].onboarding/verifyRouteLogic.test.ts
+++ b/services/agora/src/pages/conversation/[postSlugId].onboarding/verifyRouteLogic.test.ts
@@ -7,6 +7,7 @@ function createNoSurveyStatus(): SurveyStatusCheckResponse {
   return {
     surveyGate: {
       hasSurvey: false,
+      isOptional: false,
       canParticipate: true,
       status: "no_survey",
     },
@@ -20,6 +21,7 @@ function createSurveyStatus(): SurveyStatusCheckResponse {
   return {
     surveyGate: {
       hasSurvey: true,
+      isOptional: false,
       canParticipate: false,
       status: "not_started",
     },
@@ -101,6 +103,7 @@ describe("resolveVerifyRouteDecision", () => {
       questions: [],
       surveyGate: {
         hasSurvey: false,
+        isOptional: false,
         canParticipate: true,
         status: "no_survey",
       },

--- a/services/agora/src/pages/conversation/new/survey/index.i18n.ts
+++ b/services/agora/src/pages/conversation/new/survey/index.i18n.ts
@@ -5,6 +5,9 @@ export interface ConversationSurveyStepTranslations {
   addQuestionButton: string;
   pageTitle: string;
   pageDescription: string;
+  optionalSurveyToggleLabel: string;
+  optionalSurveyToggleHint: string;
+  questionRequirementDisabledHint: string;
   noQuestionsTitle: string;
   noQuestionsDescription: string;
   questionLabel: string;
@@ -46,6 +49,11 @@ export const conversationSurveyStepTranslations: Record<
     pageTitle: "Conversation survey",
     pageDescription:
       "Add an optional demographics survey. Required questions gate participation; fully optional surveys remain informational.",
+    optionalSurveyToggleLabel: "Make survey optional",
+    optionalSurveyToggleHint:
+      "People can participate without answering. Question required settings are ignored until this is turned off.",
+    questionRequirementDisabledHint:
+      "Ignored because the whole survey is optional.",
     noQuestionsTitle: "No survey yet",
     noQuestionsDescription:
       "Leave this empty to publish without a survey, or add questions now.",
@@ -83,6 +91,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "إضافة سؤال",
     pageTitle: "استبيان المحادثة",
     pageDescription: "أضف استبيانًا ديموغرافيًا اختياريًا. الأسئلة المطلوبة تقيّد المشاركة، أما الاستبيانات الاختيارية بالكامل فتبقى معلوماتية.",
+    optionalSurveyToggleLabel: "اجعل الاستبيان اختياريًا",
+    optionalSurveyToggleHint:
+      "يمكن للأشخاص المشاركة دون الإجابة. يتم تجاهل إعدادات إلزامية الأسئلة حتى يتم إيقاف هذا الخيار.",
+    questionRequirementDisabledHint:
+      "يتم تجاهله لأن الاستبيان بأكمله اختياري.",
     noQuestionsTitle: "لا يوجد استبيان بعد",
     noQuestionsDescription: "اترك هذه الصفحة فارغة للنشر بدون استبيان، أو أضف أسئلة الآن.",
     questionLabel: "السؤال {number}",
@@ -119,6 +132,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "Agregar pregunta",
     pageTitle: "Encuesta de la conversación",
     pageDescription: "Agrega una encuesta demográfica opcional. Las preguntas obligatorias bloquean la participación; las encuestas totalmente opcionales siguen siendo informativas.",
+    optionalSurveyToggleLabel: "Hacer la encuesta opcional",
+    optionalSurveyToggleHint:
+      "Las personas pueden participar sin responder. Los ajustes obligatorios de las preguntas se ignoran hasta desactivar esto.",
+    questionRequirementDisabledHint:
+      "Se ignora porque toda la encuesta es opcional.",
     noQuestionsTitle: "Aún no hay encuesta",
     noQuestionsDescription: "Déjalo vacío para publicar sin encuesta o agrega preguntas ahora.",
     questionLabel: "Pregunta {number}",
@@ -155,6 +173,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "افزودن پرسش",
     pageTitle: "نظرسنجی گفتگو",
     pageDescription: "یک نظرسنجی جمعیت‌شناختی اختیاری اضافه کنید. پرسش‌های الزامی مشارکت را محدود می‌کنند؛ نظرسنجی‌های کاملاً اختیاری فقط جنبه اطلاعاتی دارند.",
+    optionalSurveyToggleLabel: "اختیاری کردن کل نظرسنجی",
+    optionalSurveyToggleHint:
+      "افراد می‌توانند بدون پاسخ دادن مشارکت کنند. تنظیمات الزامی پرسش‌ها تا خاموش شدن این گزینه نادیده گرفته می‌شود.",
+    questionRequirementDisabledHint:
+      "نادیده گرفته می‌شود چون کل نظرسنجی اختیاری است.",
     noQuestionsTitle: "هنوز نظرسنجی‌ای وجود ندارد",
     noQuestionsDescription: "برای انتشار بدون نظرسنجی این بخش را خالی بگذارید، یا همین حالا پرسش اضافه کنید.",
     questionLabel: "پرسش {number}",
@@ -191,6 +214,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "Ajouter une question",
     pageTitle: "Questionnaire de la conversation",
     pageDescription: "Ajoutez un questionnaire démographique facultatif. Les questions obligatoires conditionnent la participation ; un questionnaire entièrement facultatif reste informatif.",
+    optionalSurveyToggleLabel: "Rendre le questionnaire facultatif",
+    optionalSurveyToggleHint:
+      "Les personnes peuvent participer sans répondre. Les réglages obligatoires des questions sont ignorés jusqu'à désactivation.",
+    questionRequirementDisabledHint:
+      "Ignoré car tout le questionnaire est facultatif.",
     noQuestionsTitle: "Pas encore de questionnaire",
     noQuestionsDescription: "Laissez cette étape vide pour publier sans questionnaire, ou ajoutez des questions maintenant.",
     questionLabel: "Question {number}",
@@ -227,6 +255,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "הוספת שאלה",
     pageTitle: "סקר השיחה",
     pageDescription: "הוסיפו סקר דמוגרפי אופציונלי. שאלות חובה מגבילות השתתפות; סקר שכל כולו אופציונלי נשאר אינפורמטיבי בלבד.",
+    optionalSurveyToggleLabel: "להפוך את הסקר לאופציונלי",
+    optionalSurveyToggleHint:
+      "אפשר להשתתף בלי לענות. הגדרות החובה של השאלות יזכו להתעלמות עד לכיבוי אפשרות זו.",
+    questionRequirementDisabledHint:
+      "מתעלמים מזה כי כל הסקר אופציונלי.",
     noQuestionsTitle: "עדיין אין סקר",
     noQuestionsDescription: "השאירו את השלב הזה ריק כדי לפרסם בלי סקר, או הוסיפו שאלות עכשיו.",
     questionLabel: "שאלה {number}",
@@ -263,6 +296,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "質問を追加",
     pageTitle: "会話アンケート",
     pageDescription: "任意の属性アンケートを追加します。必須質問は参加条件になります。すべて任意のアンケートは情報表示のみです。",
+    optionalSurveyToggleLabel: "アンケートを任意にする",
+    optionalSurveyToggleHint:
+      "回答しなくても参加できます。この設定をオフにするまで、質問の必須設定は無視されます。",
+    questionRequirementDisabledHint:
+      "アンケート全体が任意のため無視されます。",
     noQuestionsTitle: "アンケートはまだありません",
     noQuestionsDescription: "アンケートなしで公開する場合はこのままにするか、今すぐ質問を追加してください。",
     questionLabel: "質問 {number}",
@@ -299,6 +337,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "Суроо кошуу",
     pageTitle: "Сүйлөшүүнүн сурамжылоосу",
     pageDescription: "Ыктыярдуу демографиялык сурамжылоо кошуңуз. Милдеттүү суроолор катышууну чектейт; толугу менен ыктыярдуу сурамжылоо маалыматтык бойдон калат.",
+    optionalSurveyToggleLabel: "Сурамжылоону ыктыярдуу кылуу",
+    optionalSurveyToggleHint:
+      "Адамдар жооп бербей эле катыша алат. Бул өчүрүлгөнчө суроолордун милдеттүү жөндөөлөрү эске алынбайт.",
+    questionRequirementDisabledHint:
+      "Сурамжылоонун баары ыктыярдуу болгондуктан эске алынбайт.",
     noQuestionsTitle: "Азырынча сурамжылоо жок",
     noQuestionsDescription: "Сурамжылоосуз жарыялоо үчүн муну бош калтырыңыз же азыр суроолорду кошуңуз.",
     questionLabel: "Суроо {number}",
@@ -335,6 +378,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "Добавить вопрос",
     pageTitle: "Опрос беседы",
     pageDescription: "Добавьте необязательный демографический опрос. Обязательные вопросы ограничивают участие; полностью необязательный опрос остаётся информационным.",
+    optionalSurveyToggleLabel: "Сделать опрос необязательным",
+    optionalSurveyToggleHint:
+      "Люди могут участвовать без ответов. Настройки обязательности вопросов игнорируются, пока этот режим включён.",
+    questionRequirementDisabledHint:
+      "Игнорируется, потому что весь опрос необязательный.",
     noQuestionsTitle: "Опроса пока нет",
     noQuestionsDescription: "Оставьте этот шаг пустым, чтобы опубликовать без опроса, или добавьте вопросы сейчас.",
     questionLabel: "Вопрос {number}",
@@ -371,6 +419,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "添加问题",
     pageTitle: "对话问卷",
     pageDescription: "添加一份可选的人口统计问卷。必答问题会限制参与；全部可选的问卷仅用于信息收集。",
+    optionalSurveyToggleLabel: "将问卷设为可选",
+    optionalSurveyToggleHint:
+      "用户无需回答也能参与。关闭此选项前，问题的必答设置会被忽略。",
+    questionRequirementDisabledHint:
+      "由于整个问卷是可选的，此设置会被忽略。",
     noQuestionsTitle: "还没有问卷",
     noQuestionsDescription: "如要无问卷发布，可保持为空；或者现在添加问题。",
     questionLabel: "问题 {number}",
@@ -407,6 +460,11 @@ export const conversationSurveyStepTranslations: Record<
     addQuestionButton: "新增問題",
     pageTitle: "對話問卷",
     pageDescription: "新增一份可選的人口統計問卷。必答問題會限制參與；完全可選的問卷僅作資訊用途。",
+    optionalSurveyToggleLabel: "將問卷設為可選",
+    optionalSurveyToggleHint:
+      "使用者無需回答也能參與。關閉此選項前，問題的必答設定會被忽略。",
+    questionRequirementDisabledHint:
+      "由於整份問卷是可選的，此設定會被忽略。",
     noQuestionsTitle: "還沒有問卷",
     noQuestionsDescription: "若要不含問卷直接發布，可保持空白；或現在新增問題。",
     questionLabel: "問題 {number}",

--- a/services/agora/src/pages/conversation/new/survey/index.vue
+++ b/services/agora/src/pages/conversation/new/survey/index.vue
@@ -19,6 +19,14 @@
       <div class="intro-card">
         <div class="intro-card__title">{{ t("pageTitle") }}</div>
         <div class="intro-card__description">{{ t("pageDescription") }}</div>
+        <q-toggle
+          :model-value="isSurveyOptional"
+          :label="t('optionalSurveyToggleLabel')"
+          @update:model-value="(value) => updateSurveyOptional({ isOptional: value })"
+        />
+        <div class="intro-card__description">
+          {{ t("optionalSurveyToggleHint") }}
+        </div>
       </div>
 
       <div v-if="surveyConfigValue === null || surveyConfigValue.questions.length === 0" class="empty-card">
@@ -33,7 +41,7 @@
               {{ t("questionLabel", { number: questionIndex + 1 }) }}
             </div>
             <div class="question-card__subtitle">
-              {{ question.isRequired ? t("requiredLabel") : t("optionalLabel") }}
+              {{ isSurveyOptional || !question.isRequired ? t("optionalLabel") : t("requiredLabel") }}
             </div>
           </div>
 
@@ -78,10 +86,14 @@
         />
 
         <q-toggle
-          :model-value="question.isRequired"
-          :label="question.isRequired ? t('requiredLabel') : t('optionalLabel')"
+          :model-value="isSurveyOptional ? false : question.isRequired"
+          :disable="isSurveyOptional"
+          :label="isSurveyOptional || !question.isRequired ? t('optionalLabel') : t('requiredLabel')"
           @update:model-value="(value) => updateQuestionRequired({ questionIndex, isRequired: value })"
         />
+        <div v-if="isSurveyOptional" class="constraints-help">
+          {{ t("questionRequirementDisabledHint") }}
+        </div>
 
         <div v-if="question.questionType === 'choice'" class="constraints-grid">
           <q-input
@@ -158,8 +170,8 @@
         <div v-if="question.questionType !== 'free_text'" class="options-list">
           <div
             v-for="(option, optionIndex) in question.options ?? []"
-            :key="optionIndex"
             :id="getOptionInputId({ questionIndex, optionIndex })"
+            :key="optionIndex"
             class="option-editor"
             @keydown.enter="handleOptionEditorEnter({ event: $event, questionIndex })"
           >
@@ -340,6 +352,9 @@ const surveyConfigValue = computed(() => surveyConfig.value);
 const surveyQuestions = computed(() => {
   return surveyConfig.value?.questions ?? [];
 });
+const isSurveyOptional = computed(() => {
+  return surveyConfig.value?.isOptional === true;
+});
 const largeOptionWarningThreshold = SURVEY_LARGE_OPTION_WARNING_THRESHOLD;
 
 function clearSurveyValidationError(): void {
@@ -481,8 +496,17 @@ function ensureSurveyConfig(): void {
   }
 
   if (surveyConfig.value === null) {
-    surveyConfig.value = { questions: [] };
+    surveyConfig.value = { isOptional: false, questions: [] };
   }
+}
+
+function updateSurveyOptional({ isOptional }: { isOptional: boolean | null }): void {
+  ensureSurveyConfig();
+  if (surveyConfig.value === null) {
+    return;
+  }
+
+  surveyConfig.value.isOptional = isOptional === true;
 }
 
 function addQuestion(): void {

--- a/services/agora/src/shared/types/zod.ts
+++ b/services/agora/src/shared/types/zod.ts
@@ -641,6 +641,7 @@ export const zodSurveyQuestionConfig = z
 
 export const zodSurveyConfig = z
     .object({
+        isOptional: z.boolean().optional().default(false),
         questions: z.array(zodSurveyQuestionConfig),
     })
     .strict()
@@ -691,6 +692,7 @@ export const zodSurveyAggregateSuppressionReason = z.enum([
 export const zodSurveyGateSummary = z
     .object({
         hasSurvey: z.boolean(),
+        isOptional: z.boolean(),
         canParticipate: z.boolean(),
         status: zodSurveyGateStatus,
     })

--- a/services/agora/src/utils/api/post/post.i18n.ts
+++ b/services/agora/src/utils/api/post/post.i18n.ts
@@ -1,0 +1,44 @@
+import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
+
+export interface PostApiTranslations {
+  conversationNotFound: string;
+}
+
+export const postApiTranslations: Record<
+  SupportedDisplayLanguageCodes,
+  PostApiTranslations
+> = {
+  en: {
+    conversationNotFound: "Conversation not found",
+  },
+  ar: {
+    conversationNotFound: "المحادثة غير موجودة",
+  },
+  es: {
+    conversationNotFound: "Conversación no encontrada",
+  },
+  fa: {
+    conversationNotFound: "گفتگو یافت نشد",
+  },
+  he: {
+    conversationNotFound: "השיחה לא נמצאה",
+  },
+  fr: {
+    conversationNotFound: "Conversation introuvable",
+  },
+  "zh-Hans": {
+    conversationNotFound: "未找到对话",
+  },
+  "zh-Hant": {
+    conversationNotFound: "未找到對話",
+  },
+  ja: {
+    conversationNotFound: "会話が見つかりません",
+  },
+  ky: {
+    conversationNotFound: "Талкуу табылган жок",
+  },
+  ru: {
+    conversationNotFound: "Обсуждение не найдено",
+  },
+};

--- a/services/agora/src/utils/api/post/post.ts
+++ b/services/agora/src/utils/api/post/post.ts
@@ -9,6 +9,7 @@ import {
   DefaultApiAxiosParamCreator,
   DefaultApiFactory,
 } from "src/api";
+import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import type { ImportCsvConversationResponse } from "src/shared/types/dto";
 import type {
   FetchFeedResponse,
@@ -38,6 +39,10 @@ import { useNotify } from "../../ui/notify";
 import { api,axiosInstance } from "../client";
 import type { AxiosErrorResponse, AxiosSuccessResponse } from "../common";
 import { useCommonApi } from "../common";
+import {
+  type PostApiTranslations,
+  postApiTranslations,
+} from "./post.i18n";
 
 export function useBackendPostApi() {
   const {
@@ -47,6 +52,7 @@ export function useBackendPostApi() {
   } = useCommonApi();
 
   const { showNotifyMessage } = useNotify();
+  const { t } = useComponentI18n<PostApiTranslations>(postApiTranslations);
 
   const router = useRouter();
 
@@ -92,8 +98,10 @@ export function useBackendPostApi() {
       }
     } catch (error) {
       if (axiosInstance.isAxiosError(error) && error.status === 404) {
-        showNotifyMessage("Conversation resource not found.");
+        const conversationNotFoundMessage = t("conversationNotFound");
+        showNotifyMessage(conversationNotFoundMessage);
         await router.push({ name: "/" });
+        throw new Error(conversationNotFoundMessage, { cause: error });
       }
       throw error;
     }

--- a/services/agora/src/utils/api/survey/useSurveyQueries.ts
+++ b/services/agora/src/utils/api/survey/useSurveyQueries.ts
@@ -1,9 +1,51 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/vue-query";
-import { type SurveyAnswerSubmission, type SurveyConfig } from "src/shared/types/zod";
+import type { SurveyStatusCheckResponse } from "src/shared/types/dto";
+import {
+  type SurveyAnswerSubmission,
+  type SurveyConfig,
+  type SurveyGateSummary,
+} from "src/shared/types/zod";
 import { useBackendAuthApi } from "src/utils/api/auth";
 import { computed, type MaybeRefOrGetter, toValue } from "vue";
 
+import { updateConversationQueryCache } from "../post/useConversationQuery";
 import { useBackendSurveyApi } from "./survey";
+
+function updateSurveyGateViewerCaches({
+  queryClient,
+  conversationSlugId,
+  surveyGate,
+}: {
+  queryClient: ReturnType<typeof useQueryClient>;
+  conversationSlugId: string;
+  surveyGate: SurveyGateSummary;
+}): void {
+  queryClient.setQueriesData<SurveyStatusCheckResponse>(
+    { queryKey: ["survey-status", conversationSlugId] },
+    (oldData) => {
+      if (oldData === undefined) {
+        return oldData;
+      }
+
+      return {
+        ...oldData,
+        surveyGate,
+      };
+    }
+  );
+
+  updateConversationQueryCache({
+    queryClient,
+    conversationSlugId,
+    updateConversation: (conversation) => ({
+      ...conversation,
+      interaction: {
+        ...conversation.interaction,
+        surveyGate,
+      },
+    }),
+  });
+}
 
 async function invalidateSurveyViewerQueries({
   queryClient,
@@ -252,10 +294,19 @@ export function useSurveyConfigUpdateMutation({
       }
       return response.data;
     },
-    onSuccess: async () => {
+    onSuccess: async (data) => {
+      const slugId = toValue(conversationSlugId);
+      if (data.surveyGate !== undefined) {
+        updateSurveyGateViewerCaches({
+          queryClient,
+          conversationSlugId: slugId,
+          surveyGate: data.surveyGate,
+        });
+      }
+
       await invalidateSurveyViewerQueries({
         queryClient,
-        conversationSlugId: toValue(conversationSlugId),
+        conversationSlugId: slugId,
         includeDerivedSurveyQueries: true,
       });
     },

--- a/services/agora/src/utils/survey/config.test.ts
+++ b/services/agora/src/utils/survey/config.test.ts
@@ -5,6 +5,7 @@ import { buildSurveyConfigForSave } from "./config";
 
 function createChoiceSurveyConfig(): SurveyConfig {
   return {
+    isOptional: false,
     questions: [
       {
         questionType: "choice",

--- a/services/agora/src/utils/survey/config.ts
+++ b/services/agora/src/utils/survey/config.ts
@@ -250,6 +250,7 @@ export function normalizeSurveyConfig({
   }
 
   const candidateConfig = {
+    isOptional: surveyConfig.isOptional,
     questions: normalizedQuestions,
   } satisfies SurveyConfig;
 
@@ -469,10 +470,13 @@ export function areSurveyConfigsEqual({
     return left === right;
   }
 
-  return areSurveyQuestionsEqual({
-    left: left.questions,
-    right: right.questions,
-  });
+  return (
+    left.isOptional === right.isOptional &&
+    areSurveyQuestionsEqual({
+      left: left.questions,
+      right: right.questions,
+    })
+  );
 }
 
 export interface SurveyConfigChangeSummary {

--- a/services/api/database/flyway/V0060__dapper_xavin.sql
+++ b/services/api/database/flyway/V0060__dapper_xavin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "survey_config" ADD COLUMN "is_optional" boolean DEFAULT false NOT NULL;

--- a/services/api/drizzle/0059_dapper_xavin.sql
+++ b/services/api/drizzle/0059_dapper_xavin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "survey_config" ADD COLUMN "is_optional" boolean DEFAULT false NOT NULL;

--- a/services/api/drizzle/meta/0059_snapshot.json
+++ b/services/api/drizzle/meta/0059_snapshot.json
@@ -1,0 +1,8600 @@
+{
+  "id": "f8644cc2-4560-4a1c-9b9f-82a47e911ae5",
+  "prevId": "22ed3326-918b-402b-b4b0-885e7d3fc720",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_attempt_email": {
+      "name": "auth_attempt_email",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_reachability": {
+          "name": "email_reachability",
+          "type": "email_reachability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_attempt_email_canonical_check": {
+          "name": "auth_attempt_email_canonical_check",
+          "value": "\"auth_attempt_email\".\"email\" = lower(btrim(\"auth_attempt_email\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_attempt_phone": {
+      "name": "auth_attempt_phone",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"auth_attempt_phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_content": {
+      "name": "conversation_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_content_conversation_id_conversation_id_fk": {
+          "name": "conversation_content_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_content",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_artifact": {
+      "name": "conversation_export_artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_artifact_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "export_file_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "export_file_audience_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "export_artifact_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_artifact_generation_idx": {
+          "name": "conversation_export_artifact_generation_idx",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_artifact_shared_unique": {
+          "name": "conversation_export_artifact_shared_unique",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_artifact\".\"subject_user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_artifact_requester_unique": {
+          "name": "conversation_export_artifact_requester_unique",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_artifact\".\"subject_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_artifact_generation_id_conversation_export_generation_id_fk": {
+          "name": "conversation_export_artifact_generation_id_conversation_export_generation_id_fk",
+          "tableFrom": "conversation_export_artifact",
+          "tableTo": "conversation_export_generation",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_artifact_subject_user_id_user_id_fk": {
+          "name": "conversation_export_artifact_subject_user_id_user_id_fk",
+          "tableFrom": "conversation_export_artifact",
+          "tableTo": "user",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_generation": {
+      "name": "conversation_export_generation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_generation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_generation_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collecting'"
+        },
+        "collecting_ends_at": {
+          "name": "collecting_ends_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_generation_conversation_idx": {
+          "name": "conversation_export_generation_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_collecting_due_idx": {
+          "name": "conversation_export_generation_collecting_due_idx",
+          "columns": [
+            {
+              "expression": "collecting_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_generation\".\"status\" = 'collecting'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_queued_due_idx": {
+          "name": "conversation_export_generation_queued_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_generation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_collecting_unique": {
+          "name": "conversation_export_generation_collecting_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_generation\".\"status\" = 'collecting'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_processing_unique": {
+          "name": "conversation_export_generation_processing_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_generation\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_generation_conversation_id_conversation_id_fk": {
+          "name": "conversation_export_generation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_export_generation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_export_generation_slug_id_unique": {
+          "name": "conversation_export_generation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_request_file": {
+      "name": "conversation_export_request_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_request_file_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "export_file_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "export_file_audience_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_request_file_artifact_idx": {
+          "name": "conversation_export_request_file_artifact_idx",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_file_unique": {
+          "name": "conversation_export_request_file_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_request_file_request_id_conversation_export_request_id_fk": {
+          "name": "conversation_export_request_file_request_id_conversation_export_request_id_fk",
+          "tableFrom": "conversation_export_request_file",
+          "tableTo": "conversation_export_request",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_file_artifact_id_conversation_export_artifact_id_fk": {
+          "name": "conversation_export_request_file_artifact_id_conversation_export_artifact_id_fk",
+          "tableFrom": "conversation_export_request_file",
+          "tableTo": "conversation_export_artifact",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_request": {
+      "name": "conversation_export_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_request_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "export_cancellation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_notified_at": {
+          "name": "started_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_notified_at": {
+          "name": "completed_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_notified_at": {
+          "name": "failed_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_request_conversation_idx": {
+          "name": "conversation_export_request_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_generation_idx": {
+          "name": "conversation_export_request_generation_idx",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_active_history_idx": {
+          "name": "conversation_export_request_active_history_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_expiry_idx": {
+          "name": "conversation_export_request_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_active_unique": {
+          "name": "conversation_export_request_active_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_request\".\"status\" = 'processing' AND \"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_request_conversation_id_conversation_id_fk": {
+          "name": "conversation_export_request_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_generation_id_conversation_export_generation_id_fk": {
+          "name": "conversation_export_request_generation_id_conversation_export_generation_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "conversation_export_generation",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_user_id_user_id_fk": {
+          "name": "conversation_export_request_user_id_user_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_export_request_slug_id_unique": {
+          "name": "conversation_export_request_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_import": {
+      "name": "conversation_import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_import_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "import_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "import_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csv_file_metadata": {
+          "name": "csv_file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_import_status_idx": {
+          "name": "conversation_import_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_created_idx": {
+          "name": "conversation_import_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_user_idx": {
+          "name": "conversation_import_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_conversation_idx": {
+          "name": "conversation_import_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_active_user_unique": {
+          "name": "conversation_import_active_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_import\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_import_conversation_id_conversation_id_fk": {
+          "name": "conversation_import_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_import",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_import_user_id_user_id_fk": {
+          "name": "conversation_import_user_id_user_id_fk",
+          "tableFrom": "conversation_import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_import_slug_id_unique": {
+          "name": "conversation_import_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_import_conversation_id_unique": {
+          "name": "conversation_import_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_moderation": {
+      "name": "conversation_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "conversation_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_moderation_conversation_id_moderation_action_idx": {
+          "name": "conversation_moderation_conversation_id_moderation_action_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "moderation_action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_moderation_conversation_id_conversation_id_fk": {
+          "name": "conversation_moderation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_moderation_author_id_user_id_fk": {
+          "name": "conversation_moderation_author_id_user_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_moderation_conversation_id_unique": {
+          "name": "conversation_moderation_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_report": {
+      "name": "conversation_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_id_idx": {
+          "name": "conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_report_conversation_id_conversation_id_fk": {
+          "name": "conversation_report_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_report_author_id_user_id_fk": {
+          "name": "conversation_report_author_id_user_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_polis_content_id": {
+          "name": "current_polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_ranking_score_id": {
+          "name": "current_ranking_score_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_conversation_at": {
+          "name": "index_conversation_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexed": {
+          "name": "is_indexed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "participation_mode": {
+          "name": "participation_mode",
+          "type": "participation_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'account_required'"
+        },
+        "conversation_type": {
+          "name": "conversation_type",
+          "type": "conversation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polis'"
+        },
+        "is_importing": {
+          "name": "is_importing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_event_ticket": {
+          "name": "requires_event_ticket",
+          "type": "event_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion_count": {
+          "name": "opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_vote_count": {
+          "name": "total_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_participant_count": {
+          "name": "total_participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "moderated_opinion_count": {
+          "name": "moderated_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hidden_opinion_count": {
+          "name": "hidden_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "import_url": {
+          "name": "import_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_conversation_url": {
+          "name": "import_conversation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_export_url": {
+          "name": "import_export_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_created_at": {
+          "name": "import_created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_author": {
+          "name": "import_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_method": {
+          "name": "import_method",
+          "type": "import_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source_config": {
+          "name": "external_source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_feed_idx": {
+          "name": "conversation_feed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation\".\"is_indexed\" = true AND \"conversation\".\"is_importing\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_type_importing_idx": {
+          "name": "conversation_type_importing_idx",
+          "columns": [
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_author_timeline_idx": {
+          "name": "conversation_author_timeline_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_author_id_user_id_fk": {
+          "name": "conversation_author_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_content_id_conversation_content_id_fk": {
+          "name": "conversation_current_content_id_conversation_content_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_polis_content_id_polis_content_id_fk": {
+          "name": "conversation_current_polis_content_id_polis_content_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "current_polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_ranking_score_id_ranking_score_id_fk": {
+          "name": "conversation_current_ranking_score_id_ranking_score_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ranking_score",
+          "columnsFrom": [
+            "current_ranking_score_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_slug_id_unique": {
+          "name": "conversation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_current_content_id_unique": {
+          "name": "conversation_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "conversation_current_polis_content_id_unique": {
+          "name": "conversation_current_polis_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_polis_content_id"
+          ]
+        },
+        "conversation_current_ranking_score_id_unique": {
+          "name": "conversation_current_ranking_score_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_ranking_score_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_topic": {
+      "name": "conversation_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_topic_index": {
+          "name": "conversation_topic_index",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_topic_conversation_id_conversation_id_fk": {
+          "name": "conversation_topic_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_topic_topic_id_topic_id_fk": {
+          "name": "conversation_topic_topic_id_topic_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_topic_unique": {
+          "name": "conversation_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_update_queue": {
+      "name": "conversation_update_queue",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_math_update_at": {
+          "name": "last_math_update_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_update_queue_pending": {
+          "name": "idx_conversation_update_queue_pending",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_math_update_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_update_queue\".\"requested_at\" > \"conversation_update_queue\".\"last_math_update_at\" OR \"conversation_update_queue\".\"last_math_update_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_update_queue_conversation_id_conversation_id_fk": {
+          "name": "conversation_update_queue_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_update_queue",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device": {
+      "name": "device",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_expiry": {
+          "name": "session_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_user_id_user_id_fk": {
+          "name": "device_user_id_user_id_fk",
+          "tableFrom": "device",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email": {
+      "name": "email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "email_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_reachability": {
+          "name": "email_reachability",
+          "type": "email_reachability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_active_unique": {
+          "name": "email_active_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_user_id_user_id_fk": {
+          "name": "email_user_id_user_id_fk",
+          "tableFrom": "email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_canonical_check": {
+          "name": "email_canonical_check",
+          "value": "\"email\".\"email\" = lower(btrim(\"email\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_ticket": {
+      "name": "event_ticket",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_ticket_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "ticket_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_slug": {
+          "name": "event_slug",
+          "type": "event_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pcd_type": {
+          "name": "pcd_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_event_idx": {
+          "name": "user_event_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_ticket_nullifier_event_active_unique": {
+          "name": "event_ticket_nullifier_event_active_unique",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_ticket\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nullifier_idx": {
+          "name": "nullifier_idx",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_ticket_user_id_user_id_fk": {
+          "name": "event_ticket_user_id_user_id_fk",
+          "tableFrom": "event_ticket",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followed_topic": {
+      "name": "followed_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "followed_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "followed_topic_index": {
+          "name": "followed_topic_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "followed_topic_user_id_user_id_fk": {
+          "name": "followed_topic_user_id_user_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "followed_topic_topic_id_topic_id_fk": {
+          "name": "followed_topic_topic_id_topic_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followed_topic_unique": {
+          "name": "followed_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_comparison": {
+      "name": "maxdiff_comparison",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_comparison_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_result_id": {
+          "name": "maxdiff_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "best_slug_id": {
+          "name": "best_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worst_slug_id": {
+          "name": "worst_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_set": {
+          "name": "candidate_set",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "maxdiff_comparison_result_idx": {
+          "name": "maxdiff_comparison_result_idx",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_comparison_active_result_position_unique": {
+          "name": "maxdiff_comparison_active_result_position_unique",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"maxdiff_comparison\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_comparison_maxdiff_result_id_maxdiff_result_id_fk": {
+          "name": "maxdiff_comparison_maxdiff_result_id_maxdiff_result_id_fk",
+          "tableFrom": "maxdiff_comparison",
+          "tableTo": "maxdiff_result",
+          "columnsFrom": [
+            "maxdiff_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item_content": {
+      "name": "maxdiff_item_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_item_id": {
+          "name": "maxdiff_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maxdiff_item_content_maxdiff_item_id_maxdiff_item_id_fk": {
+          "name": "maxdiff_item_content_maxdiff_item_id_maxdiff_item_id_fk",
+          "tableFrom": "maxdiff_item_content",
+          "tableTo": "maxdiff_item",
+          "columnsFrom": [
+            "maxdiff_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "maxdiff_item_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "maxdiff_item_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item_external_source": {
+      "name": "maxdiff_item_external_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_external_source_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_item_id": {
+          "name": "maxdiff_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "external_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_metadata": {
+          "name": "external_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_external_source_external_id_idx": {
+          "name": "maxdiff_external_source_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_external_source_dedup_idx": {
+          "name": "maxdiff_external_source_dedup_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_item_external_source_maxdiff_item_id_maxdiff_item_id_fk": {
+          "name": "maxdiff_item_external_source_maxdiff_item_id_maxdiff_item_id_fk",
+          "tableFrom": "maxdiff_item_external_source",
+          "tableTo": "maxdiff_item",
+          "columnsFrom": [
+            "maxdiff_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_external_source_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_item_external_source_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_item_external_source",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_item_external_source_maxdiff_item_id_unique": {
+          "name": "maxdiff_item_external_source_maxdiff_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "maxdiff_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item": {
+      "name": "maxdiff_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "maxdiff_lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "snapshot_score": {
+          "name": "snapshot_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_rank": {
+          "name": "snapshot_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_participant_count": {
+          "name": "snapshot_participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_item_slug_idx": {
+          "name": "maxdiff_item_slug_idx",
+          "columns": [
+            {
+              "expression": "slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_item_conversation_active_idx": {
+          "name": "maxdiff_item_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_item_lifecycle_idx": {
+          "name": "maxdiff_item_lifecycle_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_item_author_id_user_id_fk": {
+          "name": "maxdiff_item_author_id_user_id_fk",
+          "tableFrom": "maxdiff_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_item_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_item",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_item_slug_id_unique": {
+          "name": "maxdiff_item_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_result": {
+      "name": "maxdiff_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_result_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ranking": {
+          "name": "ranking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comparisons": {
+          "name": "comparisons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_result_complete_idx": {
+          "name": "maxdiff_result_complete_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_complete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_result_conversation_idx": {
+          "name": "maxdiff_result_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_result_participant_id_user_id_fk": {
+          "name": "maxdiff_result_participant_id_user_id_fk",
+          "tableFrom": "maxdiff_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_result_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_result_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_result",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_result_participant_id_conversation_id_unique": {
+          "name": "maxdiff_result_participant_id_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_user_entity_score": {
+      "name": "maxdiff_user_entity_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_user_entity_score_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_result_id": {
+          "name": "maxdiff_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug_id": {
+          "name": "entity_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_left": {
+          "name": "uncertainty_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_right": {
+          "name": "uncertainty_right",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maxdiff_user_entity_score_maxdiff_result_id_maxdiff_result_id_fk": {
+          "name": "maxdiff_user_entity_score_maxdiff_result_id_maxdiff_result_id_fk",
+          "tableFrom": "maxdiff_user_entity_score",
+          "tableTo": "maxdiff_result",
+          "columnsFrom": [
+            "maxdiff_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_user_entity_score_maxdiff_result_id_entity_slug_id_unique": {
+          "name": "maxdiff_user_entity_score_maxdiff_result_id_entity_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "maxdiff_result_id",
+            "entity_slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_export": {
+      "name": "notification_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_export_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_request_id": {
+          "name": "export_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_slug_id": {
+          "name": "export_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "export_cancellation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_export_notification_idx": {
+          "name": "notification_export_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_export_notification_id_notification_id_fk": {
+          "name": "notification_export_notification_id_notification_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_export_export_request_id_conversation_export_request_id_fk": {
+          "name": "notification_export_export_request_id_conversation_export_request_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "conversation_export_request",
+          "columnsFrom": [
+            "export_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_export_conversation_id_conversation_id_fk": {
+          "name": "notification_export_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_import": {
+      "name": "notification_import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_import_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_id": {
+          "name": "import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_import_notification_id_notification_id_fk": {
+          "name": "notification_import_notification_id_notification_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_import_import_id_conversation_import_id_fk": {
+          "name": "notification_import_import_id_conversation_import_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "conversation_import",
+          "columnsFrom": [
+            "import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_import_conversation_id_conversation_id_fk": {
+          "name": "notification_import_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_new_opinion": {
+      "name": "notification_new_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_new_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_new_opinion_notification_id_notification_id_fk": {
+          "name": "notification_new_opinion_notification_id_notification_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_author_id_user_id_fk": {
+          "name": "notification_new_opinion_author_id_user_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_opinion_id_opinion_id_fk": {
+          "name": "notification_new_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_conversation_id_conversation_id_fk": {
+          "name": "notification_new_opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_opinion_vote": {
+      "name": "notification_opinion_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_opinion_vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_votes": {
+          "name": "num_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_opinion_vote_notification_id_notification_id_fk": {
+          "name": "notification_opinion_vote_notification_id_notification_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_opinion_id_opinion_id_fk": {
+          "name": "notification_opinion_vote_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_conversation_id_conversation_id_fk": {
+          "name": "notification_opinion_vote_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_notification": {
+          "name": "user_idx_notification",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_createdAt_idx": {
+          "name": "notification_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_slug_id_unique": {
+          "name": "notification_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_content": {
+      "name": "opinion_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_content_opinion_id_opinion_id_fk": {
+          "name": "opinion_content_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "opinion_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_moderation": {
+      "name": "opinion_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "opinion_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_moderation_opinion_id_opinion_id_fk": {
+          "name": "opinion_moderation_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_moderation_author_id_user_id_fk": {
+          "name": "opinion_moderation_author_id_user_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_moderation_opinion_id_unique": {
+          "name": "opinion_moderation_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_report": {
+      "name": "opinion_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_id_idx": {
+          "name": "opinion_id_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_report_opinion_id_opinion_id_fk": {
+          "name": "opinion_report_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_report_author_id_user_id_fk": {
+          "name": "opinion_report_author_id_user_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion": {
+      "name": "opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_passes": {
+          "name": "num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_ga_consensus_pa": {
+          "name": "polis_ga_consensus_pa",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_ga_consensus_pd": {
+          "name": "polis_ga_consensus_pd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_priority": {
+          "name": "polis_priority",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_divisiveness": {
+          "name": "polis_divisiveness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cluster_0_id": {
+          "name": "cluster_0_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_num_agrees": {
+          "name": "cluster_0_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_num_disagrees": {
+          "name": "cluster_0_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_num_passes": {
+          "name": "cluster_0_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_id": {
+          "name": "cluster_1_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_num_agrees": {
+          "name": "cluster_1_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_num_disagrees": {
+          "name": "cluster_1_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_num_passes": {
+          "name": "cluster_1_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_id": {
+          "name": "cluster_2_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_num_agrees": {
+          "name": "cluster_2_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_num_disagrees": {
+          "name": "cluster_2_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_num_passes": {
+          "name": "cluster_2_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_id": {
+          "name": "cluster_3_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_num_agrees": {
+          "name": "cluster_3_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_num_disagrees": {
+          "name": "cluster_3_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_num_passes": {
+          "name": "cluster_3_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_id": {
+          "name": "cluster_4_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_num_agrees": {
+          "name": "cluster_4_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_num_disagrees": {
+          "name": "cluster_4_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_num_passes": {
+          "name": "cluster_4_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_id": {
+          "name": "cluster_5_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_num_agrees": {
+          "name": "cluster_5_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_num_disagrees": {
+          "name": "cluster_5_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_num_passes": {
+          "name": "cluster_5_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polis_majority_type": {
+          "name": "polis_majority_type",
+          "type": "vote_enum_simple",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polis_majority_ps": {
+          "name": "polis_majority_ps",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_createdAt_idx": {
+          "name": "opinion_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_slugId_idx": {
+          "name": "opinion_slugId_idx",
+          "columns": [
+            {
+              "expression": "slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_authorId_idx": {
+          "name": "opinion_authorId_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_conversation_active_idx": {
+          "name": "opinion_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_author_id_user_id_fk": {
+          "name": "opinion_author_id_user_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_conversation_id_conversation_id_fk": {
+          "name": "opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_current_content_id_opinion_content_id_fk": {
+          "name": "opinion_current_content_id_opinion_content_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_0_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_0_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_0_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_1_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_1_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_2_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_2_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_3_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_3_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_3_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_4_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_4_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_4_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_5_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_5_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_5_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_slug_id_unique": {
+          "name": "opinion_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_polis_majority": {
+          "name": "check_polis_majority",
+          "value": "(\n            (\"opinion\".\"polis_majority_type\" IS NOT NULL AND \"opinion\".\"polis_majority_ps\" IS NOT NULL)\n            OR\n            (\"opinion\".\"polis_majority_type\" IS NULL AND \"opinion\".\"polis_majority_ps\" IS NULL)\n            )"
+        },
+        "check_polis_null": {
+          "name": "check_polis_null",
+          "value": "((\"opinion\".\"cluster_0_id\" IS NOT NULL AND \"opinion\".\"cluster_0_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_0_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_0_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_0_id\" IS NULL AND \"opinion\".\"cluster_0_num_agrees\" IS NULL AND \"opinion\".\"cluster_0_num_disagrees\" IS NULL AND \"opinion\".\"cluster_0_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_1_id\" IS NOT NULL AND \"opinion\".\"cluster_1_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_1_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_1_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_1_id\" IS NULL AND \"opinion\".\"cluster_1_num_agrees\" IS NULL AND \"opinion\".\"cluster_1_num_disagrees\" IS NULL AND \"opinion\".\"cluster_1_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_2_id\" IS NOT NULL AND \"opinion\".\"cluster_2_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_2_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_2_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_2_id\" IS NULL AND \"opinion\".\"cluster_2_num_agrees\" IS NULL AND \"opinion\".\"cluster_2_num_disagrees\" IS NULL AND \"opinion\".\"cluster_2_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_3_id\" IS NOT NULL AND \"opinion\".\"cluster_3_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_3_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_3_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_3_id\" IS NULL AND \"opinion\".\"cluster_3_num_agrees\" IS NULL AND \"opinion\".\"cluster_3_num_disagrees\" IS NULL AND \"opinion\".\"cluster_3_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_4_id\" IS NOT NULL AND \"opinion\".\"cluster_4_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_4_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_4_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_4_id\" IS NULL AND \"opinion\".\"cluster_4_num_agrees\" IS NULL AND \"opinion\".\"cluster_4_num_disagrees\" IS NULL AND \"opinion\".\"cluster_4_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_5_id\" IS NOT NULL AND \"opinion\".\"cluster_5_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_5_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_5_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_5_id\" IS NULL AND \"opinion\".\"cluster_5_num_agrees\" IS NULL AND \"opinion\".\"cluster_5_num_disagrees\" IS NULL AND \"opinion\".\"cluster_5_num_passes\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_full_image_path": {
+          "name": "is_full_image_path",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_name_unique": {
+          "name": "organization_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "organization_website_url_unique": {
+          "name": "organization_website_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_email_destination_state": {
+      "name": "otp_email_destination_state",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failed_verify_attempts": {
+          "name": "consecutive_failed_verify_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff_until": {
+          "name": "backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otp_email_destination_updated_idx": {
+          "name": "otp_email_destination_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "otp_email_destination_canonical_check": {
+          "name": "otp_email_destination_canonical_check",
+          "value": "\"otp_email_destination_state\".\"email\" = lower(btrim(\"otp_email_destination_state\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.otp_phone_destination_state": {
+      "name": "otp_phone_destination_state",
+      "schema": "",
+      "columns": {
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failed_verify_attempts": {
+          "name": "consecutive_failed_verify_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff_until": {
+          "name": "backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otp_phone_destination_updated_idx": {
+          "name": "otp_phone_destination_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phone": {
+      "name": "phone",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "phone_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phone_hash_active_unique": {
+          "name": "phone_hash_active_unique",
+          "columns": [
+            {
+              "expression": "phone_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"phone\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phone_hash_idx": {
+          "name": "phone_hash_idx",
+          "columns": [
+            {
+              "expression": "phone_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phone_user_id_user_id_fk": {
+          "name": "phone_user_id_user_id_fk",
+          "tableFrom": "phone",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster_opinion": {
+      "name": "polis_cluster_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_content_id": {
+          "name": "polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polis_cluster_id": {
+          "name": "polis_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_type": {
+          "name": "agreement_type",
+          "type": "vote_enum_simple",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability_agreement": {
+          "name": "probability_agreement",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_agreement": {
+          "name": "number_agreement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_repness": {
+          "name": "raw_repness",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "polis_cluster_opinion_opinionId_idx": {
+          "name": "polis_cluster_opinion_opinionId_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "polis_cluster_opinion_polisClusterId_idx": {
+          "name": "polis_cluster_opinion_polisClusterId_idx",
+          "columns": [
+            {
+              "expression": "polis_cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "polis_cluster_opinion_polis_content_id_polis_content_id_fk": {
+          "name": "polis_cluster_opinion_polis_content_id_polis_content_id_fk",
+          "tableFrom": "polis_cluster_opinion",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_opinion_polis_cluster_id_polis_cluster_id_fk": {
+          "name": "polis_cluster_opinion_polis_cluster_id_polis_cluster_id_fk",
+          "tableFrom": "polis_cluster_opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "polis_cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_opinion_opinion_id_opinion_id_fk": {
+          "name": "polis_cluster_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "polis_cluster_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_perc_btwn_0_and_1": {
+          "name": "check_perc_btwn_0_and_1",
+          "value": "\"polis_cluster_opinion\".\"probability_agreement\" BETWEEN 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster": {
+      "name": "polis_cluster",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_content_id": {
+          "name": "polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "polis_key_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_users": {
+          "name": "num_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_label": {
+          "name": "ai_label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_polis_content_id_polis_content_id_fk": {
+          "name": "polis_cluster_polis_content_id_polis_content_id_fk",
+          "tableFrom": "polis_cluster",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster_translation": {
+      "name": "polis_cluster_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_cluster_id": {
+          "name": "polis_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_label": {
+          "name": "ai_label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_translation_polis_cluster_id_polis_cluster_id_fk": {
+          "name": "polis_cluster_translation_polis_cluster_id_polis_cluster_id_fk",
+          "tableFrom": "polis_cluster_translation",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "polis_cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_cluster_language": {
+          "name": "unique_cluster_language",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polis_cluster_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster_user": {
+      "name": "polis_cluster_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_content_id": {
+          "name": "polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polis_cluster_id": {
+          "name": "polis_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_user_polis_content_id_polis_content_id_fk": {
+          "name": "polis_cluster_user_polis_content_id_polis_content_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_user_polis_cluster_id_polis_cluster_id_fk": {
+          "name": "polis_cluster_user_polis_cluster_id_polis_cluster_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "polis_cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_user_user_id_user_id_fk": {
+          "name": "polis_cluster_user_user_id_user_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_belong_per_conv_at_a_time": {
+          "name": "unique_belong_per_conv_at_a_time",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polis_content_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polis_content": {
+      "name": "polis_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_content_conversation_id_conversation_id_fk": {
+          "name": "polis_content_conversation_id_conversation_id_fk",
+          "tableFrom": "polis_content",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_score_entity": {
+      "name": "ranking_score_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ranking_score_entity_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ranking_score_id": {
+          "name": "ranking_score_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug_id": {
+          "name": "entity_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_left": {
+          "name": "uncertainty_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_right": {
+          "name": "uncertainty_right",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ranking_score_entity_score_idx": {
+          "name": "ranking_score_entity_score_idx",
+          "columns": [
+            {
+              "expression": "ranking_score_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ranking_score_entity_slug_idx": {
+          "name": "ranking_score_entity_slug_idx",
+          "columns": [
+            {
+              "expression": "ranking_score_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ranking_score_entity_ranking_score_id_ranking_score_id_fk": {
+          "name": "ranking_score_entity_ranking_score_id_ranking_score_id_fk",
+          "tableFrom": "ranking_score_entity",
+          "tableTo": "ranking_score",
+          "columnsFrom": [
+            "ranking_score_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_score": {
+      "name": "ranking_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ranking_score_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_counts": {
+          "name": "participant_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_sources_snapshot": {
+          "name": "group_sources_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_weights_snapshot": {
+          "name": "user_weights_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_learning": {
+          "name": "preference_learning",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_rights": {
+          "name": "voting_rights",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregation_config": {
+          "name": "aggregation_config",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_score_conversation_id_conversation_id_fk": {
+          "name": "ranking_score_conversation_id_conversation_id_fk",
+          "tableFrom": "ranking_score",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answer_option": {
+      "name": "survey_answer_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_answer_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_answer_id": {
+          "name": "survey_answer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_answer_option_answer_option_active_uidx": {
+          "name": "survey_answer_option_answer_option_active_uidx",
+          "columns": [
+            {
+              "expression": "survey_answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "survey_question_option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_answer_option\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_option_survey_answer_id_survey_answer_id_fk": {
+          "name": "survey_answer_option_survey_answer_id_survey_answer_id_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_answer",
+          "columnsFrom": [
+            "survey_answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_answer_option_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_answer_question_fk": {
+          "name": "survey_answer_option_answer_question_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_answer",
+          "columnsFrom": [
+            "survey_answer_id",
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "survey_question_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_option_question_fk": {
+          "name": "survey_answer_option_option_question_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id",
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "survey_question_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answer": {
+      "name": "survey_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_answer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_response_id": {
+          "name": "survey_response_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_question_semantic_version": {
+          "name": "answered_question_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_value_html": {
+          "name": "text_value_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_answer_response_question_active_uidx": {
+          "name": "survey_answer_response_question_active_uidx",
+          "columns": [
+            {
+              "expression": "survey_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "survey_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_answer\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_survey_response_id_survey_response_id_fk": {
+          "name": "survey_answer_survey_response_id_survey_response_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "columnsFrom": [
+            "survey_response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_survey_question_id_survey_question_id_fk": {
+          "name": "survey_answer_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_response_conversation_fk": {
+          "name": "survey_answer_response_conversation_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "columnsFrom": [
+            "survey_response_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_question_conversation_fk": {
+          "name": "survey_answer_question_conversation_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_answer_id_question_unique": {
+          "name": "survey_answer_id_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "survey_question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_config": {
+      "name": "survey_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_config_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision": {
+          "name": "current_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_config_active_conversation_uidx": {
+          "name": "survey_config_active_conversation_uidx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_config\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_config_conversation_id_conversation_id_fk": {
+          "name": "survey_config_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_config",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_config_id_conversation_unique": {
+          "name": "survey_config_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_content": {
+      "name": "survey_question_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constraints": {
+          "name": "constraints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language_code": {
+          "name": "source_language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_language_confidence": {
+          "name": "source_language_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_content_survey_question_id_survey_question_id_fk": {
+          "name": "survey_question_content_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_question_content",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_content_translation": {
+      "name": "survey_question_content_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_content_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_content_id": {
+          "name": "survey_question_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_language_code": {
+          "name": "display_language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_question_text": {
+          "name": "translated_question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_content_translation_survey_question_content_id_survey_question_content_id_fk": {
+          "name": "survey_question_content_translation_survey_question_content_id_survey_question_content_id_fk",
+          "tableFrom": "survey_question_content_translation",
+          "tableTo": "survey_question_content",
+          "columnsFrom": [
+            "survey_question_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_content_translation_unique": {
+          "name": "survey_question_content_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_question_content_id",
+            "display_language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option_content": {
+      "name": "survey_question_option_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language_code": {
+          "name": "source_language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_language_confidence": {
+          "name": "source_language_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_option_content_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_question_option_content_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_question_option_content",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option_content_translation": {
+      "name": "survey_question_option_content_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_content_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_option_content_id": {
+          "name": "survey_question_option_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_language_code": {
+          "name": "display_language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_option_text": {
+          "name": "translated_option_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_option_content_translation_survey_question_option_content_id_survey_question_option_content_id_fk": {
+          "name": "survey_question_option_content_translation_survey_question_option_content_id_survey_question_option_content_id_fk",
+          "tableFrom": "survey_question_option_content_translation",
+          "tableTo": "survey_question_option_content",
+          "columnsFrom": [
+            "survey_question_option_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_option_content_translation_unique": {
+          "name": "survey_question_option_content_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_question_option_content_id",
+            "display_language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option": {
+      "name": "survey_question_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_option_active_question_display_order_uidx": {
+          "name": "survey_question_option_active_question_display_order_uidx",
+          "columns": [
+            {
+              "expression": "survey_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_question_option\".\"current_content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_option_survey_question_id_survey_question_id_fk": {
+          "name": "survey_question_option_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_question_option",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_option_current_content_id_survey_question_option_content_id_fk": {
+          "name": "survey_question_option_current_content_id_survey_question_option_content_id_fk",
+          "tableFrom": "survey_question_option",
+          "tableTo": "survey_question_option_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_option_slug_id_unique": {
+          "name": "survey_question_option_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "survey_question_option_current_content_id_unique": {
+          "name": "survey_question_option_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "survey_question_option_id_question_unique": {
+          "name": "survey_question_option_id_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "survey_question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question": {
+      "name": "survey_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_config_id": {
+          "name": "survey_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "choice_display": {
+          "name": "choice_display",
+          "type": "survey_choice_display",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_semantic_version": {
+          "name": "current_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_active_config_display_order_uidx": {
+          "name": "survey_question_active_config_display_order_uidx",
+          "columns": [
+            {
+              "expression": "survey_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_question\".\"current_content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_config_idx": {
+          "name": "survey_question_config_idx",
+          "columns": [
+            {
+              "expression": "survey_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_survey_config_id_survey_config_id_fk": {
+          "name": "survey_question_survey_config_id_survey_config_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_conversation_id_conversation_id_fk": {
+          "name": "survey_question_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_current_content_id_survey_question_content_id_fk": {
+          "name": "survey_question_current_content_id_survey_question_content_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_question_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_config_conversation_fk": {
+          "name": "survey_question_config_conversation_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_slug_id_unique": {
+          "name": "survey_question_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "survey_question_current_content_id_unique": {
+          "name": "survey_question_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "survey_question_id_conversation_unique": {
+          "name": "survey_question_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_response": {
+      "name": "survey_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_response_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_response_conversation_created_idx": {
+          "name": "survey_response_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_response_participant_id_user_id_fk": {
+          "name": "survey_response_participant_id_user_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_response_conversation_id_conversation_id_fk": {
+          "name": "survey_response_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_response_conversation_participant_unique": {
+          "name": "survey_response_conversation_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        },
+        "survey_response_id_conversation_unique": {
+          "name": "survey_response_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_weight": {
+          "name": "score_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_code_unique": {
+          "name": "topic_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "topic_name_unique": {
+          "name": "topic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "topic_description_unique": {
+          "name": "topic_description_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_display_language": {
+      "name": "user_display_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_display_language_user_idx": {
+          "name": "user_display_language_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_display_language_user_id_user_id_fk": {
+          "name": "user_display_language_user_id_user_id_fk",
+          "tableFrom": "user_display_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_display_language_unique": {
+          "name": "user_display_language_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mute_preference": {
+      "name": "user_mute_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_mute_preference_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_mute": {
+          "name": "user_idx_mute",
+          "columns": [
+            {
+              "expression": "source_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mute_preference_source_user_id_user_id_fk": {
+          "name": "user_mute_preference_source_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_mute_preference_target_user_id_user_id_fk": {
+          "name": "user_mute_preference_target_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_unique_mute": {
+          "name": "user_unique_mute",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_user_id",
+            "target_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organization_mapping": {
+      "name": "user_organization_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_organization_mapping_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_organization": {
+          "name": "user_idx_organization",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_organization_mapping_user_id_user_id_fk": {
+          "name": "user_organization_mapping_user_id_user_id_fk",
+          "tableFrom": "user_organization_mapping",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_organization_mapping_organization_id_organization_id_fk": {
+          "name": "user_organization_mapping_organization_id_organization_id_fk",
+          "tableFrom": "user_organization_mapping",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_orgaization_mapping": {
+          "name": "unique_user_orgaization_mapping",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_spoken_languages": {
+      "name": "user_spoken_languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_spoken_languages_user_idx": {
+          "name": "user_spoken_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_spoken_languages_user_id_user_id_fk": {
+          "name": "user_spoken_languages_user_id_user_id_fk",
+          "tableFrom": "user_spoken_languages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_spoken_languages_unique": {
+          "name": "user_spoken_languages_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "polis_participant_id": {
+          "name": "polis_participant_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_site_moderator": {
+          "name": "is_site_moderator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_site_org_admin": {
+          "name": "is_site_org_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_imported": {
+          "name": "is_imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_conversation_count": {
+          "name": "active_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_conversation_count": {
+          "name": "total_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_isDeleted_idx": {
+          "name": "user_isDeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_content": {
+      "name": "vote_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_content_id": {
+          "name": "opinion_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "vote_enum_all",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vote_content_vote_id_vote_id_fk": {
+          "name": "vote_content_vote_id_vote_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "vote",
+          "columnsFrom": [
+            "vote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_content_opinion_content_id_opinion_content_id_fk": {
+          "name": "vote_content_opinion_content_id_opinion_content_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "opinion_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polis_vote_id": {
+          "name": "polis_vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vote_authorId_idx": {
+          "name": "vote_authorId_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_opinion_active_idx": {
+          "name": "vote_opinion_active_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_author_id_user_id_fk": {
+          "name": "vote_author_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_opinion_id_opinion_id_fk": {
+          "name": "vote_opinion_id_opinion_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_current_content_id_vote_content_id_fk": {
+          "name": "vote_current_content_id_vote_content_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "vote_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vote_author_id_opinion_id_unique": {
+          "name": "vote_author_id_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_id",
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zk_passport": {
+      "name": "zk_passport",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "zk_passport_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citizenship": {
+          "name": "citizenship",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sex": {
+          "name": "sex",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zk_passport_nullifier_active_unique": {
+          "name": "zk_passport_nullifier_active_unique",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zk_passport\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zk_passport_nullifier_idx": {
+          "name": "zk_passport_nullifier_idx",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zk_passport_user_id_user_id_fk": {
+          "name": "zk_passport_user_id_user_id_fk",
+          "tableFrom": "zk_passport",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_type": {
+      "name": "auth_type",
+      "schema": "public",
+      "values": [
+        "register",
+        "login_known_device",
+        "login_new_device",
+        "merge",
+        "restore_deleted",
+        "restore_and_merge"
+      ]
+    },
+    "public.conversation_moderation_action": {
+      "name": "conversation_moderation_action",
+      "schema": "public",
+      "values": [
+        "lock"
+      ]
+    },
+    "public.conversation_type": {
+      "name": "conversation_type",
+      "schema": "public",
+      "values": [
+        "polis",
+        "maxdiff"
+      ]
+    },
+    "public.email_reachability": {
+      "name": "email_reachability",
+      "schema": "public",
+      "values": [
+        "safe",
+        "risky",
+        "invalid",
+        "unknown"
+      ]
+    },
+    "public.email_type": {
+      "name": "email_type",
+      "schema": "public",
+      "values": [
+        "primary",
+        "backup",
+        "secondary",
+        "other"
+      ]
+    },
+    "public.event_slug": {
+      "name": "event_slug",
+      "schema": "public",
+      "values": [
+        "devconnect-2025"
+      ]
+    },
+    "public.export_artifact_status_enum": {
+      "name": "export_artifact_status_enum",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.export_cancellation_reason_enum": {
+      "name": "export_cancellation_reason_enum",
+      "schema": "public",
+      "values": [
+        "duplicate_in_batch",
+        "cooldown_active"
+      ]
+    },
+    "public.export_failure_reason_enum": {
+      "name": "export_failure_reason_enum",
+      "schema": "public",
+      "values": [
+        "processing_error",
+        "timeout",
+        "server_restart"
+      ]
+    },
+    "public.export_file_audience_enum": {
+      "name": "export_file_audience_enum",
+      "schema": "public",
+      "values": [
+        "redacted",
+        "owner",
+        "requester"
+      ]
+    },
+    "public.export_file_type_enum": {
+      "name": "export_file_type_enum",
+      "schema": "public",
+      "values": [
+        "bundle",
+        "comments",
+        "votes",
+        "participants",
+        "summary",
+        "stats",
+        "survey_questions",
+        "survey_question_options",
+        "survey_participant_responses",
+        "survey_public_aggregates",
+        "survey_full_aggregates"
+      ]
+    },
+    "public.export_generation_status_enum": {
+      "name": "export_generation_status_enum",
+      "schema": "public",
+      "values": [
+        "collecting",
+        "queued",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.export_status_enum": {
+      "name": "export_status_enum",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.external_source_type": {
+      "name": "external_source_type",
+      "schema": "public",
+      "values": [
+        "github_issue"
+      ]
+    },
+    "public.import_failure_reason_enum": {
+      "name": "import_failure_reason_enum",
+      "schema": "public",
+      "values": [
+        "processing_error",
+        "timeout",
+        "server_restart",
+        "invalid_data_format"
+      ]
+    },
+    "public.import_method": {
+      "name": "import_method",
+      "schema": "public",
+      "values": [
+        "url",
+        "csv"
+      ]
+    },
+    "public.import_status_enum": {
+      "name": "import_status_enum",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.maxdiff_lifecycle_status": {
+      "name": "maxdiff_lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "in_progress",
+        "canceled"
+      ]
+    },
+    "public.moderation_reason_enum": {
+      "name": "moderation_reason_enum",
+      "schema": "public",
+      "values": [
+        "misleading",
+        "antisocial",
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "opinion_vote",
+        "new_opinion",
+        "export_started",
+        "export_completed",
+        "export_failed",
+        "export_cancelled",
+        "import_started",
+        "import_completed",
+        "import_failed"
+      ]
+    },
+    "public.opinion_moderation_action": {
+      "name": "opinion_moderation_action",
+      "schema": "public",
+      "values": [
+        "move",
+        "hide"
+      ]
+    },
+    "public.participation_mode": {
+      "name": "participation_mode",
+      "schema": "public",
+      "values": [
+        "account_required",
+        "strong_verification",
+        "email_verification",
+        "guest"
+      ]
+    },
+    "public.phone_country_code": {
+      "name": "phone_country_code",
+      "schema": "public",
+      "values": [
+        "AC",
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AO",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NU",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TA",
+        "TC",
+        "TD",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "XK",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW"
+      ]
+    },
+    "public.polis_key_enum": {
+      "name": "polis_key_enum",
+      "schema": "public",
+      "values": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5"
+      ]
+    },
+    "public.report_reason_enum": {
+      "name": "report_reason_enum",
+      "schema": "public",
+      "values": [
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam",
+        "misleading",
+        "antisocial"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "F",
+        "M",
+        "X"
+      ]
+    },
+    "public.survey_choice_display": {
+      "name": "survey_choice_display",
+      "schema": "public",
+      "values": [
+        "auto",
+        "list",
+        "dropdown"
+      ]
+    },
+    "public.survey_question_type": {
+      "name": "survey_question_type",
+      "schema": "public",
+      "values": [
+        "choice",
+        "free_text"
+      ]
+    },
+    "public.ticket_provider": {
+      "name": "ticket_provider",
+      "schema": "public",
+      "values": [
+        "zupass"
+      ]
+    },
+    "public.vote_enum_all": {
+      "name": "vote_enum_all",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree",
+        "pass"
+      ]
+    },
+    "public.vote_enum_simple": {
+      "name": "vote_enum_simple",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1777075824732,
       "tag": "0058_majestic_inertia",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1777301654418,
+      "tag": "0059_dapper_xavin",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -1337,6 +1337,9 @@
                                                                     "hasSurvey": {
                                                                         "type": "boolean"
                                                                     },
+                                                                    "isOptional": {
+                                                                        "type": "boolean"
+                                                                    },
                                                                     "canParticipate": {
                                                                         "type": "boolean"
                                                                     },
@@ -1353,6 +1356,7 @@
                                                                 },
                                                                 "required": [
                                                                     "hasSurvey",
+                                                                    "isOptional",
                                                                     "canParticipate",
                                                                     "status"
                                                                 ],
@@ -2262,6 +2266,9 @@
                                                             "hasSurvey": {
                                                                 "type": "boolean"
                                                             },
+                                                            "isOptional": {
+                                                                "type": "boolean"
+                                                            },
                                                             "canParticipate": {
                                                                 "type": "boolean"
                                                             },
@@ -2278,6 +2285,7 @@
                                                         },
                                                         "required": [
                                                             "hasSurvey",
+                                                            "isOptional",
                                                             "canParticipate",
                                                             "status"
                                                         ],
@@ -2642,6 +2650,9 @@
                                                                     "hasSurvey": {
                                                                         "type": "boolean"
                                                                     },
+                                                                    "isOptional": {
+                                                                        "type": "boolean"
+                                                                    },
                                                                     "canParticipate": {
                                                                         "type": "boolean"
                                                                     },
@@ -2658,6 +2669,7 @@
                                                                 },
                                                                 "required": [
                                                                     "hasSurvey",
+                                                                    "isOptional",
                                                                     "canParticipate",
                                                                     "status"
                                                                 ],
@@ -5444,6 +5456,10 @@
                                         "nullable": true,
                                         "type": "object",
                                         "properties": {
+                                            "isOptional": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            },
                                             "questions": {
                                                 "type": "array",
                                                 "items": {
@@ -6412,6 +6428,9 @@
                                                                 "hasSurvey": {
                                                                     "type": "boolean"
                                                                 },
+                                                                "isOptional": {
+                                                                    "type": "boolean"
+                                                                },
                                                                 "canParticipate": {
                                                                     "type": "boolean"
                                                                 },
@@ -6428,6 +6447,7 @@
                                                             },
                                                             "required": [
                                                                 "hasSurvey",
+                                                                "isOptional",
                                                                 "canParticipate",
                                                                 "status"
                                                             ],
@@ -6536,6 +6556,10 @@
                                                     "nullable": true,
                                                     "type": "object",
                                                     "properties": {
+                                                        "isOptional": {
+                                                            "default": false,
+                                                            "type": "boolean"
+                                                        },
                                                         "questions": {
                                                             "type": "array",
                                                             "items": {
@@ -6767,6 +6791,7 @@
                                                         }
                                                     },
                                                     "required": [
+                                                        "isOptional",
                                                         "questions"
                                                     ],
                                                     "additionalProperties": false
@@ -6874,6 +6899,10 @@
                                         "nullable": true,
                                         "type": "object",
                                         "properties": {
+                                            "isOptional": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            },
                                             "questions": {
                                                 "type": "array",
                                                 "items": {
@@ -7598,6 +7627,9 @@
                                                 "hasSurvey": {
                                                     "type": "boolean"
                                                 },
+                                                "isOptional": {
+                                                    "type": "boolean"
+                                                },
                                                 "canParticipate": {
                                                     "type": "boolean"
                                                 },
@@ -7614,6 +7646,7 @@
                                             },
                                             "required": [
                                                 "hasSurvey",
+                                                "isOptional",
                                                 "canParticipate",
                                                 "status"
                                             ],
@@ -7669,6 +7702,9 @@
                                                 "hasSurvey": {
                                                     "type": "boolean"
                                                 },
+                                                "isOptional": {
+                                                    "type": "boolean"
+                                                },
                                                 "canParticipate": {
                                                     "type": "boolean"
                                                 },
@@ -7685,6 +7721,7 @@
                                             },
                                             "required": [
                                                 "hasSurvey",
+                                                "isOptional",
                                                 "canParticipate",
                                                 "status"
                                             ],
@@ -7855,6 +7892,9 @@
                                                         "hasSurvey": {
                                                             "type": "boolean"
                                                         },
+                                                        "isOptional": {
+                                                            "type": "boolean"
+                                                        },
                                                         "canParticipate": {
                                                             "type": "boolean"
                                                         },
@@ -7871,6 +7911,7 @@
                                                     },
                                                     "required": [
                                                         "hasSurvey",
+                                                        "isOptional",
                                                         "canParticipate",
                                                         "status"
                                                     ],
@@ -7968,6 +8009,9 @@
                                                         "hasSurvey": {
                                                             "type": "boolean"
                                                         },
+                                                        "isOptional": {
+                                                            "type": "boolean"
+                                                        },
                                                         "canParticipate": {
                                                             "type": "boolean"
                                                         },
@@ -7984,6 +8028,7 @@
                                                     },
                                                     "required": [
                                                         "hasSurvey",
+                                                        "isOptional",
                                                         "canParticipate",
                                                         "status"
                                                     ],
@@ -8049,6 +8094,10 @@
                                     "surveyConfig": {
                                         "type": "object",
                                         "properties": {
+                                            "isOptional": {
+                                                "default": false,
+                                                "type": "boolean"
+                                            },
                                             "questions": {
                                                 "type": "array",
                                                 "items": {
@@ -8312,6 +8361,9 @@
                                                 "hasSurvey": {
                                                     "type": "boolean"
                                                 },
+                                                "isOptional": {
+                                                    "type": "boolean"
+                                                },
                                                 "canParticipate": {
                                                     "type": "boolean"
                                                 },
@@ -8328,6 +8380,7 @@
                                             },
                                             "required": [
                                                 "hasSurvey",
+                                                "isOptional",
                                                 "canParticipate",
                                                 "status"
                                             ],

--- a/services/api/src/service/conversationExport/generators/surveyShared.test.ts
+++ b/services/api/src/service/conversationExport/generators/surveyShared.test.ts
@@ -19,6 +19,7 @@ import {
 const surveyConfig: ActiveSurveyConfigRecord = {
     id: 1,
     currentRevision: 1,
+    isOptional: false,
     questions: [
         {
             id: 11,

--- a/services/api/src/service/conversationExport/generators/surveyShared.ts
+++ b/services/api/src/service/conversationExport/generators/surveyShared.ts
@@ -725,10 +725,12 @@ export function buildSurveyAggregateRows({
     }
     const exportMetadata = buildSurveyExportMetadata({ activeSurveyConfig });
 
-    const countedParticipantStates = context.participantStates.filter(
-        (participantState) =>
-            participantState.surveyGate.status === "complete_valid",
-    );
+    const countedParticipantStates = activeSurveyConfig.isOptional
+        ? context.participantStates
+        : context.participantStates.filter(
+              (participantState) =>
+                  participantState.surveyGate.status === "complete_valid",
+          );
     const rows: PublicSurveyAggregateRow[] = [];
 
     for (const question of exportMetadata.questionsInExportOrder) {
@@ -745,6 +747,7 @@ export function buildSurveyAggregateRows({
                         participantState.surveyState.answersByQuestionId.get(
                             question.id,
                         ),
+                    surveyIsOptional: activeSurveyConfig.isOptional,
                 }),
             }))
             .filter(
@@ -865,10 +868,12 @@ export function buildSurveyAggregateCsvRows({
     }
     const exportMetadata = buildSurveyExportMetadata({ activeSurveyConfig });
 
-    const countedParticipantStates = context.participantStates.filter(
-        (participantState) =>
-            participantState.surveyGate.status === "complete_valid",
-    );
+    const countedParticipantStates = activeSurveyConfig.isOptional
+        ? context.participantStates
+        : context.participantStates.filter(
+              (participantState) =>
+                  participantState.surveyGate.status === "complete_valid",
+          );
     const rows: SurveyAggregateCsvRow[] = [];
 
     for (const question of exportMetadata.questionsInExportOrder) {
@@ -889,6 +894,7 @@ export function buildSurveyAggregateCsvRows({
                         participantState.surveyState.answersByQuestionId.get(
                             question.id,
                         ),
+                    surveyIsOptional: activeSurveyConfig.isOptional,
                 }),
             }))
             .filter(
@@ -1065,12 +1071,14 @@ export function buildSurveyParticipantResponseRows({
                     participantState.surveyState.answersByQuestionId.get(
                         question.id,
                     ),
+                surveyIsOptional: activeSurveyConfig.isOptional,
             });
 
             const baseRow = {
                 "participant-id": exportParticipantId,
                 "response-status": participantState.surveyGate.status,
                 "is-currently-counted":
+                    activeSurveyConfig.isOptional ||
                     participantState.surveyGate.status === "complete_valid"
                         ? 1
                         : 0,

--- a/services/api/src/service/participationGate.test.ts
+++ b/services/api/src/service/participationGate.test.ts
@@ -178,4 +178,13 @@ describe("getParticipationBlockedReasonFromSurveyGateStatus", () => {
             }),
         ).toBeUndefined();
     });
+
+    it("returns no block reason for optional surveys", () => {
+        expect(
+            getParticipationBlockedReasonFromSurveyGateStatus({
+                surveyGateStatus: "not_started",
+                isOptional: true,
+            }),
+        ).toBeUndefined();
+    });
 });

--- a/services/api/src/service/participationGate.ts
+++ b/services/api/src/service/participationGate.ts
@@ -63,9 +63,15 @@ function requiresRegisteredLoggedInUser({
 
 export function getParticipationBlockedReasonFromSurveyGateStatus({
     surveyGateStatus,
+    isOptional = false,
 }: {
     surveyGateStatus: SurveyGateStatus;
+    isOptional?: boolean;
 }): ParticipationBlockedReason | undefined {
+    if (isOptional) {
+        return undefined;
+    }
+
     switch (surveyGateStatus) {
         case "needs_update":
             return "survey_outdated";
@@ -280,6 +286,7 @@ export async function checkConversationParticipation({
         const surveyBlockedReason = getParticipationBlockedReasonFromSurveyGateStatus(
             {
                 surveyGateStatus: surveyGate.status,
+                isOptional: surveyGate.isOptional,
             },
         );
         if (surveyBlockedReason !== undefined) {

--- a/services/api/src/service/survey.test.ts
+++ b/services/api/src/service/survey.test.ts
@@ -84,14 +84,17 @@ function createPassedAnswer({
 function createSurveyState({
     questions,
     answersByQuestionId = new Map(),
+    isOptional = false,
 }: {
     questions: ActiveSurveyQuestionRecord[];
     answersByQuestionId?: Map<number, StoredSurveyAnswer>;
+    isOptional?: boolean;
 }): SurveyParticipantState {
     return {
         activeSurveyConfig: {
             id: 1,
             currentRevision: 1,
+            isOptional,
             questions,
         },
         response: undefined,
@@ -100,6 +103,28 @@ function createSurveyState({
 }
 
 describe("deriveSurveyRouteResolution", () => {
+    it("does not gate participation when the whole survey is optional", async () => {
+        const { deriveSurveyGate } = await surveyModulePromise;
+        const requiredQuestion = createFreeTextQuestion({
+            id: 1,
+            slugId: "required-question",
+            isRequired: true,
+            displayOrder: 0,
+        });
+
+        const result = deriveSurveyGate({
+            surveyState: createSurveyState({
+                questions: [requiredQuestion],
+                isOptional: true,
+            }),
+            participantId: "participant-1",
+        });
+
+        expect(result.canParticipate).toBe(true);
+        expect(result.requiredQuestionCount).toBe(0);
+        expect(result.status).toBe("not_started");
+    });
+
     it("routes to the first untouched optional question before later required questions", async () => {
         const { deriveSurveyRouteResolution } = await surveyModulePromise;
         const optionalQuestion = createFreeTextQuestion({
@@ -192,6 +217,25 @@ describe("deriveSurveyQuestionFormItem", () => {
             questionType: "free_text",
             textValueHtml: "Saved answer",
         });
+    });
+
+    it("presents required questions as optional when the whole survey is optional", async () => {
+        const { deriveSurveyQuestionFormItem } = await surveyModulePromise;
+        const requiredQuestion = createFreeTextQuestion({
+            id: 1,
+            slugId: "required-question",
+            isRequired: true,
+            displayOrder: 0,
+        });
+
+        const formItem = deriveSurveyQuestionFormItem({
+            question: requiredQuestion,
+            storedAnswer: undefined,
+            surveyIsOptional: true,
+        });
+
+        expect(formItem.isRequired).toBe(false);
+        expect(formItem.isMissingRequired).toBe(false);
     });
 });
 

--- a/services/api/src/service/survey.ts
+++ b/services/api/src/service/survey.ts
@@ -138,6 +138,7 @@ interface SurveyConfigUpdateEffect {
 
 interface InternalSurveyGateSummary {
     hasSurvey: boolean;
+    isOptional: boolean;
     canParticipate: boolean;
     status: InternalSurveyGateStatus;
 }
@@ -221,6 +222,7 @@ function toSurveyGateDto({
 }): SurveyGateSummary {
     return {
         hasSurvey: surveyGate.hasSurvey,
+        isOptional: surveyGate.isOptional,
         canParticipate: surveyGate.canParticipate,
         status:
             surveyGate.status === "withdrawn"
@@ -258,6 +260,7 @@ export interface ActiveSurveyQuestionRecord {
 export interface ActiveSurveyConfigRecord {
     id: number;
     currentRevision: number;
+    isOptional: boolean;
     questions: ActiveSurveyQuestionRecord[];
 }
 
@@ -285,6 +288,23 @@ function isStoredSurveyAnswerPassed({
         storedAnswer.optionSlugIds.length === 0 &&
         htmlToCountedText(storedAnswer.textValueHtml ?? "").length === 0
     );
+}
+
+function getParticipantSurveyQuestion({
+    question,
+    surveyIsOptional,
+}: {
+    question: ActiveSurveyQuestionRecord;
+    surveyIsOptional: boolean;
+}): ActiveSurveyQuestionRecord {
+    if (!surveyIsOptional || !question.isRequired) {
+        return question;
+    }
+
+    return {
+        ...question,
+        isRequired: false,
+    };
 }
 
 function isSurveyQuestionCompleted({
@@ -560,42 +580,48 @@ export function validateSurveyAnswer({
 export function deriveSurveyQuestionFormItem({
     question,
     storedAnswer,
+    surveyIsOptional = false,
 }: {
     question: ActiveSurveyQuestionRecord;
     storedAnswer: StoredSurveyAnswer | undefined;
+    surveyIsOptional?: boolean;
 }): SurveyQuestionFormItem {
+    const effectiveQuestion = getParticipantSurveyQuestion({
+        question,
+        surveyIsOptional,
+    });
     const candidateAnswer =
         storedAnswer === undefined
             ? undefined
             : surveyQuestionToAnswerDraft({
-                  question,
+                  question: effectiveQuestion,
                   storedAnswer,
               });
     const isPassed =
         storedAnswer !== undefined &&
-        isStoredSurveyAnswerPassed({ question, storedAnswer });
+        isStoredSurveyAnswerPassed({ question: effectiveQuestion, storedAnswer });
     const isStale =
-        question.isRequired &&
+        effectiveQuestion.isRequired &&
         storedAnswer !== undefined &&
         !isPassed &&
         candidateAnswer !== undefined &&
         (storedAnswer.answeredQuestionSemanticVersion !==
-            question.currentSemanticVersion ||
-            !validateSurveyAnswer({ question, answer: candidateAnswer }));
+            effectiveQuestion.currentSemanticVersion ||
+            !validateSurveyAnswer({ question: effectiveQuestion, answer: candidateAnswer }));
     const currentAnswer = isStale ? undefined : candidateAnswer;
     const isCurrentAnswerValid =
         currentAnswer !== undefined &&
-        validateSurveyAnswer({ question, answer: currentAnswer });
+        validateSurveyAnswer({ question: effectiveQuestion, answer: currentAnswer });
 
     return {
-        ...surveyQuestionToConfig({ question }),
+        ...surveyQuestionToConfig({ question: effectiveQuestion }),
         currentAnswer,
         isPassed,
         isMissingRequired:
-            question.isRequired && !isCurrentAnswerValid && !isStale,
+            effectiveQuestion.isRequired && !isCurrentAnswerValid && !isStale,
         isStale,
         isCurrentAnswerValid,
-        currentSemanticVersion: question.currentSemanticVersion,
+        currentSemanticVersion: effectiveQuestion.currentSemanticVersion,
         answeredQuestionSemanticVersion: isStale
             ? undefined
             : storedAnswer?.answeredQuestionSemanticVersion,
@@ -613,6 +639,7 @@ export function deriveSurveyGate({
     if (activeSurveyConfig === undefined) {
         return {
             hasSurvey: false,
+            isOptional: false,
             canParticipate: true,
             status: "no_survey",
             requiredQuestionCount: 0,
@@ -621,10 +648,12 @@ export function deriveSurveyGate({
         };
     }
 
+    const surveyIsOptional = activeSurveyConfig.isOptional;
     const requiredQuestions = activeSurveyConfig.questions.filter(
         (question) => question.isRequired,
     );
     const requiresSurveyCompletion = doesSurveyRequireCompletion({
+        isOptional: surveyIsOptional,
         requiredQuestionCount: requiredQuestions.length,
     });
 
@@ -632,7 +661,10 @@ export function deriveSurveyGate({
         const completedQuestionCount = activeSurveyConfig.questions.filter(
             (question) => {
                 return isSurveyQuestionCompleted({
-                    question,
+                    question: getParticipantSurveyQuestion({
+                        question,
+                        surveyIsOptional,
+                    }),
                     storedAnswer: answersByQuestionId.get(question.id),
                 });
             },
@@ -651,6 +683,7 @@ export function deriveSurveyGate({
                     : "not_started";
         return {
             hasSurvey: true,
+            isOptional: surveyIsOptional,
             canParticipate: true,
             status,
             requiredQuestionCount: 0,
@@ -662,6 +695,7 @@ export function deriveSurveyGate({
     if (participantId === undefined) {
         return {
             hasSurvey: true,
+            isOptional: surveyIsOptional,
             canParticipate: false,
             status: "not_started",
             requiredQuestionCount: requiredQuestions.length,
@@ -673,6 +707,7 @@ export function deriveSurveyGate({
     if (response?.withdrawnAt !== null && response?.withdrawnAt !== undefined) {
         return {
             hasSurvey: true,
+            isOptional: surveyIsOptional,
             canParticipate: false,
             status: "withdrawn",
             requiredQuestionCount: requiredQuestions.length,
@@ -713,6 +748,7 @@ export function deriveSurveyGate({
 
     return {
         hasSurvey: true,
+        isOptional: surveyIsOptional,
         canParticipate: status === "complete_valid",
         status,
         requiredQuestionCount: requiredQuestions.length,
@@ -747,6 +783,7 @@ export function deriveSurveyRouteResolution({
             const questionFormItem = deriveSurveyQuestionFormItem({
                 question,
                 storedAnswer: surveyState.answersByQuestionId.get(question.id),
+                surveyIsOptional: surveyState.activeSurveyConfig.isOptional,
             });
             if (
                 !questionFormItem.isCurrentAnswerValid &&
@@ -774,6 +811,7 @@ export function deriveSurveyRouteResolution({
         const questionFormItem = deriveSurveyQuestionFormItem({
             question,
             storedAnswer: surveyState.answersByQuestionId.get(question.id),
+            surveyIsOptional: surveyState.activeSurveyConfig.isOptional,
         });
         if (
             !questionFormItem.isCurrentAnswerValid &&
@@ -843,6 +881,7 @@ export async function getActiveSurveyConfigRecord({
         .select({
             id: surveyConfigTable.id,
             currentRevision: surveyConfigTable.currentRevision,
+            isOptional: surveyConfigTable.isOptional,
         })
         .from(surveyConfigTable)
         .where(
@@ -945,6 +984,7 @@ export async function getActiveSurveyConfigRecord({
     return {
         id: surveyConfig.id,
         currentRevision: surveyConfig.currentRevision,
+        isOptional: surveyConfig.isOptional,
         questions: questionRows.map((question) => ({
             id: question.questionId,
             slugId: question.questionSlugId,
@@ -1973,6 +2013,7 @@ async function replaceSurveyConfigById({
         .update(surveyConfigTable)
         .set({
             currentRevision: existingSurveyConfig.currentRevision + 1,
+            isOptional: surveyConfig.isOptional,
             updatedAt: now,
         })
         .where(eq(surveyConfigTable.id, surveyConfigId));
@@ -2008,12 +2049,14 @@ export async function setSurveyConfigForConversation({
         .limit(1);
     const existingSurveyConfig = existingSurveyConfigRows.at(0);
     const previousRequiresSurvey = doesSurveyRequireCompletion({
+        isOptional: previousSurveyConfig?.isOptional ?? false,
         requiredQuestionCount:
             previousSurveyConfig?.questions.filter(
                 (question) => question.isRequired,
             ).length ?? 0,
     });
     const nextRequiresSurvey = doesSurveyRequireCompletion({
+        isOptional: normalizedSurveyConfig?.isOptional ?? false,
         requiredQuestionCount:
             normalizedSurveyConfig?.questions.filter(
                 (question) => question.isRequired,
@@ -2040,6 +2083,7 @@ export async function setSurveyConfigForConversation({
             .values({
                 conversationId,
                 currentRevision: 1,
+                isOptional: normalizedSurveyConfig.isOptional,
                 createdAt: now,
                 updatedAt: now,
                 deletedAt: null,
@@ -2092,6 +2136,7 @@ export async function getSurveyConfigForConversation({
     }
 
     return {
+        isOptional: activeSurveyConfig.isOptional,
         questions: activeSurveyConfig.questions.map((question) =>
             surveyQuestionToConfig({ question }),
         ),
@@ -2169,6 +2214,7 @@ export async function fetchSurveyForm({
                 storedAnswer: localizedSurveyState.answersByQuestionId.get(
                     question.id,
                 ),
+                surveyIsOptional: localizedActiveSurveyConfig.isOptional,
             }),
         ),
         surveyGate: toSurveyGateDto({ surveyGate }),
@@ -2376,12 +2422,16 @@ export async function saveSurveyAnswer({
         throw httpErrors.notFound("Survey not found");
     }
 
-    const question = activeSurveyConfig.questions.find(
+    const storedQuestion = activeSurveyConfig.questions.find(
         (currentQuestion) => currentQuestion.slugId === questionSlugId,
     );
-    if (question === undefined) {
+    if (storedQuestion === undefined) {
         throw httpErrors.notFound("Survey question not found");
     }
+    const question = getParticipantSurveyQuestion({
+        question: storedQuestion,
+        surveyIsOptional: activeSurveyConfig.isOptional,
+    });
 
     if (answer !== null && !validateSurveyAnswer({ question, answer })) {
         throw httpErrors.badRequest("Invalid survey answer payload");
@@ -2619,6 +2669,7 @@ export async function saveSurveyAnswer({
         shouldRecomputeAnalysisForSurveyTransition({
             previousSurveyGateStatus: previousSurveyGate.status,
             nextSurveyGateStatus: nextSurveyGate.status,
+            isOptional: activeSurveyConfig.isOptional,
         })
     ) {
         await refreshConversationAnalysisForSurveyChange({
@@ -2725,6 +2776,7 @@ export async function withdrawSurveyResponse({
         shouldRecomputeAnalysisForSurveyTransition({
             previousSurveyGateStatus: previousSurveyGate.status,
             nextSurveyGateStatus: nextSurveyGate.status,
+            isOptional: previousSurveyState.activeSurveyConfig.isOptional,
         })
     ) {
         await refreshConversationAnalysisForSurveyChange({

--- a/services/api/src/service/survey.ts
+++ b/services/api/src/service/survey.ts
@@ -2810,6 +2810,7 @@ export async function updateSurveyConfigByAuthor({
     googleCloudCredentials?: GoogleCloudCredentials;
 }): Promise<{
     currentRevision: number;
+    surveyGate: SurveyGateSummary;
 }> {
     const conversation = await getConversationAccessContextBySlugId({
         db,
@@ -2870,6 +2871,11 @@ export async function updateSurveyConfigByAuthor({
 
     return {
         currentRevision: activeSurveyConfig.currentRevision,
+        surveyGate: await getSurveyGateSummary({
+            db,
+            conversationId: conversation.conversationId,
+            participantId: userId,
+        }),
     };
 }
 

--- a/services/api/src/service/surveyAnalysis.test.ts
+++ b/services/api/src/service/surveyAnalysis.test.ts
@@ -198,6 +198,18 @@ describe("deriveSurveyGateStatusForAnalysis", () => {
             }),
         ).toBe("complete_valid");
     });
+
+    it("ignores required question gating when the whole survey is optional", () => {
+        expect(
+            deriveSurveyGateStatusForAnalysis({
+                hasSurvey: true,
+                isOptional: true,
+                questions: [requiredChoiceQuestion],
+                answersByQuestionId: new Map(),
+                withdrawnAt: null,
+            }),
+        ).toBe("not_started");
+    });
 });
 
 describe("analysis eligibility helpers", () => {
@@ -222,6 +234,15 @@ describe("analysis eligibility helpers", () => {
                 surveyGateStatus: "needs_update",
             }),
         ).toBe(false);
+    });
+
+    it("treats every optional survey status as analysis-eligible", () => {
+        expect(
+            isSurveyGateStatusEligibleForAnalysis({
+                surveyGateStatus: "not_started",
+                isOptional: true,
+            }),
+        ).toBe(true);
     });
 
     it("recomputes analysis when eligibility changes because a survey is withdrawn or invalidated", () => {
@@ -288,5 +309,11 @@ describe("analysis eligibility helpers", () => {
     it("distinguishes optional-only from required surveys", () => {
         expect(doesSurveyRequireCompletion({ requiredQuestionCount: 0 })).toBe(false);
         expect(doesSurveyRequireCompletion({ requiredQuestionCount: 1 })).toBe(true);
+        expect(
+            doesSurveyRequireCompletion({
+                isOptional: true,
+                requiredQuestionCount: 1,
+            }),
+        ).toBe(false);
     });
 });

--- a/services/api/src/shared-backend/schema.ts
+++ b/services/api/src/shared-backend/schema.ts
@@ -1400,6 +1400,7 @@ export const surveyConfigTable = pgTable(
             .notNull()
             .references(() => conversationTable.id),
         currentRevision: integer("current_revision").notNull().default(1),
+        isOptional: boolean("is_optional").notNull().default(false),
         createdAt: timestamp("created_at", {
             mode: "date",
             precision: 0,

--- a/services/api/src/shared-backend/surveyAnalysis.ts
+++ b/services/api/src/shared-backend/surveyAnalysis.ts
@@ -208,11 +208,13 @@ function validateSurveyAnswerContentForAnalysis({
 
 export function deriveSurveyGateStatusForAnalysis({
     hasSurvey,
+    isOptional = false,
     questions,
     answersByQuestionId,
     withdrawnAt,
 }: {
     hasSurvey: boolean;
+    isOptional?: boolean;
     questions: SurveyQuestionAnalysisRecord[];
     answersByQuestionId: Map<number, SurveyStoredAnswerAnalysisRecord>;
     withdrawnAt: Date | null;
@@ -225,16 +227,24 @@ export function deriveSurveyGateStatusForAnalysis({
         return "withdrawn";
     }
 
-    const requiredQuestions = questions.filter((question) => question.isRequired);
+    const effectiveQuestions = isOptional
+        ? questions.map((question) => ({ ...question, isRequired: false }))
+        : questions;
+    const requiredQuestions = effectiveQuestions.filter(
+        (question) => question.isRequired,
+    );
     if (requiredQuestions.length === 0) {
-        const completedQuestionCount = questions.filter((question) => {
+        const completedQuestionCount = effectiveQuestions.filter((question) => {
             return isSurveyQuestionCompletedForAnalysis({
                 question,
                 answer: answersByQuestionId.get(question.questionId),
             });
         }).length;
 
-        if (completedQuestionCount === questions.length && questions.length > 0) {
+        if (
+            completedQuestionCount === effectiveQuestions.length &&
+            effectiveQuestions.length > 0
+        ) {
             return "complete_valid";
         }
 
@@ -274,9 +284,15 @@ export function deriveSurveyGateStatusForAnalysis({
 
 export function isSurveyGateStatusEligibleForAnalysis({
     surveyGateStatus,
+    isOptional = false,
 }: {
     surveyGateStatus: SurveyGateStatus;
+    isOptional?: boolean;
 }): boolean {
+    if (isOptional) {
+        return true;
+    }
+
     return (
         surveyGateStatus === "no_survey" ||
         surveyGateStatus === "complete_valid"
@@ -286,16 +302,20 @@ export function isSurveyGateStatusEligibleForAnalysis({
 export function shouldRecomputeAnalysisForSurveyTransition({
     previousSurveyGateStatus,
     nextSurveyGateStatus,
+    isOptional = false,
 }: {
     previousSurveyGateStatus: SurveyGateStatus;
     nextSurveyGateStatus: SurveyGateStatus;
+    isOptional?: boolean;
 }): boolean {
     return (
         isSurveyGateStatusEligibleForAnalysis({
             surveyGateStatus: previousSurveyGateStatus,
+            isOptional,
         }) !==
         isSurveyGateStatusEligibleForAnalysis({
             surveyGateStatus: nextSurveyGateStatus,
+            isOptional,
         })
     );
 }
@@ -319,10 +339,16 @@ export function shouldRecomputeAnalysisForSurveyConfigChange({
 }
 
 export function doesSurveyRequireCompletion({
+    isOptional = false,
     requiredQuestionCount,
 }: {
+    isOptional?: boolean;
     requiredQuestionCount: number;
 }): boolean {
+    if (isOptional) {
+        return false;
+    }
+
     return requiredQuestionCount > 0;
 }
 
@@ -336,7 +362,10 @@ export async function getEligibleParticipantIdsForAnalysis({
     candidateParticipantIds: string[];
 }): Promise<Set<string> | undefined> {
     const surveyConfigRows = await db
-        .select({ id: surveyConfigTable.id })
+        .select({
+            id: surveyConfigTable.id,
+            isOptional: surveyConfigTable.isOptional,
+        })
         .from(surveyConfigTable)
         .where(
             and(
@@ -352,6 +381,9 @@ export async function getEligibleParticipantIdsForAnalysis({
     const activeSurveyConfig = surveyConfigRows[0];
     if (candidateParticipantIds.length === 0) {
         return new Set();
+    }
+    if (activeSurveyConfig.isOptional) {
+        return new Set(candidateParticipantIds);
     }
 
     const questionRows = await db
@@ -419,6 +451,7 @@ export async function getEligibleParticipantIdsForAnalysis({
         optionSlugIds: optionSlugIdsByQuestionId.get(question.questionId) ?? [],
     }));
     if (!doesSurveyRequireCompletion({
+        isOptional: activeSurveyConfig.isOptional,
         requiredQuestionCount: questions.filter((question) => question.isRequired)
             .length,
     })) {
@@ -514,6 +547,7 @@ export async function getEligibleParticipantIdsForAnalysis({
     for (const response of responseRows) {
         const surveyGateStatus = deriveSurveyGateStatusForAnalysis({
             hasSurvey: true,
+            isOptional: activeSurveyConfig.isOptional,
             questions,
             answersByQuestionId:
                 answersByResponseId.get(response.responseId) ??
@@ -523,6 +557,7 @@ export async function getEligibleParticipantIdsForAnalysis({
         if (
             isSurveyGateStatusEligibleForAnalysis({
                 surveyGateStatus,
+                isOptional: activeSurveyConfig.isOptional,
             })
         ) {
             eligibleParticipantIds.add(response.participantId);

--- a/services/api/src/shared/types/zod.ts
+++ b/services/api/src/shared/types/zod.ts
@@ -641,6 +641,7 @@ export const zodSurveyQuestionConfig = z
 
 export const zodSurveyConfig = z
     .object({
+        isOptional: z.boolean().optional().default(false),
         questions: z.array(zodSurveyQuestionConfig),
     })
     .strict()
@@ -691,6 +692,7 @@ export const zodSurveyAggregateSuppressionReason = z.enum([
 export const zodSurveyGateSummary = z
     .object({
         hasSurvey: z.boolean(),
+        isOptional: z.boolean(),
         canParticipate: z.boolean(),
         status: zodSurveyGateStatus,
     })

--- a/services/load-testing/src/api/api.ts
+++ b/services/load-testing/src/api/api.ts
@@ -718,6 +718,7 @@ export const ApiV1ConversationCreatePostRequestExternalSourceConfigSourceTypeEnu
 export type ApiV1ConversationCreatePostRequestExternalSourceConfigSourceTypeEnum = typeof ApiV1ConversationCreatePostRequestExternalSourceConfigSourceTypeEnum[keyof typeof ApiV1ConversationCreatePostRequestExternalSourceConfigSourceTypeEnum];
 
 export interface ApiV1ConversationCreatePostRequestSurveyConfig {
+    'isOptional'?: boolean;
     'questions': Array<ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner>;
 }
 /**
@@ -1101,6 +1102,7 @@ export interface ApiV1ConversationFetchRecentPost200ResponseConversationDataList
 }
 export interface ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGate {
     'hasSurvey': boolean;
+    'isOptional': boolean;
     'canParticipate': boolean;
     'status': ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGateStatusEnum;
 }
@@ -1303,6 +1305,7 @@ export const ApiV1ConversationGetForEditPost200ResponseOneOf1ReasonEnum = {
 export type ApiV1ConversationGetForEditPost200ResponseOneOf1ReasonEnum = typeof ApiV1ConversationGetForEditPost200ResponseOneOf1ReasonEnum[keyof typeof ApiV1ConversationGetForEditPost200ResponseOneOf1ReasonEnum];
 
 export interface ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig {
+    'isOptional': boolean;
     'questions': Array<ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfigQuestionsInner>;
 }
 /**
@@ -2190,6 +2193,7 @@ export interface ApiV1SurveyConfigUpdatePostRequest {
     'surveyConfig': ApiV1SurveyConfigUpdatePostRequestSurveyConfig;
 }
 export interface ApiV1SurveyConfigUpdatePostRequestSurveyConfig {
+    'isOptional'?: boolean;
     'questions': Array<ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner>;
 }
 export interface ApiV1SurveyFormFetchPost200Response {

--- a/services/load-testing/src/api/docs/ApiV1ConversationCreatePostRequestSurveyConfig.md
+++ b/services/load-testing/src/api/docs/ApiV1ConversationCreatePostRequestSurveyConfig.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**isOptional** | **boolean** |  | [optional] [default to false]
 **questions** | [**Array&lt;ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner&gt;**](ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner.md) |  | [default to undefined]
 
 ## Example
@@ -13,6 +14,7 @@ Name | Type | Description | Notes
 import { ApiV1ConversationCreatePostRequestSurveyConfig } from './api';
 
 const instance: ApiV1ConversationCreatePostRequestSurveyConfig = {
+    isOptional,
     questions,
 };
 ```

--- a/services/load-testing/src/api/docs/ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGate.md
+++ b/services/load-testing/src/api/docs/ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGate.md
@@ -6,6 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **hasSurvey** | **boolean** |  | [default to undefined]
+**isOptional** | **boolean** |  | [default to undefined]
 **canParticipate** | **boolean** |  | [default to undefined]
 **status** | **string** |  | [default to undefined]
 
@@ -16,6 +17,7 @@ import { ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInt
 
 const instance: ApiV1ConversationFetchRecentPost200ResponseConversationDataListInnerInteractionSurveyGate = {
     hasSurvey,
+    isOptional,
     canParticipate,
     status,
 };

--- a/services/load-testing/src/api/docs/ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig.md
+++ b/services/load-testing/src/api/docs/ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**isOptional** | **boolean** |  | [default to false]
 **questions** | [**Array&lt;ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfigQuestionsInner&gt;**](ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfigQuestionsInner.md) |  | [default to undefined]
 
 ## Example
@@ -13,6 +14,7 @@ Name | Type | Description | Notes
 import { ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig } from './api';
 
 const instance: ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig = {
+    isOptional,
     questions,
 };
 ```

--- a/services/load-testing/src/api/docs/ApiV1SurveyConfigUpdatePostRequestSurveyConfig.md
+++ b/services/load-testing/src/api/docs/ApiV1SurveyConfigUpdatePostRequestSurveyConfig.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**isOptional** | **boolean** |  | [optional] [default to false]
 **questions** | [**Array&lt;ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner&gt;**](ApiV1ConversationCreatePostRequestSurveyConfigQuestionsInner.md) |  | [default to undefined]
 
 ## Example
@@ -13,6 +14,7 @@ Name | Type | Description | Notes
 import { ApiV1SurveyConfigUpdatePostRequestSurveyConfig } from './api';
 
 const instance: ApiV1SurveyConfigUpdatePostRequestSurveyConfig = {
+    isOptional,
     questions,
 };
 ```

--- a/services/load-testing/src/shared/types/zod.ts
+++ b/services/load-testing/src/shared/types/zod.ts
@@ -641,6 +641,7 @@ export const zodSurveyQuestionConfig = z
 
 export const zodSurveyConfig = z
     .object({
+        isOptional: z.boolean().optional().default(false),
         questions: z.array(zodSurveyQuestionConfig),
     })
     .strict()
@@ -691,6 +692,7 @@ export const zodSurveyAggregateSuppressionReason = z.enum([
 export const zodSurveyGateSummary = z
     .object({
         hasSurvey: z.boolean(),
+        isOptional: z.boolean(),
         canParticipate: z.boolean(),
         status: zodSurveyGateStatus,
     })

--- a/services/math-updater/src/shared-backend/schema.ts
+++ b/services/math-updater/src/shared-backend/schema.ts
@@ -1400,6 +1400,7 @@ export const surveyConfigTable = pgTable(
             .notNull()
             .references(() => conversationTable.id),
         currentRevision: integer("current_revision").notNull().default(1),
+        isOptional: boolean("is_optional").notNull().default(false),
         createdAt: timestamp("created_at", {
             mode: "date",
             precision: 0,

--- a/services/math-updater/src/shared-backend/surveyAnalysis.ts
+++ b/services/math-updater/src/shared-backend/surveyAnalysis.ts
@@ -208,11 +208,13 @@ function validateSurveyAnswerContentForAnalysis({
 
 export function deriveSurveyGateStatusForAnalysis({
     hasSurvey,
+    isOptional = false,
     questions,
     answersByQuestionId,
     withdrawnAt,
 }: {
     hasSurvey: boolean;
+    isOptional?: boolean;
     questions: SurveyQuestionAnalysisRecord[];
     answersByQuestionId: Map<number, SurveyStoredAnswerAnalysisRecord>;
     withdrawnAt: Date | null;
@@ -225,16 +227,24 @@ export function deriveSurveyGateStatusForAnalysis({
         return "withdrawn";
     }
 
-    const requiredQuestions = questions.filter((question) => question.isRequired);
+    const effectiveQuestions = isOptional
+        ? questions.map((question) => ({ ...question, isRequired: false }))
+        : questions;
+    const requiredQuestions = effectiveQuestions.filter(
+        (question) => question.isRequired,
+    );
     if (requiredQuestions.length === 0) {
-        const completedQuestionCount = questions.filter((question) => {
+        const completedQuestionCount = effectiveQuestions.filter((question) => {
             return isSurveyQuestionCompletedForAnalysis({
                 question,
                 answer: answersByQuestionId.get(question.questionId),
             });
         }).length;
 
-        if (completedQuestionCount === questions.length && questions.length > 0) {
+        if (
+            completedQuestionCount === effectiveQuestions.length &&
+            effectiveQuestions.length > 0
+        ) {
             return "complete_valid";
         }
 
@@ -274,9 +284,15 @@ export function deriveSurveyGateStatusForAnalysis({
 
 export function isSurveyGateStatusEligibleForAnalysis({
     surveyGateStatus,
+    isOptional = false,
 }: {
     surveyGateStatus: SurveyGateStatus;
+    isOptional?: boolean;
 }): boolean {
+    if (isOptional) {
+        return true;
+    }
+
     return (
         surveyGateStatus === "no_survey" ||
         surveyGateStatus === "complete_valid"
@@ -286,16 +302,20 @@ export function isSurveyGateStatusEligibleForAnalysis({
 export function shouldRecomputeAnalysisForSurveyTransition({
     previousSurveyGateStatus,
     nextSurveyGateStatus,
+    isOptional = false,
 }: {
     previousSurveyGateStatus: SurveyGateStatus;
     nextSurveyGateStatus: SurveyGateStatus;
+    isOptional?: boolean;
 }): boolean {
     return (
         isSurveyGateStatusEligibleForAnalysis({
             surveyGateStatus: previousSurveyGateStatus,
+            isOptional,
         }) !==
         isSurveyGateStatusEligibleForAnalysis({
             surveyGateStatus: nextSurveyGateStatus,
+            isOptional,
         })
     );
 }
@@ -319,10 +339,16 @@ export function shouldRecomputeAnalysisForSurveyConfigChange({
 }
 
 export function doesSurveyRequireCompletion({
+    isOptional = false,
     requiredQuestionCount,
 }: {
+    isOptional?: boolean;
     requiredQuestionCount: number;
 }): boolean {
+    if (isOptional) {
+        return false;
+    }
+
     return requiredQuestionCount > 0;
 }
 
@@ -336,7 +362,10 @@ export async function getEligibleParticipantIdsForAnalysis({
     candidateParticipantIds: string[];
 }): Promise<Set<string> | undefined> {
     const surveyConfigRows = await db
-        .select({ id: surveyConfigTable.id })
+        .select({
+            id: surveyConfigTable.id,
+            isOptional: surveyConfigTable.isOptional,
+        })
         .from(surveyConfigTable)
         .where(
             and(
@@ -352,6 +381,9 @@ export async function getEligibleParticipantIdsForAnalysis({
     const activeSurveyConfig = surveyConfigRows[0];
     if (candidateParticipantIds.length === 0) {
         return new Set();
+    }
+    if (activeSurveyConfig.isOptional) {
+        return new Set(candidateParticipantIds);
     }
 
     const questionRows = await db
@@ -419,6 +451,7 @@ export async function getEligibleParticipantIdsForAnalysis({
         optionSlugIds: optionSlugIdsByQuestionId.get(question.questionId) ?? [],
     }));
     if (!doesSurveyRequireCompletion({
+        isOptional: activeSurveyConfig.isOptional,
         requiredQuestionCount: questions.filter((question) => question.isRequired)
             .length,
     })) {
@@ -514,6 +547,7 @@ export async function getEligibleParticipantIdsForAnalysis({
     for (const response of responseRows) {
         const surveyGateStatus = deriveSurveyGateStatusForAnalysis({
             hasSurvey: true,
+            isOptional: activeSurveyConfig.isOptional,
             questions,
             answersByQuestionId:
                 answersByResponseId.get(response.responseId) ??
@@ -523,6 +557,7 @@ export async function getEligibleParticipantIdsForAnalysis({
         if (
             isSurveyGateStatusEligibleForAnalysis({
                 surveyGateStatus,
+                isOptional: activeSurveyConfig.isOptional,
             })
         ) {
             eligibleParticipantIds.add(response.participantId);

--- a/services/math-updater/src/shared/types/zod.ts
+++ b/services/math-updater/src/shared/types/zod.ts
@@ -641,6 +641,7 @@ export const zodSurveyQuestionConfig = z
 
 export const zodSurveyConfig = z
     .object({
+        isOptional: z.boolean().optional().default(false),
         questions: z.array(zodSurveyQuestionConfig),
     })
     .strict()
@@ -691,6 +692,7 @@ export const zodSurveyAggregateSuppressionReason = z.enum([
 export const zodSurveyGateSummary = z
     .object({
         hasSurvey: z.boolean(),
+        isOptional: z.boolean(),
         canParticipate: z.boolean(),
         status: zodSurveyGateStatus,
     })

--- a/services/scoring-worker/src/scoring_worker/generated_models.py
+++ b/services/scoring-worker/src/scoring_worker/generated_models.py
@@ -219,6 +219,7 @@ class SurveyConfig(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     conversation_id: Mapped[int] = mapped_column(Integer)
     current_revision: Mapped[int] = mapped_column(Integer, server_default="1")
+    is_optional: Mapped[bool] = mapped_column(Boolean, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/services/shared-backend/src/schema.ts
+++ b/services/shared-backend/src/schema.ts
@@ -1399,6 +1399,7 @@ export const surveyConfigTable = pgTable(
             .notNull()
             .references(() => conversationTable.id),
         currentRevision: integer("current_revision").notNull().default(1),
+        isOptional: boolean("is_optional").notNull().default(false),
         createdAt: timestamp("created_at", {
             mode: "date",
             precision: 0,

--- a/services/shared-backend/src/surveyAnalysis.ts
+++ b/services/shared-backend/src/surveyAnalysis.ts
@@ -207,11 +207,13 @@ function validateSurveyAnswerContentForAnalysis({
 
 export function deriveSurveyGateStatusForAnalysis({
     hasSurvey,
+    isOptional = false,
     questions,
     answersByQuestionId,
     withdrawnAt,
 }: {
     hasSurvey: boolean;
+    isOptional?: boolean;
     questions: SurveyQuestionAnalysisRecord[];
     answersByQuestionId: Map<number, SurveyStoredAnswerAnalysisRecord>;
     withdrawnAt: Date | null;
@@ -224,16 +226,24 @@ export function deriveSurveyGateStatusForAnalysis({
         return "withdrawn";
     }
 
-    const requiredQuestions = questions.filter((question) => question.isRequired);
+    const effectiveQuestions = isOptional
+        ? questions.map((question) => ({ ...question, isRequired: false }))
+        : questions;
+    const requiredQuestions = effectiveQuestions.filter(
+        (question) => question.isRequired,
+    );
     if (requiredQuestions.length === 0) {
-        const completedQuestionCount = questions.filter((question) => {
+        const completedQuestionCount = effectiveQuestions.filter((question) => {
             return isSurveyQuestionCompletedForAnalysis({
                 question,
                 answer: answersByQuestionId.get(question.questionId),
             });
         }).length;
 
-        if (completedQuestionCount === questions.length && questions.length > 0) {
+        if (
+            completedQuestionCount === effectiveQuestions.length &&
+            effectiveQuestions.length > 0
+        ) {
             return "complete_valid";
         }
 
@@ -273,9 +283,15 @@ export function deriveSurveyGateStatusForAnalysis({
 
 export function isSurveyGateStatusEligibleForAnalysis({
     surveyGateStatus,
+    isOptional = false,
 }: {
     surveyGateStatus: SurveyGateStatus;
+    isOptional?: boolean;
 }): boolean {
+    if (isOptional) {
+        return true;
+    }
+
     return (
         surveyGateStatus === "no_survey" ||
         surveyGateStatus === "complete_valid"
@@ -285,16 +301,20 @@ export function isSurveyGateStatusEligibleForAnalysis({
 export function shouldRecomputeAnalysisForSurveyTransition({
     previousSurveyGateStatus,
     nextSurveyGateStatus,
+    isOptional = false,
 }: {
     previousSurveyGateStatus: SurveyGateStatus;
     nextSurveyGateStatus: SurveyGateStatus;
+    isOptional?: boolean;
 }): boolean {
     return (
         isSurveyGateStatusEligibleForAnalysis({
             surveyGateStatus: previousSurveyGateStatus,
+            isOptional,
         }) !==
         isSurveyGateStatusEligibleForAnalysis({
             surveyGateStatus: nextSurveyGateStatus,
+            isOptional,
         })
     );
 }
@@ -318,10 +338,16 @@ export function shouldRecomputeAnalysisForSurveyConfigChange({
 }
 
 export function doesSurveyRequireCompletion({
+    isOptional = false,
     requiredQuestionCount,
 }: {
+    isOptional?: boolean;
     requiredQuestionCount: number;
 }): boolean {
+    if (isOptional) {
+        return false;
+    }
+
     return requiredQuestionCount > 0;
 }
 
@@ -335,7 +361,10 @@ export async function getEligibleParticipantIdsForAnalysis({
     candidateParticipantIds: string[];
 }): Promise<Set<string> | undefined> {
     const surveyConfigRows = await db
-        .select({ id: surveyConfigTable.id })
+        .select({
+            id: surveyConfigTable.id,
+            isOptional: surveyConfigTable.isOptional,
+        })
         .from(surveyConfigTable)
         .where(
             and(
@@ -351,6 +380,9 @@ export async function getEligibleParticipantIdsForAnalysis({
     const activeSurveyConfig = surveyConfigRows[0];
     if (candidateParticipantIds.length === 0) {
         return new Set();
+    }
+    if (activeSurveyConfig.isOptional) {
+        return new Set(candidateParticipantIds);
     }
 
     const questionRows = await db
@@ -418,6 +450,7 @@ export async function getEligibleParticipantIdsForAnalysis({
         optionSlugIds: optionSlugIdsByQuestionId.get(question.questionId) ?? [],
     }));
     if (!doesSurveyRequireCompletion({
+        isOptional: activeSurveyConfig.isOptional,
         requiredQuestionCount: questions.filter((question) => question.isRequired)
             .length,
     })) {
@@ -513,6 +546,7 @@ export async function getEligibleParticipantIdsForAnalysis({
     for (const response of responseRows) {
         const surveyGateStatus = deriveSurveyGateStatusForAnalysis({
             hasSurvey: true,
+            isOptional: activeSurveyConfig.isOptional,
             questions,
             answersByQuestionId:
                 answersByResponseId.get(response.responseId) ??
@@ -522,6 +556,7 @@ export async function getEligibleParticipantIdsForAnalysis({
         if (
             isSurveyGateStatusEligibleForAnalysis({
                 surveyGateStatus,
+                isOptional: activeSurveyConfig.isOptional,
             })
         ) {
             eligibleParticipantIds.add(response.participantId);

--- a/services/shared/src/types/zod.ts
+++ b/services/shared/src/types/zod.ts
@@ -640,6 +640,7 @@ export const zodSurveyQuestionConfig = z
 
 export const zodSurveyConfig = z
     .object({
+        isOptional: z.boolean().optional().default(false),
         questions: z.array(zodSurveyQuestionConfig),
     })
     .strict()
@@ -690,6 +691,7 @@ export const zodSurveyAggregateSuppressionReason = z.enum([
 export const zodSurveyGateSummary = z
     .object({
         hasSurvey: z.boolean(),
+        isOptional: z.boolean(),
         canParticipate: z.boolean(),
         status: zodSurveyGateStatus,
     })


### PR DESCRIPTION
## Summary
- Add survey-level optionality across schemas, migrations, generated API clients, owner editing UI, participant onboarding, and requirement banners.
- Update participation gating, survey analysis/export eligibility, and cache refresh behavior so optional surveys do not block participation and immediately update viewer state after edits.
- Include the missing translated conversation error message from the branch history.

## Tests
- `cd services/api && pnpm test -- src/service/survey.test.ts src/service/surveyAnalysis.test.ts src/service/participationGate.test.ts src/service/conversationExport/generators/surveyShared.test.ts`
- `cd services/agora && pnpm test -- src/utils/survey/config.test.ts src/components/post/conversationRequirementBannerLogic.test.ts src/composables/conversation/useConversationSurveyState.test.ts 'src/pages/conversation/[postSlugId].onboarding/verifyRouteLogic.test.ts'`
- `cd services/api && pnpm lint`
- `cd services/agora && pnpm lint`
- `cd services/agora && pnpm exec vue-tsc --noEmit -p tsconfig.json`
- `git diff --check`

Deploy: agora, api, math-updater, scoring-worker