### PR TITLE
fix(survey): improve optional survey handling

### DIFF
--- a/services/agora/src/components/post/ConversationRequirementBanner.vue
+++ b/services/agora/src/components/post/ConversationRequirementBanner.vue
@@ -12,6 +12,7 @@
     <template #action>
       <q-btn
         v-if="showActionButton"
+        class="survey-banner__action-btn"
         flat
         no-caps
         :color="buttonColor"
@@ -200,9 +201,10 @@ async function handleOpenSurvey(): Promise<void> {
 @use "sass:color";
 
 .survey-banner {
-  margin-top: 0.5rem;
-  border-radius: 12px;
+  margin-top: 0.75rem;
+  border-radius: 16px;
   border: 1px solid transparent;
+  padding: 0.85rem 1rem;
 
   &.survey-banner--required {
     background-color: rgba($warning, 0.12);
@@ -221,6 +223,42 @@ async function handleOpenSurvey(): Promise<void> {
     border-color: rgba($positive, 0.22);
     color: color.adjust($positive, $lightness: -12%);
   }
+
+  :deep(.q-banner__avatar > .q-icon) {
+    border-radius: 10px;
+    padding: 0.2rem;
+  }
+
+  &.survey-banner--required :deep(.q-banner__avatar > .q-icon) {
+    background-color: rgba($warning, 0.14);
+  }
+
+  &.survey-banner--progress :deep(.q-banner__avatar > .q-icon) {
+    background-color: rgba($primary, 0.12);
+  }
+
+  &.survey-banner--complete :deep(.q-banner__avatar > .q-icon) {
+    background-color: rgba($positive, 0.12);
+  }
+
+  :deep(.survey-banner__action-btn) {
+    min-height: 2.25rem;
+    border-radius: 999px;
+    padding-inline: 0.85rem;
+    font-weight: 600;
+  }
+
+  &.survey-banner--required :deep(.survey-banner__action-btn) {
+    background-color: rgba($warning, 0.14);
+  }
+
+  &.survey-banner--progress :deep(.survey-banner__action-btn) {
+    background-color: rgba($primary, 0.1);
+  }
+
+  &.survey-banner--complete :deep(.survey-banner__action-btn) {
+    background-color: rgba($positive, 0.12);
+  }
 }
 
 .survey-banner__content {
@@ -230,11 +268,61 @@ async function handleOpenSurvey(): Promise<void> {
 }
 
 .survey-banner__title {
-  font-weight: 600;
+  font-weight: 700;
+  line-height: 1.25;
 }
 
 .survey-banner__message {
   font-size: 0.875rem;
   line-height: 1.35;
+}
+
+@media (max-width: $breakpoint-xs-max) {
+  .survey-banner {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+      "avatar content"
+      ". actions";
+    align-items: start;
+    column-gap: 0.75rem;
+    padding: 0.9rem;
+
+    :deep(.q-banner__avatar) {
+      grid-area: avatar;
+    }
+
+    :deep(.q-banner__avatar:not(:empty) + .q-banner__content) {
+      padding-inline-start: 0;
+    }
+
+    :deep(.q-banner__content) {
+      grid-area: content;
+      min-width: 0;
+    }
+
+    :deep(.q-banner__actions) {
+      grid-area: actions;
+      justify-content: stretch;
+      margin-top: 0.75rem;
+      padding-inline-start: 0;
+      width: 100%;
+    }
+
+    :deep(.survey-banner__action-btn) {
+      width: 100%;
+      min-height: 2.65rem;
+      padding-inline: 1rem;
+    }
+  }
+
+  .survey-banner__content {
+    gap: 0.25rem;
+  }
+
+  .survey-banner__message {
+    font-size: 0.92rem;
+    line-height: 1.4;
+  }
 }
 </style>

--- a/services/agora/src/components/post/comments/CommentComposer.vue
+++ b/services/agora/src/components/post/comments/CommentComposer.vue
@@ -435,6 +435,18 @@ function onLoginCallback() {
   unlockRoute();
 }
 
+function discardDraft(): void {
+  opinionBody.value = "";
+  characterCount.value = 0;
+  innerFocus.value = false;
+  deleteOpinionDraft(props.postSlugId);
+  unlockRoute();
+}
+
+defineExpose({
+  discardDraft,
+});
+
 function onBeforeRouteLeaveCallback(to: RouteGuardDestination): boolean {
   if (characterCount.value === 0) {
     deleteOpinionDraft(props.postSlugId);

--- a/services/agora/src/components/post/display/PostContent.vue
+++ b/services/agora/src/components/post/display/PostContent.vue
@@ -16,6 +16,7 @@
       :conversation-type="extendedPostData.metadata.conversationType"
       :external-source-config="extendedPostData.metadata.externalSourceConfig ?? null"
       @open-moderation-history="$emit('openModerationHistory')"
+      @conversation-deleted="$emit('conversationDeleted')"
     />
 
     <div class="postDiv">
@@ -102,6 +103,7 @@ defineProps<{
 
 defineEmits<{
   openModerationHistory: [];
+  conversationDeleted: [];
   verified: [payload: { userIdChanged: boolean; needsCacheRefresh: boolean }];
 }>();
 

--- a/services/agora/src/components/post/display/PostMetadata.vue
+++ b/services/agora/src/components/post/display/PostMetadata.vue
@@ -158,6 +158,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   openModerationHistory: [];
+  conversationDeleted: [];
 }>();
 
 const router = useRouter();
@@ -326,6 +327,15 @@ async function syncGitHubCallback(): Promise<void> {
   }
 }
 
+async function conversationDeletedCallback(): Promise<void> {
+  emit("conversationDeleted");
+
+  const slugPrefix = `/conversation/${props.postSlugId}`;
+  if (route.path === slugPrefix || route.path.startsWith(`${slugPrefix}/`)) {
+    await router.push({ name: "/" });
+  }
+}
+
 function clickedMoreIcon() {
   const showSyncGitHub =
     props.conversationType === "maxdiff" &&
@@ -346,6 +356,7 @@ function clickedMoreIcon() {
       exportConversationCallback,
       shareCallback,
       syncGitHubCallback: showSyncGitHub ? syncGitHubCallback : null,
+      conversationDeletedCallback,
     },
   );
 }

--- a/services/agora/src/components/survey/SurveyConfigEditor.vue
+++ b/services/agora/src/components/survey/SurveyConfigEditor.vue
@@ -1,0 +1,1266 @@
+<template>
+  <div class="survey-config-editor">
+    <div class="survey-config-editor__intro-card">
+      <div class="survey-config-editor__title">{{ texts.title }}</div>
+      <div class="survey-config-editor__description">{{ texts.description }}</div>
+      <q-toggle
+        v-if="hasSurveyQuestions"
+        :model-value="isSurveyOptional"
+        :label="texts.optionalSurveyToggleLabel"
+        @update:model-value="(value) => updateSurveyOptional({ isOptional: value })"
+      />
+      <div v-if="hasSurveyQuestions" class="survey-config-editor__description">
+        {{ isSurveyOptional ? texts.optionalSurveyToggleHint : texts.requiredSurveyToggleHint }}
+      </div>
+    </div>
+
+    <slot name="between-intro-and-editor" />
+
+    <div
+      class="survey-config-editor__body"
+      :class="{ 'survey-config-editor__body--card': bodyCard }"
+    >
+      <div v-if="!hasSurveyQuestions" class="survey-config-editor__empty-card">
+        <div class="survey-config-editor__title">{{ texts.noQuestionsTitle }}</div>
+        <div class="survey-config-editor__description">
+          {{ texts.noQuestionsDescription }}
+        </div>
+      </div>
+
+      <div
+        v-for="(question, questionIndex) in surveyQuestions"
+        :key="questionIndex"
+        class="survey-config-editor__question-card"
+      >
+        <div class="survey-config-editor__question-header">
+          <div>
+            <div class="survey-config-editor__title">
+              {{ texts.questionTitle({ number: questionIndex + 1 }) }}
+            </div>
+            <div class="survey-config-editor__description">
+              {{ isSurveyOptional || !question.isRequired ? texts.optionalLabel : texts.requiredLabel }}
+            </div>
+          </div>
+
+          <q-btn
+            flat
+            no-caps
+            color="negative"
+            :label="texts.removeQuestionLabel"
+            @click="requestRemoveQuestion({ questionIndex })"
+          />
+        </div>
+
+        <q-select
+          :model-value="question.questionType"
+          outlined
+          emit-value
+          map-options
+          :label="texts.questionTypeLabel"
+          :options="questionTypeOptions"
+          @update:model-value="(value) => updateQuestionType({ questionIndex, questionType: value })"
+        />
+
+        <q-select
+          v-if="question.questionType !== 'free_text'"
+          :model-value="question.choiceDisplay"
+          outlined
+          emit-value
+          map-options
+          :label="texts.choiceDisplayLabel"
+          :options="choiceDisplayOptions"
+          @update:model-value="(value) => updateQuestionChoiceDisplay({ questionIndex, choiceDisplay: value })"
+        />
+
+        <q-input
+          :model-value="question.questionText"
+          outlined
+          autogrow
+          :maxlength="500"
+          :error="shouldShowQuestionTextError({ question })"
+          :label="texts.questionPromptLabel"
+          @update:model-value="(value) => updateQuestionText({ questionIndex, questionText: value })"
+        />
+
+        <div
+          v-if="shouldShowQuestionSemanticToggle({ question })"
+          class="survey-config-editor__help-block"
+        >
+          <q-toggle
+            :model-value="question.textChangeIsSemantic === true"
+            :label="texts.questionSemanticChangeLabel ?? ''"
+            @update:model-value="(value) => updateQuestionSemanticChange({ questionIndex, isSemantic: value === true })"
+          />
+          <div class="survey-config-editor__help">
+            {{ texts.questionSemanticChangeHint }}
+          </div>
+        </div>
+
+        <q-toggle
+          :model-value="isSurveyOptional ? false : question.isRequired"
+          :disable="isSurveyOptional"
+          :label="isSurveyOptional || !question.isRequired ? texts.optionalLabel : texts.requiredLabel"
+          @update:model-value="(value) => updateQuestionRequired({ questionIndex, isRequired: value })"
+        />
+        <div v-if="isSurveyOptional" class="survey-config-editor__help">
+          {{ texts.questionRequirementDisabledHint }}
+        </div>
+
+        <div v-if="question.questionType === 'choice'" class="survey-config-editor__constraints-grid">
+          <q-input
+            :model-value="question.constraints.minSelections"
+            v-bind="getChoiceConstraintInputAttrs({ optionCount: question.options.length })"
+            outlined
+            type="number"
+            :label="texts.minSelectionsLabel"
+            @update:model-value="(value) => updateChoiceConstraints({ questionIndex, minSelections: value, maxSelections: question.constraints.maxSelections })"
+          />
+
+          <q-input
+            :model-value="question.constraints.maxSelections ?? ''"
+            v-bind="getChoiceConstraintInputAttrs({ optionCount: question.options.length })"
+            outlined
+            type="number"
+            :label="texts.maxSelectionsLabel"
+            @update:model-value="(value) => updateChoiceConstraints({ questionIndex, minSelections: question.constraints.minSelections, maxSelections: value })"
+          />
+        </div>
+
+        <div v-else-if="question.questionType === 'free_text'" class="survey-config-editor__constraints-stack">
+          <q-select
+            :model-value="question.constraints.type === 'free_text' ? question.constraints.inputMode : 'rich_text'"
+            outlined
+            emit-value
+            map-options
+            :label="templateTexts.answerFormatLabel"
+            :options="freeTextInputModeOptions"
+            @update:model-value="(value) => updateFreeTextInputMode({ questionIndex, inputMode: value })"
+          />
+
+          <div
+            v-if="question.constraints.type === 'free_text' && question.constraints.inputMode === 'integer'"
+            class="survey-config-editor__constraints-grid"
+          >
+            <q-input
+              :model-value="getIntegerConstraints({ constraints: question.constraints })?.minValue ?? 1"
+              outlined
+              type="number"
+              :label="templateTexts.minValueLabel"
+              @update:model-value="(value) => updateIntegerConstraints({ questionIndex, minValue: value, maxValue: getIntegerConstraints({ constraints: question.constraints })?.maxValue })"
+            />
+
+            <q-input
+              :model-value="getIntegerConstraints({ constraints: question.constraints })?.maxValue ?? ''"
+              outlined
+              type="number"
+              :label="templateTexts.maxValueLabel"
+              @update:model-value="(value) => updateIntegerConstraints({ questionIndex, minValue: getIntegerConstraints({ constraints: question.constraints })?.minValue, maxValue: value })"
+            />
+          </div>
+
+          <div v-else class="survey-config-editor__constraints-grid">
+            <q-input
+              :model-value="getRichTextConstraints({ constraints: question.constraints })?.minPlainTextLength ?? ''"
+              outlined
+              type="number"
+              :label="texts.minTextLengthLabel"
+              @update:model-value="(value) => updateRichTextConstraints({ questionIndex, minPlainTextLength: value, maxPlainTextLength: getRichTextConstraints({ constraints: question.constraints })?.maxPlainTextLength ?? 300 })"
+            />
+
+            <q-input
+              :model-value="getRichTextConstraints({ constraints: question.constraints })?.maxPlainTextLength ?? 300"
+              outlined
+              type="number"
+              :label="texts.maxTextLengthLabel"
+              @update:model-value="(value) => updateRichTextConstraints({ questionIndex, minPlainTextLength: getRichTextConstraints({ constraints: question.constraints })?.minPlainTextLength, maxPlainTextLength: value })"
+            />
+          </div>
+
+          <div
+            v-if="getFreeTextHelp({ constraints: question.constraints }) !== ''"
+            class="survey-config-editor__help"
+          >
+            {{ getFreeTextHelp({ constraints: question.constraints }) }}
+          </div>
+        </div>
+
+        <div v-if="question.questionType !== 'free_text'" class="survey-config-editor__options-list">
+          <div
+            v-for="(option, optionIndex) in question.options ?? []"
+            :id="getOptionInputId({ questionIndex, optionIndex })"
+            :key="optionIndex"
+            class="survey-config-editor__option-editor"
+            @keydown.enter="handleOptionEditorEnter({ event: $event, questionIndex })"
+          >
+            <q-input
+              :model-value="option.optionText"
+              outlined
+              :maxlength="200"
+              :error="shouldShowOptionTextError({ question, option })"
+              :label="texts.optionLabel({ number: optionIndex + 1 })"
+              @update:model-value="(value) => updateOptionText({ questionIndex, optionIndex, optionText: value })"
+            >
+              <template #append>
+                <q-btn
+                  v-if="(question.options?.length ?? 0) > 2"
+                  flat
+                  round
+                  dense
+                  icon="mdi-close"
+                  @click.stop="requestRemoveOption({ questionIndex, optionIndex })"
+                />
+              </template>
+            </q-input>
+
+            <div
+              v-if="shouldShowOptionSemanticToggle({ question, option })"
+              class="survey-config-editor__help-block survey-config-editor__help-block--nested"
+            >
+              <q-toggle
+                :model-value="option.textChangeIsSemantic === true"
+                :label="texts.optionSemanticChangeLabel ?? ''"
+                @update:model-value="(value) => updateOptionSemanticChange({ questionIndex, optionIndex, isSemantic: value === true })"
+              />
+              <div class="survey-config-editor__help">
+                {{ texts.optionSemanticChangeHint }}
+              </div>
+            </div>
+          </div>
+
+          <q-btn
+            flat
+            no-caps
+            color="primary"
+            :label="texts.addOptionLabel"
+            @click="addOption({ questionIndex })"
+          />
+
+          <ZKInfoBanner
+            v-if="
+              shouldShowLargeOptionWarning({
+                choiceDisplay: question.choiceDisplay,
+                optionCount: question.options?.length ?? 0,
+              })
+            "
+            :message="
+              texts.largeOptionCountWarning({
+                count: question.options?.length ?? 0,
+                threshold: largeOptionWarningThreshold,
+              })
+            "
+          />
+        </div>
+      </div>
+
+      <div v-if="showActions" class="survey-config-editor__actions">
+        <q-btn
+          flat
+          no-caps
+          color="primary"
+          :label="texts.addQuestionLabel"
+          @click="addQuestion"
+        />
+        <q-btn
+          flat
+          no-caps
+          color="primary"
+          :label="templateTexts.addAgeGroupLabel"
+          @click="addTemplateQuestion({ templateId: 'age_group' })"
+        />
+        <q-btn
+          flat
+          no-caps
+          color="primary"
+          :label="templateTexts.addAgeLabel"
+          @click="addTemplateQuestion({ templateId: 'age' })"
+        />
+        <q-btn
+          flat
+          no-caps
+          color="primary"
+          :label="templateTexts.addSexAtBirthLabel"
+          @click="addTemplateQuestion({ templateId: 'sex_at_birth' })"
+        />
+        <q-btn
+          flat
+          no-caps
+          color="primary"
+          :label="templateTexts.addGenderLabel"
+          @click="addTemplateQuestion({ templateId: 'gender' })"
+        />
+        <slot name="actions" />
+      </div>
+    </div>
+
+    <ZKConfirmDialog
+      v-model="showRemoveDialog"
+      :message="removeDialogMessage"
+      :confirm-text="removeDialogConfirmText"
+      :cancel-text="texts.cancelLabel"
+      variant="destructive"
+      @confirm="handleConfirmRemoval"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import ZKConfirmDialog from "src/components/ui-library/ZKConfirmDialog.vue";
+import ZKInfoBanner from "src/components/ui-library/ZKInfoBanner.vue";
+import {
+  type SupportedDisplayLanguageCodes,
+  ZodSupportedDisplayLanguageCodes,
+} from "src/shared/languages";
+import type {
+  SurveyChoiceDisplay,
+  SurveyConfig,
+  SurveyQuestionConfig,
+  SurveyQuestionConstraints,
+  SurveyQuestionOption,
+  SurveyQuestionType,
+} from "src/shared/types/zod";
+import {
+  createChoiceSurveyQuestionConstraints,
+  createEmptySurveyOption,
+  createEmptySurveyQuestion,
+  createIntegerSurveyQuestionConstraints,
+  createRichTextSurveyQuestionConstraints,
+  normalizeChoiceSurveyQuestionConstraints,
+  shouldWarnAboutLargeSurveyOptionSet,
+  SURVEY_LARGE_OPTION_WARNING_THRESHOLD,
+} from "src/utils/survey/config";
+import {
+  createSurveyTemplateQuestion,
+  type SurveyTemplateId,
+} from "src/utils/survey/templates";
+import { surveyTemplateTextTranslations } from "src/utils/survey/templates.i18n";
+import { computed, nextTick, ref } from "vue";
+
+interface SurveyConfigEditorTexts {
+  title: string;
+  description: string;
+  optionalSurveyToggleLabel: string;
+  optionalSurveyToggleHint: string;
+  requiredSurveyToggleHint: string;
+  noQuestionsTitle: string;
+  noQuestionsDescription: string;
+  questionTitle: ({ number }: { number: number }) => string;
+  optionalLabel: string;
+  requiredLabel: string;
+  removeQuestionLabel: string;
+  questionTypeLabel: string;
+  typeChoice: string;
+  typeFreeText: string;
+  choiceDisplayLabel: string;
+  choiceDisplayAuto: string;
+  choiceDisplayList: string;
+  choiceDisplayDropdown: string;
+  questionPromptLabel: string;
+  questionRequirementDisabledHint: string;
+  minSelectionsLabel: string;
+  maxSelectionsLabel: string;
+  minTextLengthLabel: string;
+  maxTextLengthLabel: string;
+  freeTextHelp?: string;
+  optionLabel: ({ number }: { number: number }) => string;
+  addOptionLabel: string;
+  addQuestionLabel: string;
+  cancelLabel: string;
+  confirmRemoveQuestionMessage: string;
+  confirmRemoveOptionMessage: string;
+  confirmRemoveQuestionButtonLabel: string;
+  confirmRemoveOptionButtonLabel: string;
+  largeOptionCountWarning: ({
+    count,
+    threshold,
+  }: {
+    count: number;
+    threshold: number;
+  }) => string;
+  questionSemanticChangeLabel?: string;
+  questionSemanticChangeHint?: string;
+  optionSemanticChangeLabel?: string;
+  optionSemanticChangeHint?: string;
+}
+
+interface Props {
+  texts: SurveyConfigEditorTexts;
+  displayLanguage: string;
+  bodyCard?: boolean;
+  showActions?: boolean;
+  showValidationErrors?: boolean;
+  originalSurveyConfig?: SurveyConfig | null;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  bodyCard: false,
+  showActions: true,
+  showValidationErrors: false,
+  originalSurveyConfig: null,
+});
+
+const emit = defineEmits<{
+  clearValidationError: [];
+}>();
+
+const surveyConfig = defineModel<SurveyConfig | null>("surveyConfig", {
+  required: true,
+});
+
+type PendingRemoval =
+  | { type: "question"; questionIndex: number }
+  | { type: "option"; questionIndex: number; optionIndex: number };
+
+const pendingRemoval = ref<PendingRemoval | null>(null);
+const largeOptionWarningThreshold = SURVEY_LARGE_OPTION_WARNING_THRESHOLD;
+
+const currentLocale = computed<SupportedDisplayLanguageCodes>(() => {
+  const parsedLocale = ZodSupportedDisplayLanguageCodes.safeParse(props.displayLanguage);
+
+  return parsedLocale.success ? parsedLocale.data : "en";
+});
+const templateTexts = computed(() => {
+  return surveyTemplateTextTranslations[currentLocale.value];
+});
+const surveyQuestions = computed(() => {
+  return surveyConfig.value?.questions ?? [];
+});
+const hasSurveyQuestions = computed(() => {
+  return surveyQuestions.value.length > 0;
+});
+const isSurveyOptional = computed(() => {
+  return surveyConfig.value?.isOptional === true;
+});
+const questionTypeOptions = computed<Array<{ label: string; value: SurveyQuestionType }>>(
+  () => [
+    { label: props.texts.typeChoice, value: "choice" },
+    { label: props.texts.typeFreeText, value: "free_text" },
+  ]
+);
+const choiceDisplayOptions = computed<
+  Array<{ label: string; value: SurveyChoiceDisplay }>
+>(() => [
+  { label: props.texts.choiceDisplayAuto, value: "auto" },
+  { label: props.texts.choiceDisplayList, value: "list" },
+  { label: props.texts.choiceDisplayDropdown, value: "dropdown" },
+]);
+const freeTextInputModeOptions = computed<
+  Array<{ label: string; value: "rich_text" | "integer" }>
+>(() => [
+  { label: templateTexts.value.answerFormatRichText, value: "rich_text" },
+  { label: templateTexts.value.answerFormatNumber, value: "integer" },
+]);
+
+const showRemoveDialog = computed({
+  get: () => pendingRemoval.value !== null,
+  set: (value: boolean) => {
+    if (!value) {
+      pendingRemoval.value = null;
+    }
+  },
+});
+const removeDialogMessage = computed(() => {
+  switch (pendingRemoval.value?.type) {
+    case undefined:
+      return "";
+    case "question":
+      return props.texts.confirmRemoveQuestionMessage;
+    case "option":
+      return props.texts.confirmRemoveOptionMessage;
+  }
+
+  return "";
+});
+const removeDialogConfirmText = computed(() => {
+  switch (pendingRemoval.value?.type) {
+    case undefined:
+      return props.texts.removeQuestionLabel;
+    case "question":
+      return props.texts.confirmRemoveQuestionButtonLabel;
+    case "option":
+      return props.texts.confirmRemoveOptionButtonLabel;
+  }
+
+  return props.texts.removeQuestionLabel;
+});
+
+function clearSurveyValidationError(): void {
+  emit("clearValidationError");
+}
+
+function ensureSurveyConfig(): void {
+  if (surveyConfig.value === null) {
+    surveyConfig.value = { isOptional: false, questions: [] };
+  }
+}
+
+function updateSurveyOptional({ isOptional }: { isOptional: boolean | null }): void {
+  ensureSurveyConfig();
+  if (surveyConfig.value === null) {
+    return;
+  }
+
+  surveyConfig.value.isOptional = isOptional === true;
+}
+
+function addQuestion(): void {
+  clearSurveyValidationError();
+  const currentSurveyConfig = surveyConfig.value;
+  if (currentSurveyConfig === null) {
+    surveyConfig.value = {
+      isOptional: false,
+      questions: [createEmptySurveyQuestion({ displayOrder: 0 })],
+    };
+    return;
+  }
+
+  currentSurveyConfig.questions.push(
+    createEmptySurveyQuestion({ displayOrder: currentSurveyConfig.questions.length })
+  );
+}
+
+function addTemplateQuestion({ templateId }: { templateId: SurveyTemplateId }): void {
+  clearSurveyValidationError();
+  const currentSurveyConfig = surveyConfig.value;
+  if (currentSurveyConfig === null) {
+    surveyConfig.value = {
+      isOptional: false,
+      questions: [
+        createSurveyTemplateQuestion({
+          templateId,
+          displayOrder: 0,
+          displayLanguage: currentLocale.value,
+        }),
+      ],
+    };
+    return;
+  }
+
+  currentSurveyConfig.questions.push(
+    createSurveyTemplateQuestion({
+      templateId,
+      displayOrder: currentSurveyConfig.questions.length,
+      displayLanguage: currentLocale.value,
+    })
+  );
+}
+
+function shouldShowQuestionTextError({
+  question,
+}: {
+  question: SurveyQuestionConfig;
+}): boolean {
+  return props.showValidationErrors && question.questionText.trim() === "";
+}
+
+function shouldShowOptionTextError({
+  question,
+  option,
+}: {
+  question: SurveyQuestionConfig;
+  option: SurveyQuestionOption;
+}): boolean {
+  return (
+    props.showValidationErrors &&
+    question.questionType === "choice" &&
+    option.optionText.trim() === ""
+  );
+}
+
+function shouldShowLargeOptionWarning({
+  choiceDisplay,
+  optionCount,
+}: {
+  choiceDisplay: SurveyChoiceDisplay;
+  optionCount: number;
+}): boolean {
+  return shouldWarnAboutLargeSurveyOptionSet({ choiceDisplay, optionCount });
+}
+
+function getOptionInputId({
+  questionIndex,
+  optionIndex,
+}: {
+  questionIndex: number;
+  optionIndex: number;
+}): string {
+  return `survey-option-input-${questionIndex}-${optionIndex}`;
+}
+
+function getChoiceConstraintInputAttrs({
+  optionCount,
+}: {
+  optionCount: number;
+}): { min: number; max: number } {
+  return { min: 1, max: optionCount };
+}
+
+async function handleOptionEditorEnter({
+  event,
+  questionIndex,
+}: {
+  event: KeyboardEvent;
+  questionIndex: number;
+}): Promise<void> {
+  if (!(event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement)) {
+    return;
+  }
+
+  event.preventDefault();
+  await addOption({ questionIndex });
+}
+
+async function focusOptionInput({
+  questionIndex,
+  optionIndex,
+}: {
+  questionIndex: number;
+  optionIndex: number;
+}): Promise<void> {
+  await nextTick();
+  const input = document
+    .getElementById(getOptionInputId({ questionIndex, optionIndex }))
+    ?.querySelector<HTMLInputElement>("input");
+  input?.focus();
+}
+
+function getIntegerConstraints({
+  constraints,
+}: {
+  constraints: SurveyQuestionConstraints;
+}): Extract<
+  SurveyQuestionConstraints,
+  { type: "free_text"; inputMode: "integer" }
+> | undefined {
+  return constraints.type === "free_text" && constraints.inputMode === "integer"
+    ? constraints
+    : undefined;
+}
+
+function getRichTextConstraints({
+  constraints,
+}: {
+  constraints: SurveyQuestionConstraints;
+}): Extract<
+  SurveyQuestionConstraints,
+  { type: "free_text"; inputMode: "rich_text" }
+> | undefined {
+  return constraints.type === "free_text" && constraints.inputMode !== "integer"
+    ? constraints
+    : undefined;
+}
+
+function getFreeTextHelp({
+  constraints,
+}: {
+  constraints: SurveyQuestionConstraints;
+}): string {
+  if (constraints.type === "free_text" && constraints.inputMode === "integer") {
+    return templateTexts.value.numericInputHelp;
+  }
+
+  return props.texts.freeTextHelp ?? "";
+}
+
+function getOriginalQuestion({
+  question,
+}: {
+  question: SurveyQuestionConfig;
+}): SurveyQuestionConfig | undefined {
+  if (question.questionSlugId === undefined) {
+    return undefined;
+  }
+
+  return props.originalSurveyConfig?.questions.find((candidate) => {
+    return candidate.questionSlugId === question.questionSlugId;
+  });
+}
+
+function getOriginalOption({
+  question,
+  option,
+}: {
+  question: SurveyQuestionConfig;
+  option: SurveyQuestionOption;
+}): SurveyQuestionOption | undefined {
+  if (option.optionSlugId === undefined) {
+    return undefined;
+  }
+
+  const originalQuestion = getOriginalQuestion({ question });
+  if (originalQuestion === undefined || originalQuestion.questionType === "free_text") {
+    return undefined;
+  }
+
+  return originalQuestion.options.find((candidate) => {
+    return candidate.optionSlugId === option.optionSlugId;
+  });
+}
+
+function shouldShowQuestionSemanticToggle({
+  question,
+}: {
+  question: SurveyQuestionConfig;
+}): boolean {
+  if (
+    props.texts.questionSemanticChangeLabel === undefined ||
+    props.texts.questionSemanticChangeHint === undefined
+  ) {
+    return false;
+  }
+
+  const originalQuestion = getOriginalQuestion({ question });
+
+  return (
+    originalQuestion !== undefined &&
+    originalQuestion.questionText !== question.questionText
+  );
+}
+
+function shouldShowOptionSemanticToggle({
+  question,
+  option,
+}: {
+  question: SurveyQuestionConfig;
+  option: SurveyQuestionOption;
+}): boolean {
+  if (
+    props.texts.optionSemanticChangeLabel === undefined ||
+    props.texts.optionSemanticChangeHint === undefined
+  ) {
+    return false;
+  }
+
+  const originalOption = getOriginalOption({ question, option });
+
+  return originalOption !== undefined && originalOption.optionText !== option.optionText;
+}
+
+function syncQuestionSemanticChangeFlag({ questionIndex }: { questionIndex: number }): void {
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (question === undefined) {
+    return;
+  }
+
+  if (!shouldShowQuestionSemanticToggle({ question })) {
+    question.textChangeIsSemantic = undefined;
+  }
+}
+
+function syncOptionSemanticChangeFlag({
+  questionIndex,
+  optionIndex,
+}: {
+  questionIndex: number;
+  optionIndex: number;
+}): void {
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (question === undefined || question.questionType === "free_text") {
+    return;
+  }
+
+  const option = question.options[optionIndex];
+  if (option === undefined) {
+    return;
+  }
+
+  if (!shouldShowOptionSemanticToggle({ question, option })) {
+    option.textChangeIsSemantic = undefined;
+  }
+}
+
+function updateQuestionSemanticChange({
+  questionIndex,
+  isSemantic,
+}: {
+  questionIndex: number;
+  isSemantic: boolean;
+}): void {
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (question === undefined) {
+    return;
+  }
+
+  question.textChangeIsSemantic = isSemantic ? true : undefined;
+}
+
+function updateOptionSemanticChange({
+  questionIndex,
+  optionIndex,
+  isSemantic,
+}: {
+  questionIndex: number;
+  optionIndex: number;
+  isSemantic: boolean;
+}): void {
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (question === undefined || question.questionType === "free_text") {
+    return;
+  }
+
+  const option = question.options[optionIndex];
+  if (option === undefined) {
+    return;
+  }
+
+  option.textChangeIsSemantic = isSemantic ? true : undefined;
+}
+
+function reindexSurveyQuestion({
+  question,
+  displayOrder,
+}: {
+  question: SurveyQuestionConfig;
+  displayOrder: number;
+}): SurveyQuestionConfig {
+  if (question.questionType === "free_text") {
+    return {
+      ...question,
+      displayOrder,
+    };
+  }
+
+  return {
+    ...question,
+    displayOrder,
+    options: question.options.map((option, optionIndex) => ({
+      ...option,
+      displayOrder: optionIndex,
+    })),
+  };
+}
+
+function requestRemoveQuestion({ questionIndex }: { questionIndex: number }): void {
+  pendingRemoval.value = { type: "question", questionIndex };
+}
+
+function removeQuestion({ questionIndex }: { questionIndex: number }): void {
+  clearSurveyValidationError();
+  if (surveyConfig.value === null) {
+    return;
+  }
+
+  surveyConfig.value.questions.splice(questionIndex, 1);
+  if (surveyConfig.value.questions.length === 0) {
+    surveyConfig.value = null;
+    return;
+  }
+
+  surveyConfig.value.questions = surveyConfig.value.questions.map((question, index) =>
+    reindexSurveyQuestion({ question, displayOrder: index })
+  );
+}
+
+function updateQuestionText({
+  questionIndex,
+  questionText,
+}: {
+  questionIndex: number;
+  questionText: string | number | null;
+}): void {
+  clearSurveyValidationError();
+  if (surveyConfig.value === null) {
+    return;
+  }
+
+  surveyConfig.value.questions[questionIndex].questionText = String(questionText ?? "");
+  syncQuestionSemanticChangeFlag({ questionIndex });
+}
+
+function updateQuestionRequired({
+  questionIndex,
+  isRequired,
+}: {
+  questionIndex: number;
+  isRequired: boolean | null;
+}): void {
+  clearSurveyValidationError();
+  if (surveyConfig.value === null) {
+    return;
+  }
+
+  surveyConfig.value.questions[questionIndex].isRequired = isRequired === true;
+}
+
+function updateQuestionType({
+  questionIndex,
+  questionType,
+}: {
+  questionIndex: number;
+  questionType: SurveyQuestionType | null;
+}): void {
+  clearSurveyValidationError();
+  if (surveyConfig.value === null || questionType === null) {
+    return;
+  }
+
+  const currentQuestion = surveyConfig.value.questions[questionIndex];
+  const questionBase = {
+    questionSlugId: currentQuestion.questionSlugId,
+    questionText: currentQuestion.questionText,
+    isRequired: currentQuestion.isRequired,
+    displayOrder: currentQuestion.displayOrder,
+    textChangeIsSemantic: currentQuestion.textChangeIsSemantic,
+  };
+  const currentChoiceDisplay =
+    currentQuestion.questionType === "free_text" ? "auto" : currentQuestion.choiceDisplay;
+  const currentOptions =
+    currentQuestion.questionType === "free_text" ? [] : currentQuestion.options;
+  const nextOptions =
+    currentOptions.length >= 2
+      ? currentOptions
+      : [
+          createEmptySurveyOption({ displayOrder: 0 }),
+          createEmptySurveyOption({ displayOrder: 1 }),
+        ];
+
+  if (questionType === "free_text") {
+    surveyConfig.value.questions[questionIndex] = {
+      ...questionBase,
+      questionType: "free_text",
+      constraints: createRichTextSurveyQuestionConstraints(),
+    };
+    return;
+  }
+
+  surveyConfig.value.questions[questionIndex] = {
+    ...questionBase,
+    questionType: "choice",
+    choiceDisplay: currentChoiceDisplay,
+    constraints: createChoiceSurveyQuestionConstraints(),
+    options: nextOptions,
+  };
+}
+
+function updateQuestionChoiceDisplay({
+  questionIndex,
+  choiceDisplay,
+}: {
+  questionIndex: number;
+  choiceDisplay: SurveyChoiceDisplay | null;
+}): void {
+  clearSurveyValidationError();
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (question === undefined || question.questionType === "free_text" || choiceDisplay === null) {
+    return;
+  }
+
+  question.choiceDisplay = choiceDisplay;
+}
+
+async function addOption({ questionIndex }: { questionIndex: number }): Promise<void> {
+  clearSurveyValidationError();
+  if (surveyConfig.value === null) {
+    return;
+  }
+
+  const question = surveyConfig.value.questions[questionIndex];
+  if (question.questionType === "free_text") {
+    return;
+  }
+
+  question.options.push(createEmptySurveyOption({ displayOrder: question.options.length }));
+  await focusOptionInput({
+    questionIndex,
+    optionIndex: question.options.length - 1,
+  });
+}
+
+function requestRemoveOption({
+  questionIndex,
+  optionIndex,
+}: {
+  questionIndex: number;
+  optionIndex: number;
+}): void {
+  pendingRemoval.value = { type: "option", questionIndex, optionIndex };
+}
+
+function removeOption({
+  questionIndex,
+  optionIndex,
+}: {
+  questionIndex: number;
+  optionIndex: number;
+}): void {
+  clearSurveyValidationError();
+  if (surveyConfig.value === null) {
+    return;
+  }
+
+  const question = surveyConfig.value.questions[questionIndex];
+  if (question.questionType === "free_text" || question.options.length <= 2) {
+    return;
+  }
+
+  question.options.splice(optionIndex, 1);
+  question.options = question.options.map((option, index) => ({
+    ...option,
+    displayOrder: index,
+  }));
+  question.constraints = normalizeChoiceSurveyQuestionConstraints({
+    minSelections: question.constraints.minSelections,
+    maxSelections: question.constraints.maxSelections,
+    optionCount: question.options.length,
+  });
+}
+
+function updateOptionText({
+  questionIndex,
+  optionIndex,
+  optionText,
+}: {
+  questionIndex: number;
+  optionIndex: number;
+  optionText: string | number | null;
+}): void {
+  clearSurveyValidationError();
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (question === undefined || question.questionType === "free_text") {
+    return;
+  }
+
+  const option = question.options[optionIndex];
+  if (option === undefined) {
+    return;
+  }
+
+  option.optionText = String(optionText ?? "");
+  syncOptionSemanticChangeFlag({ questionIndex, optionIndex });
+}
+
+function parseOptionalInteger(value: string | number | null): number | undefined {
+  if (value === null || value === "") {
+    return undefined;
+  }
+
+  const parsedValue = Number(value);
+  if (!Number.isSafeInteger(parsedValue)) {
+    return undefined;
+  }
+
+  return parsedValue;
+}
+
+function updateChoiceConstraints({
+  questionIndex,
+  minSelections,
+  maxSelections,
+}: {
+  questionIndex: number;
+  minSelections: string | number | null;
+  maxSelections: string | number | null | undefined;
+}): void {
+  clearSurveyValidationError();
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (question === undefined || question.questionType !== "choice") {
+    return;
+  }
+
+  const parsedMinSelections = Math.max(parseOptionalInteger(minSelections) ?? 1, 1);
+  const parsedMaxSelections = parseOptionalInteger(maxSelections ?? null);
+  question.constraints = normalizeChoiceSurveyQuestionConstraints({
+    minSelections: parsedMinSelections,
+    maxSelections: parsedMaxSelections,
+    optionCount: question.options.length,
+  });
+}
+
+function updateFreeTextInputMode({
+  questionIndex,
+  inputMode,
+}: {
+  questionIndex: number;
+  inputMode: "rich_text" | "integer" | null;
+}): void {
+  clearSurveyValidationError();
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (question === undefined || question.questionType !== "free_text" || inputMode === null) {
+    return;
+  }
+
+  question.constraints =
+    inputMode === "integer"
+      ? createIntegerSurveyQuestionConstraints()
+      : createRichTextSurveyQuestionConstraints();
+}
+
+function updateRichTextConstraints({
+  questionIndex,
+  minPlainTextLength,
+  maxPlainTextLength,
+}: {
+  questionIndex: number;
+  minPlainTextLength: string | number | null | undefined;
+  maxPlainTextLength: string | number | null;
+}): void {
+  clearSurveyValidationError();
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (
+    question === undefined ||
+    question.questionType !== "free_text" ||
+    question.constraints.type !== "free_text" ||
+    question.constraints.inputMode === "integer"
+  ) {
+    return;
+  }
+
+  const parsedMaxPlainTextLength = Math.max(
+    parseOptionalInteger(maxPlainTextLength) ?? 300,
+    1
+  );
+  question.constraints = {
+    type: "free_text",
+    inputMode: "rich_text",
+    minPlainTextLength: parseOptionalInteger(minPlainTextLength ?? null),
+    maxPlainTextLength: parsedMaxPlainTextLength,
+    maxHtmlLength: parsedMaxPlainTextLength * 10,
+  };
+}
+
+function updateIntegerConstraints({
+  questionIndex,
+  minValue,
+  maxValue,
+}: {
+  questionIndex: number;
+  minValue: string | number | null | undefined;
+  maxValue: string | number | null | undefined;
+}): void {
+  clearSurveyValidationError();
+  const question = surveyConfig.value?.questions[questionIndex];
+  if (
+    question === undefined ||
+    question.questionType !== "free_text" ||
+    question.constraints.type !== "free_text" ||
+    question.constraints.inputMode !== "integer"
+  ) {
+    return;
+  }
+
+  question.constraints = {
+    type: "free_text",
+    inputMode: "integer",
+    minValue: Math.max(parseOptionalInteger(minValue ?? null) ?? 1, 1),
+    maxValue: parseOptionalInteger(maxValue ?? null),
+  };
+}
+
+function handleConfirmRemoval(): void {
+  const target = pendingRemoval.value;
+  pendingRemoval.value = null;
+
+  switch (target?.type) {
+    case undefined:
+      return;
+    case "question":
+      removeQuestion({ questionIndex: target.questionIndex });
+      return;
+    case "option":
+      removeOption({
+        questionIndex: target.questionIndex,
+        optionIndex: target.optionIndex,
+      });
+      return;
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.survey-config-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.survey-config-editor__intro-card,
+.survey-config-editor__empty-card,
+.survey-config-editor__question-card,
+.survey-config-editor__body--card {
+  background: white;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.survey-config-editor__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.survey-config-editor__title {
+  color: #111827;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.survey-config-editor__description,
+.survey-config-editor__help {
+  color: #6b7280;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.survey-config-editor__question-header,
+.survey-config-editor__actions {
+  align-items: flex-start;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.survey-config-editor__question-header {
+  justify-content: space-between;
+}
+
+.survey-config-editor__actions {
+  gap: 0.5rem;
+}
+
+.survey-config-editor__constraints-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.survey-config-editor__constraints-stack,
+.survey-config-editor__options-list,
+.survey-config-editor__option-editor,
+.survey-config-editor__help-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.survey-config-editor__constraints-stack {
+  gap: 1rem;
+}
+
+.survey-config-editor__options-list {
+  gap: 0.75rem;
+}
+
+.survey-config-editor__option-editor,
+.survey-config-editor__help-block {
+  gap: 0.35rem;
+}
+
+.survey-config-editor__help-block {
+  margin-top: -0.35rem;
+}
+
+.survey-config-editor__help-block--nested {
+  padding-inline-start: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .survey-config-editor__constraints-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .survey-config-editor__question-header {
+    flex-direction: column;
+  }
+}
+</style>

--- a/services/agora/src/pages/conversation/[conversationSlugId]/edit/survey/index.vue
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/edit/survey/index.vue
@@ -19,252 +19,38 @@
     <PageLoadingSpinner v-if="isLoading" />
 
     <div v-else class="container">
-      <ZKCard padding="1rem" class="intro-card">
-        <div class="intro-card__title">{{ t("title") }}</div>
-        <div class="intro-card__description">{{ t("description") }}</div>
-        <q-toggle
-          :model-value="isSurveyOptional"
-          :label="t('optionalSurveyToggleLabel')"
-          @update:model-value="(value) => updateSurveyOptional({ isOptional: value })"
-        />
-        <div class="intro-card__description">
-          {{ isSurveyOptional ? t("optionalSurveyToggleHint") : t("requiredSurveyToggleHint") }}
-        </div>
-      </ZKCard>
+      <SurveyConfigEditor
+        v-model:survey-config="surveyConfig"
+        body-card
+        :texts="surveyEditorTexts"
+        :display-language="locale"
+        :original-survey-config="originalSurveyConfig"
+        :show-validation-errors="surveyValidationErrorMessage !== null"
+        @clear-validation-error="clearSurveyValidationError"
+      >
+        <template #between-intro-and-editor>
+          <ZKCard padding="1rem" class="summary-card">
+            <div class="summary-card__title">{{ t("changeSummaryTitle") }}</div>
+            <div v-if="hasAnySummaryChanges" class="summary-card__list">
+              <div>{{ t("addedQuestions", { count: changeSummary.addedQuestionCount }) }}</div>
+              <div>{{ t("removedQuestions", { count: changeSummary.removedQuestionCount }) }}</div>
+              <div>{{ t("updatedQuestions", { count: changeSummary.updatedQuestionCount }) }}</div>
+              <div>{{ t("addedOptions", { count: changeSummary.addedOptionCount }) }}</div>
+              <div>{{ t("removedOptions", { count: changeSummary.removedOptionCount }) }}</div>
+              <div>{{ t("updatedOptions", { count: changeSummary.updatedOptionCount }) }}</div>
+            </div>
 
-      <ZKCard padding="1rem" class="summary-card">
-        <div class="summary-card__title">{{ t("changeSummaryTitle") }}</div>
-        <div v-if="hasAnySummaryChanges" class="summary-card__list">
-          <div>{{ t("addedQuestions", { count: changeSummary.addedQuestionCount }) }}</div>
-          <div>{{ t("removedQuestions", { count: changeSummary.removedQuestionCount }) }}</div>
-          <div>{{ t("updatedQuestions", { count: changeSummary.updatedQuestionCount }) }}</div>
-          <div>{{ t("addedOptions", { count: changeSummary.addedOptionCount }) }}</div>
-          <div>{{ t("removedOptions", { count: changeSummary.removedOptionCount }) }}</div>
-          <div>{{ t("updatedOptions", { count: changeSummary.updatedOptionCount }) }}</div>
-        </div>
+            <div v-else class="summary-card__empty">{{ t("noChangesSummary") }}</div>
+          </ZKCard>
 
-        <div v-else class="summary-card__empty">{{ t("noChangesSummary") }}</div>
-      </ZKCard>
-
-      <SurveyCompletionCountsCard
-        v-if="completionCountsQuery.data.value !== undefined"
-        :has-survey="completionCountsQuery.data.value.hasSurvey"
-        :counts="completionCountsQuery.data.value.counts"
-      />
-
-      <div class="editor-card">
-        <div v-if="surveyConfigValue === null || surveyConfigValue.questions.length === 0" class="empty-card">
-          <div class="empty-card__title">{{ t("noSurveyTitle") }}</div>
-          <div class="empty-card__description">{{ t("noSurveyDescription") }}</div>
-        </div>
-
-        <div v-for="(question, questionIndex) in surveyQuestions" :key="questionIndex" class="question-card">
-          <div class="question-card__header">
-            <div class="question-card__title">{{ t("questionTitle", { number: questionIndex + 1 }) }}</div>
-            <q-btn
-              flat
-              no-caps
-              color="negative"
-              :label="t('removeLabel')"
-              @click="requestRemoveQuestion({ questionIndex })"
-            />
-          </div>
-
-          <q-select
-            :model-value="question.questionType"
-            outlined
-            emit-value
-            map-options
-            :label="t('questionTypeLabel')"
-            :options="questionTypeOptions"
-            @update:model-value="(value) => updateQuestionType({ questionIndex, questionType: value })"
+          <SurveyCompletionCountsCard
+            v-if="completionCountsQuery.data.value !== undefined"
+            :has-survey="completionCountsQuery.data.value.hasSurvey"
+            :counts="completionCountsQuery.data.value.counts"
           />
+        </template>
 
-          <q-select
-            v-if="question.questionType !== 'free_text'"
-            :model-value="question.choiceDisplay"
-            outlined
-            emit-value
-            map-options
-            :label="t('choiceDisplayLabel')"
-            :options="choiceDisplayOptions"
-            @update:model-value="(value) => updateQuestionChoiceDisplay({ questionIndex, choiceDisplay: value })"
-          />
-
-          <q-input
-            :model-value="question.questionText"
-            outlined
-            autogrow
-            :maxlength="500"
-            :error="shouldShowQuestionTextError({ question })"
-            :label="t('questionPromptLabel')"
-            @update:model-value="(value) => updateQuestionText({ questionIndex, questionText: value })"
-          />
-
-          <div
-            v-if="shouldShowQuestionSemanticToggle({ question })"
-            class="semantic-change-block"
-          >
-            <q-toggle
-              :model-value="question.textChangeIsSemantic === true"
-              :label="t('questionSemanticChangeLabel')"
-              @update:model-value="(value) => updateQuestionSemanticChange({ questionIndex, isSemantic: value === true })"
-            />
-            <div class="semantic-change-block__hint">
-              {{ t("questionSemanticChangeHint") }}
-            </div>
-          </div>
-
-          <q-toggle
-            :model-value="isSurveyOptional ? false : question.isRequired"
-            :disable="isSurveyOptional"
-            :label="isSurveyOptional || !question.isRequired ? t('optionalLabel') : t('requiredLabel')"
-            @update:model-value="(value) => updateQuestionRequired({ questionIndex, isRequired: value })"
-          />
-          <div v-if="isSurveyOptional" class="semantic-change-block__hint">
-            {{ t("questionRequirementDisabledHint") }}
-          </div>
-
-          <div v-if="question.questionType === 'choice'" class="constraints-grid">
-            <q-input
-              :model-value="question.constraints.minSelections"
-              v-bind="getChoiceConstraintInputAttrs({ optionCount: question.options.length })"
-              outlined
-              type="number"
-              :label="t('minSelectionsLabel')"
-              @update:model-value="(value) => updateChoiceConstraints({ questionIndex, minSelections: value, maxSelections: question.constraints.maxSelections })"
-            />
-
-            <q-input
-              :model-value="question.constraints.maxSelections ?? ''"
-              v-bind="getChoiceConstraintInputAttrs({ optionCount: question.options.length })"
-              outlined
-              type="number"
-              :label="t('maxSelectionsLabel')"
-              @update:model-value="(value) => updateChoiceConstraints({ questionIndex, minSelections: question.constraints.minSelections, maxSelections: value })"
-            />
-          </div>
-
-          <div v-else-if="question.questionType === 'free_text'" class="constraints-stack">
-            <q-select
-              :model-value="question.constraints.type === 'free_text' ? question.constraints.inputMode : 'rich_text'"
-              outlined
-              emit-value
-              map-options
-              :label="templateTexts.answerFormatLabel"
-              :options="freeTextInputModeOptions"
-              @update:model-value="(value) => updateFreeTextInputMode({ questionIndex, inputMode: value })"
-            />
-
-            <div v-if="question.constraints.type === 'free_text' && question.constraints.inputMode === 'integer'" class="constraints-grid">
-              <q-input
-                :model-value="getIntegerConstraints({ constraints: question.constraints })?.minValue ?? 1"
-                outlined
-                type="number"
-                :label="templateTexts.minValueLabel"
-                @update:model-value="(value) => updateIntegerConstraints({ questionIndex, minValue: value, maxValue: getIntegerConstraints({ constraints: question.constraints })?.maxValue })"
-              />
-
-              <q-input
-                :model-value="getIntegerConstraints({ constraints: question.constraints })?.maxValue ?? ''"
-                outlined
-                type="number"
-                :label="templateTexts.maxValueLabel"
-                @update:model-value="(value) => updateIntegerConstraints({ questionIndex, minValue: getIntegerConstraints({ constraints: question.constraints })?.minValue, maxValue: value })"
-              />
-            </div>
-
-            <div v-else class="constraints-grid">
-              <q-input
-                :model-value="getRichTextConstraints({ constraints: question.constraints })?.minPlainTextLength ?? ''"
-                outlined
-                type="number"
-                :label="t('minTextLengthLabel')"
-                @update:model-value="(value) => updateRichTextConstraints({ questionIndex, minPlainTextLength: value, maxPlainTextLength: getRichTextConstraints({ constraints: question.constraints })?.maxPlainTextLength ?? 300 })"
-              />
-
-              <q-input
-                :model-value="getRichTextConstraints({ constraints: question.constraints })?.maxPlainTextLength ?? 300"
-                outlined
-                type="number"
-                :label="t('maxTextLengthLabel')"
-                @update:model-value="(value) => updateRichTextConstraints({ questionIndex, minPlainTextLength: getRichTextConstraints({ constraints: question.constraints })?.minPlainTextLength, maxPlainTextLength: value })"
-              />
-            </div>
-
-            <div class="semantic-change-block__hint">
-              {{ question.constraints.type === 'free_text' && question.constraints.inputMode === 'integer' ? templateTexts.numericInputHelp : '' }}
-            </div>
-          </div>
-
-          <div v-if="question.questionType !== 'free_text'" class="options-list">
-            <div
-              v-for="(option, optionIndex) in question.options ?? []"
-              :id="getOptionInputId({ questionIndex, optionIndex })"
-              :key="optionIndex"
-              class="option-editor"
-              @keydown.enter="handleOptionEditorEnter({ event: $event, questionIndex })"
-            >
-              <q-input
-                :model-value="option.optionText"
-                outlined
-                :maxlength="200"
-                :error="shouldShowOptionTextError({ question, option })"
-                :label="t('optionLabel', { number: optionIndex + 1 })"
-                @update:model-value="(value) => updateOptionText({ questionIndex, optionIndex, optionText: value })"
-              >
-                <template #append>
-                  <q-btn
-                    v-if="(question.options?.length ?? 0) > 2"
-                    flat
-                    round
-                    dense
-                    icon="mdi-close"
-                    @click.stop="requestRemoveOption({ questionIndex, optionIndex })"
-                  />
-                </template>
-              </q-input>
-
-              <div
-                v-if="shouldShowOptionSemanticToggle({ question, option })"
-                class="semantic-change-block semantic-change-block--nested"
-              >
-                <q-toggle
-                  :model-value="option.textChangeIsSemantic === true"
-                  :label="t('optionSemanticChangeLabel')"
-                  @update:model-value="(value) => updateOptionSemanticChange({ questionIndex, optionIndex, isSemantic: value === true })"
-                />
-                <div class="semantic-change-block__hint">
-                  {{ t("optionSemanticChangeHint") }}
-                </div>
-              </div>
-            </div>
-
-            <q-btn flat no-caps color="primary" :label="t('addOptionLabel')" @click="addOption({ questionIndex })" />
-
-            <ZKInfoBanner
-              v-if="
-                shouldShowLargeOptionWarning({
-                  choiceDisplay: question.choiceDisplay,
-                  optionCount: question.options?.length ?? 0,
-                })
-              "
-              :message="
-                t('largeOptionCountWarning', {
-                  count: question.options?.length ?? 0,
-                  threshold: largeOptionWarningThreshold,
-                })
-              "
-            />
-          </div>
-        </div>
-
-        <div class="editor-actions">
-          <q-btn flat no-caps color="primary" :label="t('addQuestionLabel')" @click="addQuestion" />
-          <q-btn flat no-caps color="primary" :label="templateTexts.addAgeGroupLabel" @click="addTemplateQuestion({ templateId: 'age_group' })" />
-          <q-btn flat no-caps color="primary" :label="templateTexts.addAgeLabel" @click="addTemplateQuestion({ templateId: 'age' })" />
-          <q-btn flat no-caps color="primary" :label="templateTexts.addSexAtBirthLabel" @click="addTemplateQuestion({ templateId: 'sex_at_birth' })" />
-          <q-btn flat no-caps color="primary" :label="templateTexts.addGenderLabel" @click="addTemplateQuestion({ templateId: 'gender' })" />
+        <template #actions>
           <q-btn
             v-if="originalSurveyConfig !== null"
             flat
@@ -274,17 +60,17 @@
             :loading="isDeleting"
             @click="requestDeleteSurvey"
           />
-        </div>
-      </div>
+        </template>
+      </SurveyConfigEditor>
     </div>
 
     <ZKConfirmDialog
-      v-model="showRemoveDialog"
-      :message="removeDialogMessage"
-      :confirm-text="removeDialogConfirmText"
+      v-model="showDeleteDialog"
+      :message="t('confirmDeleteMessage')"
+      :confirm-text="t('deleteButton')"
       :cancel-text="t('cancelLabel')"
       variant="destructive"
-      @confirm="handleConfirmRemoval"
+      @confirm="deleteSurvey"
     />
   </NewConversationLayout>
 </template>
@@ -296,20 +82,12 @@ import BackButton from "src/components/navigation/buttons/BackButton.vue";
 import DefaultMenuBar from "src/components/navigation/header/DefaultMenuBar.vue";
 import NewConversationLayout from "src/components/newConversation/NewConversationLayout.vue";
 import SurveyCompletionCountsCard from "src/components/survey/SurveyCompletionCountsCard.vue";
+import SurveyConfigEditor from "src/components/survey/SurveyConfigEditor.vue";
 import PageLoadingSpinner from "src/components/ui/PageLoadingSpinner.vue";
 import ZKCard from "src/components/ui-library/ZKCard.vue";
 import ZKConfirmDialog from "src/components/ui-library/ZKConfirmDialog.vue";
-import ZKInfoBanner from "src/components/ui-library/ZKInfoBanner.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
-import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
-import type {
-  SurveyChoiceDisplay,
-  SurveyConfig,
-  SurveyQuestionConfig,
-  SurveyQuestionConstraints,
-  SurveyQuestionOption,
-  SurveyQuestionType,
-} from "src/shared/types/zod";
+import type { SurveyConfig } from "src/shared/types/zod";
 import {
   checkFeatureManagementAccess,
   DEFAULT_FEATURE_ALLOWED_ORGS,
@@ -328,23 +106,10 @@ import {
   areSurveyConfigsEqual,
   buildSurveyConfigForSave,
   cloneSurveyConfig,
-  createChoiceSurveyQuestionConstraints,
-  createEmptySurveyOption,
-  createEmptySurveyQuestion,
-  createIntegerSurveyQuestionConstraints,
-  createRichTextSurveyQuestionConstraints,
-  normalizeChoiceSurveyQuestionConstraints,
-  shouldWarnAboutLargeSurveyOptionSet,
   summarizeSurveyConfigChanges,
-  SURVEY_LARGE_OPTION_WARNING_THRESHOLD,
 } from "src/utils/survey/config";
-import {
-  createSurveyTemplateQuestion,
-  type SurveyTemplateId,
-} from "src/utils/survey/templates";
-import { surveyTemplateTextTranslations } from "src/utils/survey/templates.i18n";
 import { useNotify } from "src/utils/ui/notify";
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import { type EditSurveyTranslations, editSurveyTranslations } from "./index.i18n";
@@ -366,21 +131,11 @@ const conversationSlugId = getSingleRouteParam(route.params.conversationSlugId);
 const isLoading = ref(true);
 const isSaving = ref(false);
 const isDeleting = ref(false);
+const showDeleteDialog = ref(false);
 const surveyConfig = ref<SurveyConfig | null>(null);
 const originalSurveyConfig = ref<SurveyConfig | null>(null);
 const surveyValidationErrorMessage = ref<string | null>(null);
 
-type PendingRemoval =
-  | { type: "question"; questionIndex: number }
-  | { type: "option"; questionIndex: number; optionIndex: number }
-  | { type: "survey" };
-
-const pendingRemoval = ref<PendingRemoval | null>(null);
-
-const surveyConfigValue = computed(() => surveyConfig.value);
-const surveyQuestions = computed(() => surveyConfig.value?.questions ?? []);
-const isSurveyOptional = computed(() => surveyConfig.value?.isOptional === true);
-const largeOptionWarningThreshold = SURVEY_LARGE_OPTION_WARNING_THRESHOLD;
 const completionCountsQuery = useSurveyCompletionCountsQuery({
   conversationSlugId: computed(() => conversationSlugId),
   enabled: computed(() => !isLoading.value),
@@ -405,92 +160,6 @@ const isSaveDisabled = computed(() => {
     !hasUnsavedChanges.value
   );
 });
-
-function shouldShowLargeOptionWarning({
-  choiceDisplay,
-  optionCount,
-}: {
-  choiceDisplay: SurveyChoiceDisplay;
-  optionCount: number;
-}): boolean {
-  return shouldWarnAboutLargeSurveyOptionSet({ choiceDisplay, optionCount });
-}
-
-function clearSurveyValidationError(): void {
-  surveyValidationErrorMessage.value = null;
-}
-
-function showSurveyValidationError(): void {
-  surveyValidationErrorMessage.value = t("validationError");
-}
-
-function shouldShowQuestionTextError({
-  question,
-}: {
-  question: SurveyQuestionConfig;
-}): boolean {
-  return (
-    surveyValidationErrorMessage.value !== null && question.questionText.trim() === ""
-  );
-}
-
-function shouldShowOptionTextError({
-  question,
-  option,
-}: {
-  question: SurveyQuestionConfig;
-  option: SurveyQuestionOption;
-}): boolean {
-  return (
-    surveyValidationErrorMessage.value !== null &&
-    question.questionType === "choice" &&
-    option.optionText.trim() === ""
-  );
-}
-
-function getOptionInputId({
-  questionIndex,
-  optionIndex,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-}): string {
-  return `survey-option-input-${questionIndex}-${optionIndex}`;
-}
-
-function getChoiceConstraintInputAttrs({
-  optionCount,
-}: {
-  optionCount: number;
-}): { min: number; max: number } {
-  return { min: 1, max: optionCount };
-}
-
-async function handleOptionEditorEnter({
-  event,
-  questionIndex,
-}: {
-  event: KeyboardEvent;
-  questionIndex: number;
-}): Promise<void> {
-  if (!(event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement)) return;
-  event.preventDefault();
-  await addOption({ questionIndex });
-}
-
-async function focusOptionInput({
-  questionIndex,
-  optionIndex,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-}): Promise<void> {
-  await nextTick();
-  const input = document
-    .getElementById(getOptionInputId({ questionIndex, optionIndex }))
-    ?.querySelector<HTMLInputElement>("input");
-  input?.focus();
-}
 const changeSummary = computed(() => {
   return summarizeSurveyConfigChanges({
     previousSurveyConfig: originalSurveyConfig.value,
@@ -507,72 +176,62 @@ const hasAnySummaryChanges = computed(() => {
     changeSummary.value.updatedOptionCount > 0
   );
 });
-const showRemoveDialog = computed({
-  get: () => pendingRemoval.value !== null,
-  set: (value: boolean) => {
-    if (!value) {
-      pendingRemoval.value = null;
-    }
-  },
-});
-const removeDialogMessage = computed(() => {
-  switch (pendingRemoval.value?.type) {
-    case undefined:
-      return "";
-    case "question":
-      return t("confirmRemoveQuestionMessage");
-    case "option":
-      return t("confirmRemoveOptionMessage");
-    case "survey":
-      return t("confirmDeleteMessage");
-  }
-
-  return "";
-});
-const removeDialogConfirmText = computed(() => {
-  switch (pendingRemoval.value?.type) {
-    case undefined:
-      return t("removeLabel");
-    case "question":
-      return t("confirmRemoveQuestionButtonLabel");
-    case "option":
-      return t("confirmRemoveOptionButtonLabel");
-    case "survey":
-      return t("deleteButton");
-  }
-
-  return t("removeLabel");
-});
-
-const questionTypeOptions: Array<{ label: string; value: SurveyQuestionType }> = [
-  { label: t("typeChoice"), value: "choice" },
-  { label: t("typeFreeText"), value: "free_text" },
-];
-const choiceDisplayOptions: Array<{ label: string; value: SurveyChoiceDisplay }> = [
-  { label: t("choiceDisplayAuto"), value: "auto" },
-  { label: t("choiceDisplayList"), value: "list" },
-  { label: t("choiceDisplayDropdown"), value: "dropdown" },
-];
-const templateTexts = computed(() => {
-  const currentLocale = locale.value as SupportedDisplayLanguageCodes;
-  return (
-    surveyTemplateTextTranslations[currentLocale] ??
-    surveyTemplateTextTranslations.en
-  );
-});
-const freeTextInputModeOptions = computed<
-  Array<{ label: string; value: "rich_text" | "integer" }>
->(() => [
-  { label: templateTexts.value.answerFormatRichText, value: "rich_text" },
-  { label: templateTexts.value.answerFormatNumber, value: "integer" },
-]);
+const surveyEditorTexts = computed(() => ({
+  title: t("title"),
+  description: t("description"),
+  optionalSurveyToggleLabel: t("optionalSurveyToggleLabel"),
+  optionalSurveyToggleHint: t("optionalSurveyToggleHint"),
+  requiredSurveyToggleHint: t("requiredSurveyToggleHint"),
+  noQuestionsTitle: t("noSurveyTitle"),
+  noQuestionsDescription: t("noSurveyDescription"),
+  questionTitle: ({ number }: { number: number }) =>
+    t("questionTitle", { number }),
+  optionalLabel: t("optionalLabel"),
+  requiredLabel: t("requiredLabel"),
+  removeQuestionLabel: t("removeLabel"),
+  questionTypeLabel: t("questionTypeLabel"),
+  typeChoice: t("typeChoice"),
+  typeFreeText: t("typeFreeText"),
+  choiceDisplayLabel: t("choiceDisplayLabel"),
+  choiceDisplayAuto: t("choiceDisplayAuto"),
+  choiceDisplayList: t("choiceDisplayList"),
+  choiceDisplayDropdown: t("choiceDisplayDropdown"),
+  questionPromptLabel: t("questionPromptLabel"),
+  questionRequirementDisabledHint: t("questionRequirementDisabledHint"),
+  minSelectionsLabel: t("minSelectionsLabel"),
+  maxSelectionsLabel: t("maxSelectionsLabel"),
+  minTextLengthLabel: t("minTextLengthLabel"),
+  maxTextLengthLabel: t("maxTextLengthLabel"),
+  optionLabel: ({ number }: { number: number }) => t("optionLabel", { number }),
+  addOptionLabel: t("addOptionLabel"),
+  addQuestionLabel: t("addQuestionLabel"),
+  cancelLabel: t("cancelLabel"),
+  confirmRemoveQuestionMessage: t("confirmRemoveQuestionMessage"),
+  confirmRemoveOptionMessage: t("confirmRemoveOptionMessage"),
+  confirmRemoveQuestionButtonLabel: t("confirmRemoveQuestionButtonLabel"),
+  confirmRemoveOptionButtonLabel: t("confirmRemoveOptionButtonLabel"),
+  largeOptionCountWarning: ({
+    count,
+    threshold,
+  }: {
+    count: number;
+    threshold: number;
+  }) => t("largeOptionCountWarning", { count, threshold }),
+  questionSemanticChangeLabel: t("questionSemanticChangeLabel"),
+  questionSemanticChangeHint: t("questionSemanticChangeHint"),
+  optionSemanticChangeLabel: t("optionSemanticChangeLabel"),
+  optionSemanticChangeHint: t("optionSemanticChangeHint"),
+}));
 
 onMounted(async () => {
   const response = await getConversationForEdit(conversationSlugId);
 
   if (!response.success) {
     showNotifyMessage(t("loadError"));
-    await router.replace({ name: "/conversation/[conversationSlugId]/edit/", params: { conversationSlugId } });
+    await router.replace({
+      name: "/conversation/[conversationSlugId]/edit/",
+      params: { conversationSlugId },
+    });
     return;
   }
 
@@ -605,6 +264,14 @@ onMounted(async () => {
   isLoading.value = false;
 });
 
+function clearSurveyValidationError(): void {
+  surveyValidationErrorMessage.value = null;
+}
+
+function showSurveyValidationError(): void {
+  surveyValidationErrorMessage.value = t("validationError");
+}
+
 async function redirectToConversation(): Promise<void> {
   await router.replace({
     name: "/conversation/[postSlugId]/",
@@ -612,427 +279,14 @@ async function redirectToConversation(): Promise<void> {
   });
 }
 
-function getOriginalQuestion({
-  question,
-}: {
-  question: SurveyQuestionConfig;
-}): SurveyQuestionConfig | undefined {
-  if (question.questionSlugId === undefined) {
-    return undefined;
-  }
-
-  return originalSurveyConfig.value?.questions.find((candidate) => {
-    return candidate.questionSlugId === question.questionSlugId;
-  });
-}
-
-function getOriginalOption({
-  question,
-  option,
-}: {
-  question: SurveyQuestionConfig;
-  option: SurveyQuestionOption;
-}): SurveyQuestionOption | undefined {
-  if (option.optionSlugId === undefined) {
-    return undefined;
-  }
-
-  const originalQuestion = getOriginalQuestion({ question });
-  if (originalQuestion === undefined || originalQuestion.questionType === "free_text") {
-    return undefined;
-  }
-
-  return originalQuestion.options.find((candidate) => {
-    return candidate.optionSlugId === option.optionSlugId;
-  });
-}
-
-function shouldShowQuestionSemanticToggle({
-  question,
-}: {
-  question: SurveyQuestionConfig;
-}): boolean {
-  const originalQuestion = getOriginalQuestion({ question });
-
-  return (
-    originalQuestion !== undefined &&
-    originalQuestion.questionText !== question.questionText
-  );
-}
-
-function shouldShowOptionSemanticToggle({
-  question,
-  option,
-}: {
-  question: SurveyQuestionConfig;
-  option: SurveyQuestionOption;
-}): boolean {
-  const originalOption = getOriginalOption({ question, option });
-
-  return originalOption !== undefined && originalOption.optionText !== option.optionText;
-}
-
-function syncQuestionSemanticChangeFlag({ questionIndex }: { questionIndex: number }): void {
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (question === undefined) {
-    return;
-  }
-
-  if (!shouldShowQuestionSemanticToggle({ question })) {
-    question.textChangeIsSemantic = undefined;
-  }
-}
-
-function syncOptionSemanticChangeFlag({
-  questionIndex,
-  optionIndex,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-}): void {
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (question === undefined || question.questionType === "free_text") {
-    return;
-  }
-
-  const option = question.options[optionIndex];
-  if (option === undefined) {
-    return;
-  }
-
-  if (!shouldShowOptionSemanticToggle({ question, option })) {
-    option.textChangeIsSemantic = undefined;
-  }
-}
-
-function updateQuestionSemanticChange({
-  questionIndex,
-  isSemantic,
-}: {
-  questionIndex: number;
-  isSemantic: boolean;
-}): void {
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (question === undefined) {
-    return;
-  }
-
-  question.textChangeIsSemantic = isSemantic ? true : undefined;
-}
-
-function updateOptionSemanticChange({
-  questionIndex,
-  optionIndex,
-  isSemantic,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-  isSemantic: boolean;
-}): void {
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (question === undefined || question.questionType === "free_text") {
-    return;
-  }
-
-  const option = question.options[optionIndex];
-  if (option === undefined) {
-    return;
-  }
-
-  option.textChangeIsSemantic = isSemantic ? true : undefined;
-}
-
-function ensureSurveyConfig(): void {
-  if (surveyConfig.value === null) {
-    surveyConfig.value = { isOptional: false, questions: [] };
-  }
-}
-
-function updateSurveyOptional({ isOptional }: { isOptional: boolean | null }): void {
-  ensureSurveyConfig();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  surveyConfig.value.isOptional = isOptional === true;
-}
-
-function addQuestion(): void {
-  clearSurveyValidationError();
-  ensureSurveyConfig();
-  surveyConfig.value?.questions.push(
-    createEmptySurveyQuestion({ displayOrder: surveyConfig.value.questions.length })
-  );
-}
-
-function addTemplateQuestion({ templateId }: { templateId: SurveyTemplateId }): void {
-  clearSurveyValidationError();
-  ensureSurveyConfig();
-  surveyConfig.value?.questions.push(
-    createSurveyTemplateQuestion({
-      templateId,
-      displayOrder: surveyConfig.value.questions.length,
-      displayLanguage: locale.value as SupportedDisplayLanguageCodes,
-    })
-  );
-}
-
-function getIntegerConstraints({
-  constraints,
-}: {
-  constraints: SurveyQuestionConstraints;
-}): Extract<SurveyQuestionConstraints, { type: "free_text"; inputMode: "integer" }> | undefined {
-  return constraints.type === "free_text" && constraints.inputMode === "integer"
-    ? constraints
-    : undefined;
-}
-
-function getRichTextConstraints({
-  constraints,
-}: {
-  constraints: SurveyQuestionConstraints;
-}): Extract<SurveyQuestionConstraints, { type: "free_text"; inputMode: "rich_text" }> | undefined {
-  return constraints.type === "free_text" && constraints.inputMode !== "integer"
-    ? constraints
-    : undefined;
-}
-
-function reindexSurveyQuestion({ question, displayOrder }: { question: SurveyQuestionConfig; displayOrder: number }): SurveyQuestionConfig {
-  if (question.questionType === "free_text") {
-    return {
-      ...question,
-      displayOrder,
-    };
-  }
-
-  return {
-    ...question,
-    displayOrder,
-    options: question.options.map((option, optionIndex) => ({
-      ...option,
-      displayOrder: optionIndex,
-    })),
-  };
-}
-
-function requestRemoveQuestion({ questionIndex }: { questionIndex: number }): void {
-  pendingRemoval.value = { type: "question", questionIndex };
-}
-
-function performRemoveQuestion({ questionIndex }: { questionIndex: number }): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) return;
-  surveyConfig.value.questions.splice(questionIndex, 1);
-  if (surveyConfig.value.questions.length === 0) {
-    surveyConfig.value = null;
-    return;
-  }
-  surveyConfig.value.questions = surveyConfig.value.questions.map((question, index) =>
-    reindexSurveyQuestion({ question, displayOrder: index })
-  );
-}
-
-function updateQuestionText({ questionIndex, questionText }: { questionIndex: number; questionText: string | number | null }): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) return;
-  surveyConfig.value.questions[questionIndex].questionText = String(questionText ?? "");
-  syncQuestionSemanticChangeFlag({ questionIndex });
-}
-
-function updateQuestionRequired({ questionIndex, isRequired }: { questionIndex: number; isRequired: boolean | null }): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) return;
-  surveyConfig.value.questions[questionIndex].isRequired = isRequired === true;
-}
-
-function updateQuestionType({ questionIndex, questionType }: { questionIndex: number; questionType: SurveyQuestionType | null }): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null || questionType === null) return;
-
-  const currentQuestion = surveyConfig.value.questions[questionIndex];
-  const questionBase = {
-    questionSlugId: currentQuestion.questionSlugId,
-    questionText: currentQuestion.questionText,
-    isRequired: currentQuestion.isRequired,
-    displayOrder: currentQuestion.displayOrder,
-    textChangeIsSemantic: currentQuestion.textChangeIsSemantic,
-  };
-  const currentChoiceDisplay = currentQuestion.questionType === "free_text"
-    ? "auto"
-    : currentQuestion.choiceDisplay;
-  const currentOptions = currentQuestion.questionType === "free_text"
-    ? []
-    : currentQuestion.options;
-  const nextOptions = currentOptions.length >= 2
-    ? currentOptions
-    : [createEmptySurveyOption({ displayOrder: 0 }), createEmptySurveyOption({ displayOrder: 1 })];
-
-  if (questionType === "free_text") {
-    surveyConfig.value.questions[questionIndex] = {
-      ...questionBase,
-      questionType: "free_text",
-      constraints: createRichTextSurveyQuestionConstraints(),
-    };
-    return;
-  }
-
-  surveyConfig.value.questions[questionIndex] = {
-    ...questionBase,
-    questionType: "choice",
-    choiceDisplay: currentChoiceDisplay,
-    constraints: createChoiceSurveyQuestionConstraints(),
-    options: nextOptions,
-  };
-}
-
-function updateQuestionChoiceDisplay({ questionIndex, choiceDisplay }: { questionIndex: number; choiceDisplay: SurveyChoiceDisplay | null }): void {
-  clearSurveyValidationError();
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (question === undefined || question.questionType === "free_text" || choiceDisplay === null) return;
-  question.choiceDisplay = choiceDisplay;
-}
-
-async function addOption({ questionIndex }: { questionIndex: number }): Promise<void> {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) return;
-  const question = surveyConfig.value.questions[questionIndex];
-  if (question.questionType === "free_text") return;
-  question.options.push(createEmptySurveyOption({ displayOrder: question.options.length }));
-  await focusOptionInput({
-    questionIndex,
-    optionIndex: question.options.length - 1,
-  });
-}
-
-function requestRemoveOption({
-  questionIndex,
-  optionIndex,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-}): void {
-  pendingRemoval.value = { type: "option", questionIndex, optionIndex };
-}
-
-function performRemoveOption({ questionIndex, optionIndex }: { questionIndex: number; optionIndex: number }): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) return;
-  const question = surveyConfig.value.questions[questionIndex];
-  if (question.questionType === "free_text" || question.options.length <= 2) return;
-  question.options.splice(optionIndex, 1);
-  question.options = question.options.map((option, index) => ({ ...option, displayOrder: index }));
-  question.constraints = normalizeChoiceSurveyQuestionConstraints({
-    minSelections: question.constraints.minSelections,
-    maxSelections: question.constraints.maxSelections,
-    optionCount: question.options.length,
-  });
-}
-
-function updateOptionText({ questionIndex, optionIndex, optionText }: { questionIndex: number; optionIndex: number; optionText: string | number | null }): void {
-  clearSurveyValidationError();
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (question === undefined || question.questionType === "free_text") return;
-  const option = question.options[optionIndex];
-  if (option === undefined) return;
-  option.optionText = String(optionText ?? "");
-  syncOptionSemanticChangeFlag({ questionIndex, optionIndex });
-}
-
-function parseOptionalInteger(value: string | number | null): number | undefined {
-  if (value === null || value === "") return undefined;
-  const parsedValue = Number(value);
-  if (!Number.isSafeInteger(parsedValue)) return undefined;
-  return parsedValue;
-}
-
-function updateChoiceConstraints({ questionIndex, minSelections, maxSelections }: { questionIndex: number; minSelections: string | number | null; maxSelections: string | number | null | undefined }): void {
-  clearSurveyValidationError();
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (question === undefined || question.questionType !== "choice") return;
-  const parsedMinSelections = Math.max(parseOptionalInteger(minSelections) ?? 1, 1);
-  const parsedMaxSelections = parseOptionalInteger(maxSelections ?? null);
-  question.constraints = normalizeChoiceSurveyQuestionConstraints({
-    minSelections: parsedMinSelections,
-    maxSelections: parsedMaxSelections,
-    optionCount: question.options.length,
-  });
-}
-
-function updateFreeTextInputMode({ questionIndex, inputMode }: { questionIndex: number; inputMode: "rich_text" | "integer" | null }): void {
-  clearSurveyValidationError();
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (question === undefined || question.questionType !== "free_text" || inputMode === null) return;
-  question.constraints = inputMode === "integer"
-    ? createIntegerSurveyQuestionConstraints()
-    : createRichTextSurveyQuestionConstraints();
-}
-
-function updateRichTextConstraints({ questionIndex, minPlainTextLength, maxPlainTextLength }: { questionIndex: number; minPlainTextLength: string | number | null | undefined; maxPlainTextLength: string | number | null }): void {
-  clearSurveyValidationError();
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (
-    question === undefined ||
-    question.questionType !== "free_text" ||
-    question.constraints.type !== "free_text" ||
-    question.constraints.inputMode === "integer"
-  ) return;
-  const parsedMaxPlainTextLength = Math.max(parseOptionalInteger(maxPlainTextLength) ?? 300, 1);
-  question.constraints = {
-    type: "free_text",
-    inputMode: "rich_text",
-    minPlainTextLength: parseOptionalInteger(minPlainTextLength ?? null),
-    maxPlainTextLength: parsedMaxPlainTextLength,
-    maxHtmlLength: parsedMaxPlainTextLength * 10,
-  };
-}
-
-function updateIntegerConstraints({ questionIndex, minValue, maxValue }: { questionIndex: number; minValue: string | number | null | undefined; maxValue: string | number | null | undefined }): void {
-  clearSurveyValidationError();
-  const question = surveyConfig.value?.questions[questionIndex];
-  if (
-    question === undefined ||
-    question.questionType !== "free_text" ||
-    question.constraints.type !== "free_text" ||
-    question.constraints.inputMode !== "integer"
-  ) return;
-  question.constraints = {
-    type: "free_text",
-    inputMode: "integer",
-    minValue: Math.max(parseOptionalInteger(minValue ?? null) ?? 1, 1),
-    maxValue: parseOptionalInteger(maxValue ?? null),
-  };
-}
-
 function requestDeleteSurvey(): void {
-  pendingRemoval.value = { type: "survey" };
-}
-
-async function handleConfirmRemoval(): Promise<void> {
-  const target = pendingRemoval.value;
-  pendingRemoval.value = null;
-
-  if (target === null) {
-    return;
-  }
-
-  switch (target.type) {
-    case "question":
-      performRemoveQuestion({ questionIndex: target.questionIndex });
-      return;
-    case "option":
-      performRemoveOption({
-        questionIndex: target.questionIndex,
-        optionIndex: target.optionIndex,
-      });
-      return;
-    case "survey":
-      await deleteSurvey();
-      return;
-  }
+  showDeleteDialog.value = true;
 }
 
 async function saveSurvey(): Promise<void> {
-  const normalizedSurveyConfigResult = buildSurveyConfigForSave({ surveyConfig: surveyConfig.value });
+  const normalizedSurveyConfigResult = buildSurveyConfigForSave({
+    surveyConfig: surveyConfig.value,
+  });
   if (!normalizedSurveyConfigResult.success) {
     showNotifyMessage(t("validationError"));
     showSurveyValidationError();
@@ -1100,90 +354,25 @@ async function deleteSurvey(): Promise<void> {
   padding-top: 0.5rem;
 }
 
-.intro-card,
-.summary-card,
-.editor-card,
-.empty-card,
-.question-card {
+.summary-card {
   display: flex;
   flex-direction: column;
   gap: 1rem;
 }
 
-.intro-card__title,
-.summary-card__title,
-.question-card__title,
-.empty-card__title {
+.summary-card__title {
   font-size: 1rem;
   font-weight: 600;
 }
 
-.intro-card__description,
-.empty-card__description,
-.summary-card__empty,
-.semantic-change-block__hint {
+.summary-card__empty {
   color: #6b7280;
   line-height: 1.4;
 }
 
-.question-card,
-.editor-card {
-  background: white;
-  border-radius: 16px;
-  padding: 1rem;
-}
-
-.question-card__header,
-.editor-actions {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.constraints-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.constraints-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.options-list,
 .summary-card__list {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-}
-
-.option-editor,
-.semantic-change-block {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.semantic-change-block {
-  margin-top: -0.35rem;
-}
-
-.semantic-change-block--nested {
-  padding-inline-start: 0.5rem;
-}
-
-@media (max-width: 700px) {
-  .constraints-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .question-card__header,
-  .editor-actions {
-    flex-direction: column;
-  }
 }
 </style>

--- a/services/agora/src/pages/conversation/[postSlugId].vue
+++ b/services/agora/src/pages/conversation/[postSlugId].vue
@@ -28,6 +28,7 @@
                 :extended-post-data="loadedConversationData"
                 :compact-mode="false"
                 @open-moderation-history="openModerationHistory()"
+                @conversation-deleted="handleConversationDeleted"
                 @verified="(payload) => handleTicketVerified(payload)"
               />
 
@@ -93,6 +94,7 @@
                 v-if="loadedConversationData.metadata.conversationType !== 'maxdiff'"
               >
                 <CommentComposer
+                  ref="commentComposerRef"
                   :post-slug-id="loadedConversationData.metadata.conversationSlugId"
                   :participation-mode="loadedConversationData.metadata.participationMode"
                   :requires-event-ticket="loadedConversationData.metadata.requiresEventTicket"
@@ -139,7 +141,7 @@ import {
   isBackToConversationCommentTab,
   navigateBackOrReplace,
 } from "src/utils/nav/historyBack";
-import { computed, onBeforeUnmount, onMounted, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
 import {
@@ -161,6 +163,7 @@ const { safeNavigateBack } = useGoBackButtonHandler();
 const authStore = useAuthenticationStore();
 const { userId } = storeToRefs(authStore);
 const { reveal: headerRevealed } = storeToRefs(useLayoutHeaderStore());
+const commentComposerRef = ref<InstanceType<typeof CommentComposer>>();
 
 const conversationConfig: ConversationParentConfig = {
   analysisRouteName: "/conversation/[postSlugId]/analysis",
@@ -233,6 +236,10 @@ function handleBack(event: MouseEvent): void {
   } else {
     void safeNavigateBack({ name: "/" });
   }
+}
+
+function handleConversationDeleted(): void {
+  commentComposerRef.value?.discardDraft();
 }
 
 // Handle conversation creation navigation

--- a/services/agora/src/pages/conversation/new/survey/index.vue
+++ b/services/agora/src/pages/conversation/new/survey/index.vue
@@ -16,225 +16,14 @@
     </Teleport>
 
     <div class="container">
-      <div class="intro-card">
-        <div class="intro-card__title">{{ t("pageTitle") }}</div>
-        <div class="intro-card__description">{{ t("pageDescription") }}</div>
-        <q-toggle
-          :model-value="isSurveyOptional"
-          :label="t('optionalSurveyToggleLabel')"
-          @update:model-value="(value) => updateSurveyOptional({ isOptional: value })"
-        />
-        <div class="intro-card__description">
-          {{ isSurveyOptional ? t("optionalSurveyToggleHint") : t("requiredSurveyToggleHint") }}
-        </div>
-      </div>
-
-      <div v-if="surveyConfigValue === null || surveyConfigValue.questions.length === 0" class="empty-card">
-        <div class="empty-card__title">{{ t("noQuestionsTitle") }}</div>
-        <div class="empty-card__description">{{ t("noQuestionsDescription") }}</div>
-      </div>
-
-      <div v-for="(question, questionIndex) in surveyQuestions" :key="questionIndex" class="question-card">
-        <div class="question-card__header">
-          <div>
-            <div class="question-card__title">
-              {{ t("questionLabel", { number: questionIndex + 1 }) }}
-            </div>
-            <div class="question-card__subtitle">
-              {{ isSurveyOptional || !question.isRequired ? t("optionalLabel") : t("requiredLabel") }}
-            </div>
-          </div>
-
-          <q-btn
-            flat
-            no-caps
-            color="negative"
-            :label="t('removeQuestionLabel')"
-            @click="requestRemoveQuestion({ questionIndex })"
-          />
-        </div>
-
-        <q-select
-          :model-value="question.questionType"
-          outlined
-          emit-value
-          map-options
-          :label="t('questionTypeLabel')"
-          :options="questionTypeOptions"
-          @update:model-value="(value) => updateQuestionType({ questionIndex, questionType: value })"
-        />
-
-        <q-select
-          v-if="question.questionType !== 'free_text'"
-          :model-value="question.choiceDisplay"
-          outlined
-          emit-value
-          map-options
-          :label="t('choiceDisplayLabel')"
-          :options="choiceDisplayOptions"
-          @update:model-value="(value) => updateQuestionChoiceDisplay({ questionIndex, choiceDisplay: value })"
-        />
-
-        <q-input
-          :model-value="question.questionText"
-          outlined
-          autogrow
-          :maxlength="500"
-          :error="shouldShowQuestionTextError({ question })"
-          :label="t('questionPromptLabel')"
-          @update:model-value="(value) => updateQuestionText({ questionIndex, questionText: value })"
-        />
-
-        <q-toggle
-          :model-value="isSurveyOptional ? false : question.isRequired"
-          :disable="isSurveyOptional"
-          :label="isSurveyOptional || !question.isRequired ? t('optionalLabel') : t('requiredLabel')"
-          @update:model-value="(value) => updateQuestionRequired({ questionIndex, isRequired: value })"
-        />
-        <div v-if="isSurveyOptional" class="constraints-help">
-          {{ t("questionRequirementDisabledHint") }}
-        </div>
-
-        <div v-if="question.questionType === 'choice'" class="constraints-grid">
-          <q-input
-            :model-value="question.constraints.minSelections"
-            v-bind="getChoiceConstraintInputAttrs({ optionCount: question.options.length })"
-            outlined
-            type="number"
-            :label="t('minSelectionsLabel')"
-            @update:model-value="(value) => updateChoiceConstraints({ questionIndex, minSelections: value, maxSelections: question.constraints.maxSelections })"
-          />
-
-          <q-input
-            :model-value="question.constraints.maxSelections ?? ''"
-            v-bind="getChoiceConstraintInputAttrs({ optionCount: question.options.length })"
-            outlined
-            type="number"
-            :label="t('maxSelectionsLabel')"
-            @update:model-value="(value) => updateChoiceConstraints({ questionIndex, minSelections: question.constraints.minSelections, maxSelections: value })"
-          />
-        </div>
-
-        <div v-else-if="question.questionType === 'free_text'" class="constraints-stack">
-          <q-select
-            :model-value="question.constraints.type === 'free_text' ? question.constraints.inputMode : 'rich_text'"
-            outlined
-            emit-value
-            map-options
-            :label="templateTexts.answerFormatLabel"
-            :options="freeTextInputModeOptions"
-            @update:model-value="(value) => updateFreeTextInputMode({ questionIndex, inputMode: value })"
-          />
-
-          <div v-if="question.constraints.type === 'free_text' && question.constraints.inputMode === 'integer'" class="constraints-grid">
-            <q-input
-              :model-value="getIntegerConstraints({ constraints: question.constraints })?.minValue ?? 1"
-              outlined
-              type="number"
-              :label="templateTexts.minValueLabel"
-              @update:model-value="(value) => updateIntegerConstraints({ questionIndex, minValue: value, maxValue: getIntegerConstraints({ constraints: question.constraints })?.maxValue })"
-            />
-
-            <q-input
-              :model-value="getIntegerConstraints({ constraints: question.constraints })?.maxValue ?? ''"
-              outlined
-              type="number"
-              :label="templateTexts.maxValueLabel"
-              @update:model-value="(value) => updateIntegerConstraints({ questionIndex, minValue: getIntegerConstraints({ constraints: question.constraints })?.minValue, maxValue: value })"
-            />
-          </div>
-
-          <div v-else class="constraints-grid">
-            <q-input
-              :model-value="getRichTextConstraints({ constraints: question.constraints })?.minPlainTextLength ?? ''"
-              outlined
-              type="number"
-              :label="t('minTextLengthLabel')"
-              @update:model-value="(value) => updateRichTextConstraints({ questionIndex, minPlainTextLength: value, maxPlainTextLength: getRichTextConstraints({ constraints: question.constraints })?.maxPlainTextLength ?? 300 })"
-            />
-
-            <q-input
-              :model-value="getRichTextConstraints({ constraints: question.constraints })?.maxPlainTextLength ?? 300"
-              outlined
-              type="number"
-              :label="t('maxTextLengthLabel')"
-              @update:model-value="(value) => updateRichTextConstraints({ questionIndex, minPlainTextLength: getRichTextConstraints({ constraints: question.constraints })?.minPlainTextLength, maxPlainTextLength: value })"
-            />
-          </div>
-
-          <div class="constraints-help">
-            {{ question.constraints.type === 'free_text' && question.constraints.inputMode === 'integer' ? templateTexts.numericInputHelp : t("freeTextHelp") }}
-          </div>
-        </div>
-
-        <div v-if="question.questionType !== 'free_text'" class="options-list">
-          <div
-            v-for="(option, optionIndex) in question.options ?? []"
-            :id="getOptionInputId({ questionIndex, optionIndex })"
-            :key="optionIndex"
-            class="option-editor"
-            @keydown.enter="handleOptionEditorEnter({ event: $event, questionIndex })"
-          >
-            <q-input
-              :model-value="option.optionText"
-              outlined
-              :maxlength="200"
-              :error="shouldShowOptionTextError({ question, option })"
-              :label="t('optionLabel', { number: optionIndex + 1 })"
-              @update:model-value="(value) => updateOptionText({ questionIndex, optionIndex, optionText: value })"
-            >
-              <template #append>
-                <q-btn
-                  v-if="(question.options?.length ?? 0) > 2"
-                  flat
-                  round
-                  dense
-                  icon="mdi-close"
-                  @click="requestRemoveOption({ questionIndex, optionIndex })"
-                />
-              </template>
-            </q-input>
-          </div>
-
-          <q-btn
-            flat
-            no-caps
-            color="primary"
-            :label="t('addOptionLabel')"
-            @click="addOption({ questionIndex })"
-          />
-
-          <ZKInfoBanner
-            v-if="
-              shouldShowLargeOptionWarning({
-                choiceDisplay: question.choiceDisplay,
-                optionCount: question.options?.length ?? 0,
-              })
-            "
-            :message="
-              t('largeOptionCountWarning', {
-                count: question.options?.length ?? 0,
-                threshold: largeOptionWarningThreshold,
-              })
-            "
-          />
-        </div>
-      </div>
-
-      <div v-if="isSurveyAllowed" class="template-actions">
-        <q-btn
-          flat
-          no-caps
-          color="primary"
-          class="add-question-button"
-          :label="t('addQuestionButton')"
-          @click="addQuestion"
-        />
-        <q-btn flat no-caps color="primary" :label="templateTexts.addAgeGroupLabel" @click="addTemplateQuestion({ templateId: 'age_group' })" />
-        <q-btn flat no-caps color="primary" :label="templateTexts.addAgeLabel" @click="addTemplateQuestion({ templateId: 'age' })" />
-        <q-btn flat no-caps color="primary" :label="templateTexts.addSexAtBirthLabel" @click="addTemplateQuestion({ templateId: 'sex_at_birth' })" />
-        <q-btn flat no-caps color="primary" :label="templateTexts.addGenderLabel" @click="addTemplateQuestion({ templateId: 'gender' })" />
-      </div>
+      <SurveyConfigEditor
+        v-model:survey-config="surveyConfig"
+        :texts="surveyEditorTexts"
+        :display-language="locale"
+        :show-actions="isSurveyAllowed"
+        :show-validation-errors="surveyValidationErrorMessage !== null"
+        @clear-validation-error="clearSurveyValidationError"
+      />
     </div>
 
     <NewConversationRouteGuard
@@ -249,15 +38,6 @@
       :ok-callback="onLoginCallback"
       active-intention="newConversation"
     />
-
-    <ZKConfirmDialog
-      v-model="showRemoveDialog"
-      :message="removeDialogMessage"
-      :confirm-text="removeDialogConfirmText"
-      :cancel-text="t('cancelLabel')"
-      variant="destructive"
-      @confirm="handleConfirmRemoval"
-    />
   </NewConversationLayout>
 </template>
 
@@ -269,19 +49,10 @@ import BackButton from "src/components/navigation/buttons/BackButton.vue";
 import DefaultMenuBar from "src/components/navigation/header/DefaultMenuBar.vue";
 import NewConversationLayout from "src/components/newConversation/NewConversationLayout.vue";
 import NewConversationRouteGuard from "src/components/newConversation/NewConversationRouteGuard.vue";
-import ZKConfirmDialog from "src/components/ui-library/ZKConfirmDialog.vue";
-import ZKInfoBanner from "src/components/ui-library/ZKInfoBanner.vue";
+import SurveyConfigEditor from "src/components/survey/SurveyConfigEditor.vue";
 import { useConversationDraft } from "src/composables/conversation/draft";
 import { usePublishConversationDraft } from "src/composables/conversation/usePublishConversationDraft";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
-import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
-import type {
-  SurveyChoiceDisplay,
-  SurveyQuestionConfig,
-  SurveyQuestionConstraints,
-  SurveyQuestionOption,
-  SurveyQuestionType,
-} from "src/shared/types/zod";
 import {
   checkFeatureAccess,
   DEFAULT_FEATURE_ALLOWED_ORGS,
@@ -295,22 +66,7 @@ import {
   navigateBackOrReplace,
 } from "src/utils/nav/historyBack";
 import { processEnv } from "src/utils/processEnv";
-import {
-  createChoiceSurveyQuestionConstraints,
-  createEmptySurveyOption,
-  createEmptySurveyQuestion,
-  createIntegerSurveyQuestionConstraints,
-  createRichTextSurveyQuestionConstraints,
-  normalizeChoiceSurveyQuestionConstraints,
-  shouldWarnAboutLargeSurveyOptionSet,
-  SURVEY_LARGE_OPTION_WARNING_THRESHOLD,
-} from "src/utils/survey/config";
-import {
-  createSurveyTemplateQuestion,
-  type SurveyTemplateId,
-} from "src/utils/survey/templates";
-import { surveyTemplateTextTranslations } from "src/utils/survey/templates.i18n";
-import { computed, nextTick, onMounted, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
 import { useRouter } from "vue-router";
 
 import {
@@ -336,93 +92,11 @@ const { conversationDraft } = storeToRefs(useNewPostDraftsStore());
 const { publishConversationDraft } = usePublishConversationDraft();
 const { createNewConversationIntention } = useLoginIntentionStore();
 
-type PendingRemoval =
-  | { type: "question"; questionIndex: number }
-  | { type: "option"; questionIndex: number; optionIndex: number };
-
 const routeGuard = ref<{ unlockRoute: () => void } | undefined>(undefined);
 const showLoginDialog = ref(false);
 const isSubmitButtonLoading = ref(false);
 const isNavigatingAway = ref(false);
 const surveyValidationErrorMessage = ref<string | null>(null);
-const pendingRemoval = ref<PendingRemoval | null>(null);
-
-const surveyConfigValue = computed(() => surveyConfig.value);
-
-const surveyQuestions = computed(() => {
-  return surveyConfig.value?.questions ?? [];
-});
-const isSurveyOptional = computed(() => {
-  return surveyConfig.value?.isOptional === true;
-});
-const largeOptionWarningThreshold = SURVEY_LARGE_OPTION_WARNING_THRESHOLD;
-
-function clearSurveyValidationError(): void {
-  surveyValidationErrorMessage.value = null;
-}
-
-function showSurveyValidationError(): void {
-  surveyValidationErrorMessage.value = t("surveyValidationError");
-}
-
-function shouldShowQuestionTextError({
-  question,
-}: {
-  question: SurveyQuestionConfig;
-}): boolean {
-  return (
-    surveyValidationErrorMessage.value !== null && question.questionText.trim() === ""
-  );
-}
-
-function shouldShowOptionTextError({
-  question,
-  option,
-}: {
-  question: SurveyQuestionConfig;
-  option: SurveyQuestionOption;
-}): boolean {
-  return (
-    surveyValidationErrorMessage.value !== null &&
-    question.questionType === "choice" &&
-    option.optionText.trim() === ""
-  );
-}
-
-const showRemoveDialog = computed({
-  get: () => pendingRemoval.value !== null,
-  set: (value: boolean) => {
-    if (!value) {
-      pendingRemoval.value = null;
-    }
-  },
-});
-
-const removeDialogMessage = computed(() => {
-  switch (pendingRemoval.value?.type) {
-    case undefined:
-      return "";
-    case "question":
-      return t("confirmRemoveQuestionMessage");
-    case "option":
-      return t("confirmRemoveOptionMessage");
-  }
-
-  return "";
-});
-
-const removeDialogConfirmText = computed(() => {
-  switch (pendingRemoval.value?.type) {
-    case undefined:
-      return t("removeQuestionLabel");
-    case "question":
-      return t("confirmRemoveQuestionButtonLabel");
-    case "option":
-      return t("confirmRemoveOptionButtonLabel");
-  }
-
-  return t("removeQuestionLabel");
-});
 
 const isSurveyAllowed = computed(() => {
   const result = checkFeatureAccess({
@@ -439,29 +113,49 @@ const isSurveyAllowed = computed(() => {
 
   return result.allowed;
 });
-
-const questionTypeOptions: Array<{ label: string; value: SurveyQuestionType }> = [
-  { label: t("typeChoice"), value: "choice" },
-  { label: t("typeFreeText"), value: "free_text" },
-];
-const choiceDisplayOptions: Array<{ label: string; value: SurveyChoiceDisplay }> = [
-  { label: t("choiceDisplayAuto"), value: "auto" },
-  { label: t("choiceDisplayList"), value: "list" },
-  { label: t("choiceDisplayDropdown"), value: "dropdown" },
-];
-const freeTextInputModeOptions = computed<
-  Array<{ label: string; value: "rich_text" | "integer" }>
->(() => [
-  { label: templateTexts.value.answerFormatRichText, value: "rich_text" },
-  { label: templateTexts.value.answerFormatNumber, value: "integer" },
-]);
-const templateTexts = computed(() => {
-  const currentLocale = locale.value as SupportedDisplayLanguageCodes;
-  return (
-    surveyTemplateTextTranslations[currentLocale] ??
-    surveyTemplateTextTranslations.en
-  );
-});
+const surveyEditorTexts = computed(() => ({
+  title: t("pageTitle"),
+  description: t("pageDescription"),
+  optionalSurveyToggleLabel: t("optionalSurveyToggleLabel"),
+  optionalSurveyToggleHint: t("optionalSurveyToggleHint"),
+  requiredSurveyToggleHint: t("requiredSurveyToggleHint"),
+  noQuestionsTitle: t("noQuestionsTitle"),
+  noQuestionsDescription: t("noQuestionsDescription"),
+  questionTitle: ({ number }: { number: number }) =>
+    t("questionLabel", { number }),
+  optionalLabel: t("optionalLabel"),
+  requiredLabel: t("requiredLabel"),
+  removeQuestionLabel: t("removeQuestionLabel"),
+  questionTypeLabel: t("questionTypeLabel"),
+  typeChoice: t("typeChoice"),
+  typeFreeText: t("typeFreeText"),
+  choiceDisplayLabel: t("choiceDisplayLabel"),
+  choiceDisplayAuto: t("choiceDisplayAuto"),
+  choiceDisplayList: t("choiceDisplayList"),
+  choiceDisplayDropdown: t("choiceDisplayDropdown"),
+  questionPromptLabel: t("questionPromptLabel"),
+  questionRequirementDisabledHint: t("questionRequirementDisabledHint"),
+  minSelectionsLabel: t("minSelectionsLabel"),
+  maxSelectionsLabel: t("maxSelectionsLabel"),
+  minTextLengthLabel: t("minTextLengthLabel"),
+  maxTextLengthLabel: t("maxTextLengthLabel"),
+  freeTextHelp: t("freeTextHelp"),
+  optionLabel: ({ number }: { number: number }) => t("optionLabel", { number }),
+  addOptionLabel: t("addOptionLabel"),
+  addQuestionLabel: t("addQuestionButton"),
+  cancelLabel: t("cancelLabel"),
+  confirmRemoveQuestionMessage: t("confirmRemoveQuestionMessage"),
+  confirmRemoveOptionMessage: t("confirmRemoveOptionMessage"),
+  confirmRemoveQuestionButtonLabel: t("confirmRemoveQuestionButtonLabel"),
+  confirmRemoveOptionButtonLabel: t("confirmRemoveOptionButtonLabel"),
+  largeOptionCountWarning: ({
+    count,
+    threshold,
+  }: {
+    count: number;
+    threshold: number;
+  }) => t("largeOptionCountWarning", { count, threshold }),
+}));
 
 onMounted(async () => {
   if (!isSurveyAllowed.value) {
@@ -470,6 +164,14 @@ onMounted(async () => {
     await router.replace({ name: "/conversation/new/seed/" });
   }
 });
+
+function clearSurveyValidationError(): void {
+  surveyValidationErrorMessage.value = null;
+}
+
+function showSurveyValidationError(): void {
+  surveyValidationErrorMessage.value = t("surveyValidationError");
+}
 
 function onLoginCallback() {
   createNewConversationIntention();
@@ -488,510 +190,6 @@ async function handleBack(event: MouseEvent): Promise<void> {
       expectedPath: "/conversation/new/seed/",
     }),
   });
-}
-
-function ensureSurveyConfig(): void {
-  if (!isSurveyAllowed.value) {
-    return;
-  }
-
-  if (surveyConfig.value === null) {
-    surveyConfig.value = { isOptional: false, questions: [] };
-  }
-}
-
-function updateSurveyOptional({ isOptional }: { isOptional: boolean | null }): void {
-  ensureSurveyConfig();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  surveyConfig.value.isOptional = isOptional === true;
-}
-
-function addQuestion(): void {
-  clearSurveyValidationError();
-  ensureSurveyConfig();
-  surveyConfig.value?.questions.push(
-    createEmptySurveyQuestion({
-      displayOrder: surveyConfig.value.questions.length,
-    })
-  );
-}
-
-function shouldShowLargeOptionWarning({
-  choiceDisplay,
-  optionCount,
-}: {
-  choiceDisplay: SurveyChoiceDisplay;
-  optionCount: number;
-}): boolean {
-  return shouldWarnAboutLargeSurveyOptionSet({ choiceDisplay, optionCount });
-}
-
-function addTemplateQuestion({ templateId }: { templateId: SurveyTemplateId }): void {
-  clearSurveyValidationError();
-  ensureSurveyConfig();
-  surveyConfig.value?.questions.push(
-    createSurveyTemplateQuestion({
-      templateId,
-      displayOrder: surveyConfig.value.questions.length,
-      displayLanguage: locale.value as SupportedDisplayLanguageCodes,
-    })
-  );
-}
-
-function getOptionInputId({
-  questionIndex,
-  optionIndex,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-}): string {
-  return `survey-option-input-${questionIndex}-${optionIndex}`;
-}
-
-function getChoiceConstraintInputAttrs({
-  optionCount,
-}: {
-  optionCount: number;
-}): { min: number; max: number } {
-  return { min: 1, max: optionCount };
-}
-
-async function handleOptionEditorEnter({
-  event,
-  questionIndex,
-}: {
-  event: KeyboardEvent;
-  questionIndex: number;
-}): Promise<void> {
-  if (!(event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement)) return;
-  event.preventDefault();
-  await addOption({ questionIndex });
-}
-
-async function focusOptionInput({
-  questionIndex,
-  optionIndex,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-}): Promise<void> {
-  await nextTick();
-  const input = document
-    .getElementById(getOptionInputId({ questionIndex, optionIndex }))
-    ?.querySelector<HTMLInputElement>("input");
-  input?.focus();
-}
-
-function getIntegerConstraints({
-  constraints,
-}: {
-  constraints: SurveyQuestionConstraints;
-}): Extract<SurveyQuestionConstraints, { type: "free_text"; inputMode: "integer" }> | undefined {
-  return constraints.type === "free_text" && constraints.inputMode === "integer"
-    ? constraints
-    : undefined;
-}
-
-function getRichTextConstraints({
-  constraints,
-}: {
-  constraints: SurveyQuestionConstraints;
-}): Extract<SurveyQuestionConstraints, { type: "free_text"; inputMode: "rich_text" }> | undefined {
-  return constraints.type === "free_text" && constraints.inputMode !== "integer"
-    ? constraints
-    : undefined;
-}
-
-function reindexSurveyQuestion({
-  question,
-  displayOrder,
-}: {
-  question: SurveyQuestionConfig;
-  displayOrder: number;
-}): SurveyQuestionConfig {
-  if (question.questionType === "free_text") {
-    return {
-      ...question,
-      displayOrder,
-    };
-  }
-
-  return {
-    ...question,
-    displayOrder,
-    options: question.options.map((option, optionIndex) => ({
-      ...option,
-      displayOrder: optionIndex,
-    })),
-  };
-}
-
-function requestRemoveQuestion({ questionIndex }: { questionIndex: number }): void {
-  pendingRemoval.value = { type: "question", questionIndex };
-}
-
-function removeQuestion({ questionIndex }: { questionIndex: number }): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  surveyConfig.value.questions.splice(questionIndex, 1);
-  if (surveyConfig.value.questions.length === 0) {
-    surveyConfig.value = null;
-    return;
-  }
-
-  surveyConfig.value.questions = surveyConfig.value.questions.map((question, index) =>
-    reindexSurveyQuestion({ question, displayOrder: index })
-  );
-}
-
-function updateQuestionText({
-  questionIndex,
-  questionText,
-}: {
-  questionIndex: number;
-  questionText: string | number | null;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  surveyConfig.value.questions[questionIndex].questionText = String(questionText ?? "");
-}
-
-function updateQuestionRequired({
-  questionIndex,
-  isRequired,
-}: {
-  questionIndex: number;
-  isRequired: boolean | null;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  surveyConfig.value.questions[questionIndex].isRequired = isRequired === true;
-}
-
-function updateQuestionType({
-  questionIndex,
-  questionType,
-}: {
-  questionIndex: number;
-  questionType: SurveyQuestionType | null;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  if (questionType === null) {
-    return;
-  }
-
-  const nextType = questionType;
-  const currentQuestion = surveyConfig.value.questions[questionIndex];
-  const questionBase = {
-    questionSlugId: currentQuestion.questionSlugId,
-    questionText: currentQuestion.questionText,
-    isRequired: currentQuestion.isRequired,
-    displayOrder: currentQuestion.displayOrder,
-    textChangeIsSemantic: currentQuestion.textChangeIsSemantic,
-  };
-  const currentChoiceDisplay =
-    currentQuestion.questionType === "free_text"
-      ? "auto"
-      : currentQuestion.choiceDisplay;
-  const currentOptions =
-    currentQuestion.questionType === "free_text" ? [] : currentQuestion.options;
-  const nextOptions =
-    currentOptions.length >= 2
-      ? currentOptions
-      : [
-          createEmptySurveyOption({ displayOrder: 0 }),
-          createEmptySurveyOption({ displayOrder: 1 }),
-        ];
-
-  if (nextType === "free_text") {
-    surveyConfig.value.questions[questionIndex] = {
-      ...questionBase,
-      questionType: "free_text",
-      constraints: createRichTextSurveyQuestionConstraints(),
-    };
-    return;
-  }
-
-  surveyConfig.value.questions[questionIndex] = {
-    ...questionBase,
-    questionType: "choice",
-    choiceDisplay: currentChoiceDisplay,
-    constraints: createChoiceSurveyQuestionConstraints(),
-    options: nextOptions,
-  };
-}
-
-function updateQuestionChoiceDisplay({
-  questionIndex,
-  choiceDisplay,
-}: {
-  questionIndex: number;
-  choiceDisplay: SurveyChoiceDisplay | null;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null || choiceDisplay === null) {
-    return;
-  }
-
-  const question = surveyConfig.value.questions[questionIndex];
-  if (question.questionType === "free_text") {
-    return;
-  }
-
-  question.choiceDisplay = choiceDisplay;
-}
-
-async function addOption({ questionIndex }: { questionIndex: number }): Promise<void> {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  const question = surveyConfig.value.questions[questionIndex];
-  if (question.questionType === "free_text") {
-    return;
-  }
-
-  question.options.push(
-    createEmptySurveyOption({ displayOrder: question.options.length })
-  );
-  await focusOptionInput({
-    questionIndex,
-    optionIndex: question.options.length - 1,
-  });
-}
-
-function requestRemoveOption({
-  questionIndex,
-  optionIndex,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-}): void {
-  pendingRemoval.value = { type: "option", questionIndex, optionIndex };
-}
-
-function removeOption({
-  questionIndex,
-  optionIndex,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  const question = surveyConfig.value.questions[questionIndex];
-  if (question.questionType === "free_text" || question.options.length <= 2) {
-    return;
-  }
-
-  question.options.splice(optionIndex, 1);
-  question.options = question.options.map((option, index) => ({
-    ...option,
-    displayOrder: index,
-  }));
-  question.constraints = normalizeChoiceSurveyQuestionConstraints({
-    minSelections: question.constraints.minSelections,
-    maxSelections: question.constraints.maxSelections,
-    optionCount: question.options.length,
-  });
-}
-
-function updateOptionText({
-  questionIndex,
-  optionIndex,
-  optionText,
-}: {
-  questionIndex: number;
-  optionIndex: number;
-  optionText: string | number | null;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  const question = surveyConfig.value.questions[questionIndex];
-  if (question.questionType === "free_text") {
-    return;
-  }
-
-  const option = question.options[optionIndex];
-  if (option === undefined) {
-    return;
-  }
-
-  option.optionText = String(optionText ?? "");
-}
-
-function parseOptionalInteger(value: string | number | null): number | undefined {
-  if (value === null || value === "") {
-    return undefined;
-  }
-
-  const parsedValue = Number(value);
-  if (!Number.isSafeInteger(parsedValue)) {
-    return undefined;
-  }
-
-  return parsedValue;
-}
-
-function updateChoiceConstraints({
-  questionIndex,
-  minSelections,
-  maxSelections,
-}: {
-  questionIndex: number;
-  minSelections: string | number | null;
-  maxSelections: string | number | null | undefined;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  const question = surveyConfig.value.questions[questionIndex];
-  if (question.questionType !== "choice") {
-    return;
-  }
-
-  const parsedMinSelections = Math.max(parseOptionalInteger(minSelections) ?? 1, 1);
-  const parsedMaxSelections = parseOptionalInteger(maxSelections ?? null);
-
-  question.constraints = normalizeChoiceSurveyQuestionConstraints({
-    minSelections: parsedMinSelections,
-    maxSelections: parsedMaxSelections,
-    optionCount: question.options.length,
-  });
-}
-
-function updateFreeTextInputMode({
-  questionIndex,
-  inputMode,
-}: {
-  questionIndex: number;
-  inputMode: "rich_text" | "integer" | null;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  const question = surveyConfig.value.questions[questionIndex];
-  if (question.questionType !== "free_text" || inputMode === null) {
-    return;
-  }
-
-  question.constraints =
-    inputMode === "integer"
-      ? createIntegerSurveyQuestionConstraints()
-      : createRichTextSurveyQuestionConstraints();
-}
-
-function updateRichTextConstraints({
-  questionIndex,
-  minPlainTextLength,
-  maxPlainTextLength,
-}: {
-  questionIndex: number;
-  minPlainTextLength: string | number | null | undefined;
-  maxPlainTextLength: string | number | null;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  const question = surveyConfig.value.questions[questionIndex];
-  if (
-    question.questionType !== "free_text" ||
-    question.constraints.type !== "free_text" ||
-    question.constraints.inputMode === "integer"
-  ) {
-    return;
-  }
-
-  const parsedMaxPlainTextLength = Math.max(
-    parseOptionalInteger(maxPlainTextLength) ?? 300,
-    1
-  );
-
-  question.constraints = {
-    type: "free_text",
-    inputMode: "rich_text",
-    minPlainTextLength: parseOptionalInteger(minPlainTextLength ?? null),
-    maxPlainTextLength: parsedMaxPlainTextLength,
-    maxHtmlLength: parsedMaxPlainTextLength * 10,
-  };
-}
-
-function updateIntegerConstraints({
-  questionIndex,
-  minValue,
-  maxValue,
-}: {
-  questionIndex: number;
-  minValue: string | number | null | undefined;
-  maxValue: string | number | null | undefined;
-}): void {
-  clearSurveyValidationError();
-  if (surveyConfig.value === null) {
-    return;
-  }
-
-  const question = surveyConfig.value.questions[questionIndex];
-  if (
-    question.questionType !== "free_text" ||
-    question.constraints.type !== "free_text" ||
-    question.constraints.inputMode !== "integer"
-  ) {
-    return;
-  }
-
-  question.constraints = {
-    type: "free_text",
-    inputMode: "integer",
-    minValue: Math.max(parseOptionalInteger(minValue ?? null) ?? 1, 1),
-    maxValue: parseOptionalInteger(maxValue ?? null),
-  };
-}
-
-function handleConfirmRemoval(): void {
-  const target = pendingRemoval.value;
-  pendingRemoval.value = null;
-  switch (target?.type) {
-    case undefined:
-      return;
-    case "question":
-      removeQuestion({ questionIndex: target.questionIndex });
-      return;
-    case "option":
-      removeOption({
-        questionIndex: target.questionIndex,
-        optionIndex: target.optionIndex,
-      });
-      return;
-  }
 }
 
 async function publishConversation(): Promise<void> {
@@ -1035,80 +233,5 @@ async function publishConversation(): Promise<void> {
   gap: 1rem;
   padding-bottom: 1rem;
   padding-top: 0.5rem;
-}
-
-.intro-card,
-.empty-card,
-.question-card {
-  background: white;
-  border-radius: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: 1rem;
-}
-
-.intro-card__title,
-.empty-card__title,
-.question-card__title {
-  color: #111827;
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.intro-card__description,
-.empty-card__description,
-.question-card__subtitle,
-.constraints-help {
-  color: #6b7280;
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-.question-card__header {
-  align-items: flex-start;
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.constraints-grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.constraints-stack {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.options-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-
-.option-editor {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.template-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.add-question-button {
-  align-self: flex-start;
-}
-
-@media (max-width: 700px) {
-  .constraints-grid {
-    grid-template-columns: 1fr;
-  }
 }
 </style>

--- a/services/agora/src/utils/actions/core/handlers.ts
+++ b/services/agora/src/utils/actions/core/handlers.ts
@@ -3,11 +3,11 @@
  * This composable provides action execution functions with proper error handling
  */
 
+import { useNewOpinionDraftsStore } from "src/stores/newOpinionDrafts";
 import { useUserStore } from "src/stores/user";
 import { useBackendPostApi } from "src/utils/api/post/post";
 import { useInvalidateFeedQuery } from "src/utils/api/post/useFeedQuery";
 import { useNotify } from "src/utils/ui/notify";
-import { useRoute, useRouter } from "vue-router";
 
 import type { ContentActionContext, ContentActionResult } from "./types";
 
@@ -15,11 +15,10 @@ import type { ContentActionContext, ContentActionResult } from "./types";
  * Composable for handling action execution
  */
 export function useActionHandlers() {
-  const router = useRouter();
-  const route = useRoute();
   const { showNotifyMessage } = useNotify();
   const { deletePostBySlugId } = useBackendPostApi();
   const { loadUserProfile } = useUserStore();
+  const { deleteOpinionDraft } = useNewOpinionDraftsStore();
   const { invalidateFeed } = useInvalidateFeedQuery();
 
   /**
@@ -39,16 +38,9 @@ export function useActionHandlers() {
       const response = await deletePostBySlugId(context.targetId);
       if (response) {
         showNotifyMessage("Conversation deleted");
+        deleteOpinionDraft(context.targetId);
         invalidateFeed();
         await loadUserProfile();
-
-        const slugPrefix = `/conversation/${context.targetId}`;
-        if (
-          route.path === slugPrefix ||
-          route.path.startsWith(`${slugPrefix}/`)
-        ) {
-          await router.push({ name: "/" });
-        }
 
         return { success: true, message: "Conversation deleted successfully" };
       } else {

--- a/services/agora/src/utils/actions/definitions/content-actions.ts
+++ b/services/agora/src/utils/actions/definitions/content-actions.ts
@@ -152,6 +152,7 @@ export function useContentActions() {
       exportConversationCallback: () => void | Promise<void>;
       shareCallback: () => void | Promise<void>;
       syncGitHubCallback: (() => void | Promise<void>) | null;
+      conversationDeletedCallback: () => void | Promise<void>;
     }
   ): void => {
     const currentUser = profileData.value.userName;
@@ -180,6 +181,7 @@ export function useContentActions() {
       const result = await handlers.handlePostDelete(context);
       if (result.success) {
         closeDialog();
+        await callbacks.conversationDeletedCallback();
       }
     };
 

--- a/services/scoring-worker/src/scoring_worker/db.py
+++ b/services/scoring-worker/src/scoring_worker/db.py
@@ -168,7 +168,12 @@ def derive_survey_gate_status_for_analysis(
     return "not_started"
 
 
-def is_survey_gate_status_eligible_for_analysis(*, survey_gate_status: str) -> bool:
+def is_survey_gate_status_eligible_for_analysis(
+    *, survey_gate_status: str, is_optional: bool = False
+) -> bool:
+    if is_optional:
+        return True
+
     return survey_gate_status in {"no_survey", "complete_valid"}
 
 
@@ -182,7 +187,7 @@ def _fetch_survey_eligible_participants_batch(
         return {}
 
     survey_configs = session.execute(
-        select(SurveyConfig.id, SurveyConfig.conversation_id).where(
+        select(SurveyConfig.id, SurveyConfig.conversation_id, SurveyConfig.is_optional).where(
             and_(
                 SurveyConfig.conversation_id.in_(conversation_ids),
                 SurveyConfig.deleted_at.is_(None),
@@ -192,7 +197,10 @@ def _fetch_survey_eligible_participants_batch(
     if not survey_configs:
         return {}
 
-    survey_config_ids = [row.id for row in survey_configs]
+    survey_config_ids = [row.id for row in survey_configs if not row.is_optional]
+    if not survey_config_ids:
+        return {}
+
     conversation_id_by_survey_config_id = {row.id: row.conversation_id for row in survey_configs}
 
     question_rows = session.execute(

--- a/services/scoring-worker/tests/test_survey_analysis.py
+++ b/services/scoring-worker/tests/test_survey_analysis.py
@@ -39,6 +39,17 @@ def test_withdrawn_survey_is_not_eligible_for_analysis() -> None:
     assert is_survey_gate_status_eligible_for_analysis(survey_gate_status="complete_valid")
 
 
+def test_optional_survey_is_eligible_regardless_of_status() -> None:
+    assert is_survey_gate_status_eligible_for_analysis(
+        survey_gate_status="withdrawn",
+        is_optional=True,
+    )
+    assert is_survey_gate_status_eligible_for_analysis(
+        survey_gate_status="needs_update",
+        is_optional=True,
+    )
+
+
 def test_optional_only_survey_is_analysis_eligible_without_response() -> None:
     question = SurveyQuestionAnalysisRecord(
         question_id=2,


### PR DESCRIPTION
## Summary
- Include optional survey voters in scoring-worker analysis even when they skip or need to update the survey.
- Reuse one Agora survey configuration editor for create and edit flows, hide the optional/required toggle until questions exist, and fix first-click question/template insertion.
- Polish the mobile survey requirement banner and clear draft statements when deleting a conversation.

## Tests
- `cd services/agora && pnpm lint`
- `cd services/scoring-worker && make test`

Deploy: agora, scoring-worker