### PR TITLE
perf(agora): use default minifier

### DIFF
--- a/services/agora/quasar.config.ts
+++ b/services/agora/quasar.config.ts
@@ -79,7 +79,6 @@ export default defineConfig((ctx) => {
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#build
     build: {
       sourcemap: "hidden", // generates .map files for Sentry but strips sourceMappingURL from bundles so browsers don't download them
-      minify: "terser",
       target: {
         browser: ["es2020", "firefox115", "chrome86", "safari14"],
         node: "node20",


### PR DESCRIPTION
## Summary
- Remove the explicit Terser minifier override from the Quasar build config.
- Let Quasar/Vite use the current default minifier to avoid forcing the slow vite:terser build path.

## Verification
- pnpm build:dev