### PR TITLE
feat(api): support org conversation ownership

### DIFF
--- a/services/api/database/flyway/V0061__puzzling_spectrum.sql
+++ b/services/api/database/flyway/V0061__puzzling_spectrum.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "conversation_organization_timeline_idx" ON "conversation" USING btree ("organization_id","is_importing","created_at","id") WHERE "conversation"."current_content_id" is not null;

--- a/services/api/drizzle/0060_puzzling_spectrum.sql
+++ b/services/api/drizzle/0060_puzzling_spectrum.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "conversation_organization_timeline_idx" ON "conversation" USING btree ("organization_id","is_importing","created_at","id") WHERE "conversation"."current_content_id" is not null;

--- a/services/api/drizzle/meta/0060_snapshot.json
+++ b/services/api/drizzle/meta/0060_snapshot.json
@@ -1,0 +1,8634 @@
+{
+  "id": "55da59d9-084b-48ba-bcd3-7cf0824cc471",
+  "prevId": "f8644cc2-4560-4a1c-9b9f-82a47e911ae5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.auth_attempt_email": {
+      "name": "auth_attempt_email",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_reachability": {
+          "name": "email_reachability",
+          "type": "email_reachability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_attempt_email_canonical_check": {
+          "name": "auth_attempt_email_canonical_check",
+          "value": "\"auth_attempt_email\".\"email\" = lower(btrim(\"auth_attempt_email\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_attempt_phone": {
+      "name": "auth_attempt_phone",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"auth_attempt_phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_content": {
+      "name": "conversation_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_content_conversation_id_conversation_id_fk": {
+          "name": "conversation_content_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_content",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_artifact": {
+      "name": "conversation_export_artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_artifact_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "export_file_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "export_file_audience_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "export_artifact_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_artifact_generation_idx": {
+          "name": "conversation_export_artifact_generation_idx",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_artifact_shared_unique": {
+          "name": "conversation_export_artifact_shared_unique",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_artifact\".\"subject_user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_artifact_requester_unique": {
+          "name": "conversation_export_artifact_requester_unique",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_artifact\".\"subject_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_artifact_generation_id_conversation_export_generation_id_fk": {
+          "name": "conversation_export_artifact_generation_id_conversation_export_generation_id_fk",
+          "tableFrom": "conversation_export_artifact",
+          "tableTo": "conversation_export_generation",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_artifact_subject_user_id_user_id_fk": {
+          "name": "conversation_export_artifact_subject_user_id_user_id_fk",
+          "tableFrom": "conversation_export_artifact",
+          "tableTo": "user",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_generation": {
+      "name": "conversation_export_generation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_generation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_generation_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collecting'"
+        },
+        "collecting_ends_at": {
+          "name": "collecting_ends_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_generation_conversation_idx": {
+          "name": "conversation_export_generation_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_collecting_due_idx": {
+          "name": "conversation_export_generation_collecting_due_idx",
+          "columns": [
+            {
+              "expression": "collecting_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_generation\".\"status\" = 'collecting'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_queued_due_idx": {
+          "name": "conversation_export_generation_queued_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_generation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_collecting_unique": {
+          "name": "conversation_export_generation_collecting_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_generation\".\"status\" = 'collecting'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_processing_unique": {
+          "name": "conversation_export_generation_processing_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_generation\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_generation_conversation_id_conversation_id_fk": {
+          "name": "conversation_export_generation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_export_generation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_export_generation_slug_id_unique": {
+          "name": "conversation_export_generation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_request_file": {
+      "name": "conversation_export_request_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_request_file_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "export_file_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "export_file_audience_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_request_file_artifact_idx": {
+          "name": "conversation_export_request_file_artifact_idx",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_file_unique": {
+          "name": "conversation_export_request_file_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_request_file_request_id_conversation_export_request_id_fk": {
+          "name": "conversation_export_request_file_request_id_conversation_export_request_id_fk",
+          "tableFrom": "conversation_export_request_file",
+          "tableTo": "conversation_export_request",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_file_artifact_id_conversation_export_artifact_id_fk": {
+          "name": "conversation_export_request_file_artifact_id_conversation_export_artifact_id_fk",
+          "tableFrom": "conversation_export_request_file",
+          "tableTo": "conversation_export_artifact",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_request": {
+      "name": "conversation_export_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_request_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "export_cancellation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_notified_at": {
+          "name": "started_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_notified_at": {
+          "name": "completed_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_notified_at": {
+          "name": "failed_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_request_conversation_idx": {
+          "name": "conversation_export_request_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_generation_idx": {
+          "name": "conversation_export_request_generation_idx",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_active_history_idx": {
+          "name": "conversation_export_request_active_history_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_expiry_idx": {
+          "name": "conversation_export_request_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_active_unique": {
+          "name": "conversation_export_request_active_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_request\".\"status\" = 'processing' AND \"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_request_conversation_id_conversation_id_fk": {
+          "name": "conversation_export_request_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_generation_id_conversation_export_generation_id_fk": {
+          "name": "conversation_export_request_generation_id_conversation_export_generation_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "conversation_export_generation",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_user_id_user_id_fk": {
+          "name": "conversation_export_request_user_id_user_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_export_request_slug_id_unique": {
+          "name": "conversation_export_request_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_import": {
+      "name": "conversation_import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_import_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "import_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "import_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csv_file_metadata": {
+          "name": "csv_file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_import_status_idx": {
+          "name": "conversation_import_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_created_idx": {
+          "name": "conversation_import_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_user_idx": {
+          "name": "conversation_import_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_conversation_idx": {
+          "name": "conversation_import_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_active_user_unique": {
+          "name": "conversation_import_active_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_import\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_import_conversation_id_conversation_id_fk": {
+          "name": "conversation_import_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_import",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_import_user_id_user_id_fk": {
+          "name": "conversation_import_user_id_user_id_fk",
+          "tableFrom": "conversation_import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_import_slug_id_unique": {
+          "name": "conversation_import_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_import_conversation_id_unique": {
+          "name": "conversation_import_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_moderation": {
+      "name": "conversation_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "conversation_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_moderation_conversation_id_moderation_action_idx": {
+          "name": "conversation_moderation_conversation_id_moderation_action_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "moderation_action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_moderation_conversation_id_conversation_id_fk": {
+          "name": "conversation_moderation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_moderation_author_id_user_id_fk": {
+          "name": "conversation_moderation_author_id_user_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_moderation_conversation_id_unique": {
+          "name": "conversation_moderation_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_report": {
+      "name": "conversation_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_id_idx": {
+          "name": "conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_report_conversation_id_conversation_id_fk": {
+          "name": "conversation_report_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_report_author_id_user_id_fk": {
+          "name": "conversation_report_author_id_user_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_polis_content_id": {
+          "name": "current_polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_ranking_score_id": {
+          "name": "current_ranking_score_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index_conversation_at": {
+          "name": "index_conversation_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexed": {
+          "name": "is_indexed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "participation_mode": {
+          "name": "participation_mode",
+          "type": "participation_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'account_required'"
+        },
+        "conversation_type": {
+          "name": "conversation_type",
+          "type": "conversation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polis'"
+        },
+        "is_importing": {
+          "name": "is_importing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_event_ticket": {
+          "name": "requires_event_ticket",
+          "type": "event_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opinion_count": {
+          "name": "opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_vote_count": {
+          "name": "total_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_participant_count": {
+          "name": "total_participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "moderated_opinion_count": {
+          "name": "moderated_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hidden_opinion_count": {
+          "name": "hidden_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "import_url": {
+          "name": "import_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_conversation_url": {
+          "name": "import_conversation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_export_url": {
+          "name": "import_export_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_created_at": {
+          "name": "import_created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_author": {
+          "name": "import_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_method": {
+          "name": "import_method",
+          "type": "import_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source_config": {
+          "name": "external_source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_feed_idx": {
+          "name": "conversation_feed_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation\".\"is_indexed\" = true AND \"conversation\".\"is_importing\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_type_importing_idx": {
+          "name": "conversation_type_importing_idx",
+          "columns": [
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_author_timeline_idx": {
+          "name": "conversation_author_timeline_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_organization_timeline_idx": {
+          "name": "conversation_organization_timeline_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_author_id_user_id_fk": {
+          "name": "conversation_author_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_content_id_conversation_content_id_fk": {
+          "name": "conversation_current_content_id_conversation_content_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_polis_content_id_polis_content_id_fk": {
+          "name": "conversation_current_polis_content_id_polis_content_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "current_polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_ranking_score_id_ranking_score_id_fk": {
+          "name": "conversation_current_ranking_score_id_ranking_score_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ranking_score",
+          "columnsFrom": [
+            "current_ranking_score_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_slug_id_unique": {
+          "name": "conversation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_current_content_id_unique": {
+          "name": "conversation_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "conversation_current_polis_content_id_unique": {
+          "name": "conversation_current_polis_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_polis_content_id"
+          ]
+        },
+        "conversation_current_ranking_score_id_unique": {
+          "name": "conversation_current_ranking_score_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_ranking_score_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_topic": {
+      "name": "conversation_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_topic_index": {
+          "name": "conversation_topic_index",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_topic_conversation_id_conversation_id_fk": {
+          "name": "conversation_topic_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_topic_topic_id_topic_id_fk": {
+          "name": "conversation_topic_topic_id_topic_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_topic_unique": {
+          "name": "conversation_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_update_queue": {
+      "name": "conversation_update_queue",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_math_update_at": {
+          "name": "last_math_update_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_conversation_update_queue_pending": {
+          "name": "idx_conversation_update_queue_pending",
+          "columns": [
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_math_update_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_update_queue\".\"requested_at\" > \"conversation_update_queue\".\"last_math_update_at\" OR \"conversation_update_queue\".\"last_math_update_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_update_queue_conversation_id_conversation_id_fk": {
+          "name": "conversation_update_queue_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_update_queue",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device": {
+      "name": "device",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_expiry": {
+          "name": "session_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_user_id_user_id_fk": {
+          "name": "device_user_id_user_id_fk",
+          "tableFrom": "device",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email": {
+      "name": "email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "email_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_reachability": {
+          "name": "email_reachability",
+          "type": "email_reachability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_active_unique": {
+          "name": "email_active_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_user_id_user_id_fk": {
+          "name": "email_user_id_user_id_fk",
+          "tableFrom": "email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_canonical_check": {
+          "name": "email_canonical_check",
+          "value": "\"email\".\"email\" = lower(btrim(\"email\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_ticket": {
+      "name": "event_ticket",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_ticket_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "ticket_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_slug": {
+          "name": "event_slug",
+          "type": "event_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pcd_type": {
+          "name": "pcd_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_event_idx": {
+          "name": "user_event_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_ticket_nullifier_event_active_unique": {
+          "name": "event_ticket_nullifier_event_active_unique",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_ticket\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nullifier_idx": {
+          "name": "nullifier_idx",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_ticket_user_id_user_id_fk": {
+          "name": "event_ticket_user_id_user_id_fk",
+          "tableFrom": "event_ticket",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followed_topic": {
+      "name": "followed_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "followed_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "followed_topic_index": {
+          "name": "followed_topic_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "followed_topic_user_id_user_id_fk": {
+          "name": "followed_topic_user_id_user_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "followed_topic_topic_id_topic_id_fk": {
+          "name": "followed_topic_topic_id_topic_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followed_topic_unique": {
+          "name": "followed_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_comparison": {
+      "name": "maxdiff_comparison",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_comparison_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_result_id": {
+          "name": "maxdiff_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "best_slug_id": {
+          "name": "best_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worst_slug_id": {
+          "name": "worst_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_set": {
+          "name": "candidate_set",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "maxdiff_comparison_result_idx": {
+          "name": "maxdiff_comparison_result_idx",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_comparison_active_result_position_unique": {
+          "name": "maxdiff_comparison_active_result_position_unique",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"maxdiff_comparison\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_comparison_maxdiff_result_id_maxdiff_result_id_fk": {
+          "name": "maxdiff_comparison_maxdiff_result_id_maxdiff_result_id_fk",
+          "tableFrom": "maxdiff_comparison",
+          "tableTo": "maxdiff_result",
+          "columnsFrom": [
+            "maxdiff_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item_content": {
+      "name": "maxdiff_item_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_item_id": {
+          "name": "maxdiff_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maxdiff_item_content_maxdiff_item_id_maxdiff_item_id_fk": {
+          "name": "maxdiff_item_content_maxdiff_item_id_maxdiff_item_id_fk",
+          "tableFrom": "maxdiff_item_content",
+          "tableTo": "maxdiff_item",
+          "columnsFrom": [
+            "maxdiff_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "maxdiff_item_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "maxdiff_item_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item_external_source": {
+      "name": "maxdiff_item_external_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_external_source_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_item_id": {
+          "name": "maxdiff_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "external_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_metadata": {
+          "name": "external_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_external_source_external_id_idx": {
+          "name": "maxdiff_external_source_external_id_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_external_source_dedup_idx": {
+          "name": "maxdiff_external_source_dedup_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_item_external_source_maxdiff_item_id_maxdiff_item_id_fk": {
+          "name": "maxdiff_item_external_source_maxdiff_item_id_maxdiff_item_id_fk",
+          "tableFrom": "maxdiff_item_external_source",
+          "tableTo": "maxdiff_item",
+          "columnsFrom": [
+            "maxdiff_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_external_source_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_item_external_source_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_item_external_source",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_item_external_source_maxdiff_item_id_unique": {
+          "name": "maxdiff_item_external_source_maxdiff_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "maxdiff_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item": {
+      "name": "maxdiff_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "maxdiff_lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "snapshot_score": {
+          "name": "snapshot_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_rank": {
+          "name": "snapshot_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_participant_count": {
+          "name": "snapshot_participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_item_slug_idx": {
+          "name": "maxdiff_item_slug_idx",
+          "columns": [
+            {
+              "expression": "slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_item_conversation_active_idx": {
+          "name": "maxdiff_item_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_item_lifecycle_idx": {
+          "name": "maxdiff_item_lifecycle_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_item_author_id_user_id_fk": {
+          "name": "maxdiff_item_author_id_user_id_fk",
+          "tableFrom": "maxdiff_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_item_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_item",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_item_slug_id_unique": {
+          "name": "maxdiff_item_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_result": {
+      "name": "maxdiff_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_result_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ranking": {
+          "name": "ranking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comparisons": {
+          "name": "comparisons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_result_complete_idx": {
+          "name": "maxdiff_result_complete_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_complete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_result_conversation_idx": {
+          "name": "maxdiff_result_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_result_participant_id_user_id_fk": {
+          "name": "maxdiff_result_participant_id_user_id_fk",
+          "tableFrom": "maxdiff_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_result_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_result_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_result",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_result_participant_id_conversation_id_unique": {
+          "name": "maxdiff_result_participant_id_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_user_entity_score": {
+      "name": "maxdiff_user_entity_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_user_entity_score_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_result_id": {
+          "name": "maxdiff_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug_id": {
+          "name": "entity_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_left": {
+          "name": "uncertainty_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_right": {
+          "name": "uncertainty_right",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maxdiff_user_entity_score_maxdiff_result_id_maxdiff_result_id_fk": {
+          "name": "maxdiff_user_entity_score_maxdiff_result_id_maxdiff_result_id_fk",
+          "tableFrom": "maxdiff_user_entity_score",
+          "tableTo": "maxdiff_result",
+          "columnsFrom": [
+            "maxdiff_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_user_entity_score_maxdiff_result_id_entity_slug_id_unique": {
+          "name": "maxdiff_user_entity_score_maxdiff_result_id_entity_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "maxdiff_result_id",
+            "entity_slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_export": {
+      "name": "notification_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_export_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_request_id": {
+          "name": "export_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_slug_id": {
+          "name": "export_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "export_cancellation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_export_notification_idx": {
+          "name": "notification_export_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_export_notification_id_notification_id_fk": {
+          "name": "notification_export_notification_id_notification_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_export_export_request_id_conversation_export_request_id_fk": {
+          "name": "notification_export_export_request_id_conversation_export_request_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "conversation_export_request",
+          "columnsFrom": [
+            "export_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_export_conversation_id_conversation_id_fk": {
+          "name": "notification_export_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_import": {
+      "name": "notification_import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_import_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_id": {
+          "name": "import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_import_notification_id_notification_id_fk": {
+          "name": "notification_import_notification_id_notification_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_import_import_id_conversation_import_id_fk": {
+          "name": "notification_import_import_id_conversation_import_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "conversation_import",
+          "columnsFrom": [
+            "import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_import_conversation_id_conversation_id_fk": {
+          "name": "notification_import_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_new_opinion": {
+      "name": "notification_new_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_new_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_new_opinion_notification_id_notification_id_fk": {
+          "name": "notification_new_opinion_notification_id_notification_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_author_id_user_id_fk": {
+          "name": "notification_new_opinion_author_id_user_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_opinion_id_opinion_id_fk": {
+          "name": "notification_new_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_conversation_id_conversation_id_fk": {
+          "name": "notification_new_opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_opinion_vote": {
+      "name": "notification_opinion_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_opinion_vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_votes": {
+          "name": "num_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_opinion_vote_notification_id_notification_id_fk": {
+          "name": "notification_opinion_vote_notification_id_notification_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_opinion_id_opinion_id_fk": {
+          "name": "notification_opinion_vote_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_conversation_id_conversation_id_fk": {
+          "name": "notification_opinion_vote_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_notification": {
+          "name": "user_idx_notification",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_createdAt_idx": {
+          "name": "notification_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_slug_id_unique": {
+          "name": "notification_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_content": {
+      "name": "opinion_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_content_opinion_id_opinion_id_fk": {
+          "name": "opinion_content_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "opinion_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_moderation": {
+      "name": "opinion_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "opinion_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_moderation_opinion_id_opinion_id_fk": {
+          "name": "opinion_moderation_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_moderation_author_id_user_id_fk": {
+          "name": "opinion_moderation_author_id_user_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_moderation_opinion_id_unique": {
+          "name": "opinion_moderation_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_report": {
+      "name": "opinion_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_id_idx": {
+          "name": "opinion_id_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_report_opinion_id_opinion_id_fk": {
+          "name": "opinion_report_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_report_author_id_user_id_fk": {
+          "name": "opinion_report_author_id_user_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion": {
+      "name": "opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_passes": {
+          "name": "num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_ga_consensus_pa": {
+          "name": "polis_ga_consensus_pa",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_ga_consensus_pd": {
+          "name": "polis_ga_consensus_pd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_priority": {
+          "name": "polis_priority",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "polis_divisiveness": {
+          "name": "polis_divisiveness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cluster_0_id": {
+          "name": "cluster_0_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_num_agrees": {
+          "name": "cluster_0_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_num_disagrees": {
+          "name": "cluster_0_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_0_num_passes": {
+          "name": "cluster_0_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_id": {
+          "name": "cluster_1_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_num_agrees": {
+          "name": "cluster_1_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_num_disagrees": {
+          "name": "cluster_1_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_1_num_passes": {
+          "name": "cluster_1_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_id": {
+          "name": "cluster_2_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_num_agrees": {
+          "name": "cluster_2_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_num_disagrees": {
+          "name": "cluster_2_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_2_num_passes": {
+          "name": "cluster_2_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_id": {
+          "name": "cluster_3_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_num_agrees": {
+          "name": "cluster_3_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_num_disagrees": {
+          "name": "cluster_3_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_3_num_passes": {
+          "name": "cluster_3_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_id": {
+          "name": "cluster_4_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_num_agrees": {
+          "name": "cluster_4_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_num_disagrees": {
+          "name": "cluster_4_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_4_num_passes": {
+          "name": "cluster_4_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_id": {
+          "name": "cluster_5_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_num_agrees": {
+          "name": "cluster_5_num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_num_disagrees": {
+          "name": "cluster_5_num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cluster_5_num_passes": {
+          "name": "cluster_5_num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polis_majority_type": {
+          "name": "polis_majority_type",
+          "type": "vote_enum_simple",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polis_majority_ps": {
+          "name": "polis_majority_ps",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_createdAt_idx": {
+          "name": "opinion_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_slugId_idx": {
+          "name": "opinion_slugId_idx",
+          "columns": [
+            {
+              "expression": "slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_authorId_idx": {
+          "name": "opinion_authorId_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_conversation_active_idx": {
+          "name": "opinion_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_author_id_user_id_fk": {
+          "name": "opinion_author_id_user_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_conversation_id_conversation_id_fk": {
+          "name": "opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_current_content_id_opinion_content_id_fk": {
+          "name": "opinion_current_content_id_opinion_content_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_0_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_0_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_0_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_1_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_1_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_1_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_2_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_2_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_2_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_3_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_3_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_3_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_4_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_4_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_4_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_cluster_5_id_polis_cluster_id_fk": {
+          "name": "opinion_cluster_5_id_polis_cluster_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "cluster_5_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_slug_id_unique": {
+          "name": "opinion_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "check_polis_majority": {
+          "name": "check_polis_majority",
+          "value": "(\n            (\"opinion\".\"polis_majority_type\" IS NOT NULL AND \"opinion\".\"polis_majority_ps\" IS NOT NULL)\n            OR\n            (\"opinion\".\"polis_majority_type\" IS NULL AND \"opinion\".\"polis_majority_ps\" IS NULL)\n            )"
+        },
+        "check_polis_null": {
+          "name": "check_polis_null",
+          "value": "((\"opinion\".\"cluster_0_id\" IS NOT NULL AND \"opinion\".\"cluster_0_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_0_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_0_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_0_id\" IS NULL AND \"opinion\".\"cluster_0_num_agrees\" IS NULL AND \"opinion\".\"cluster_0_num_disagrees\" IS NULL AND \"opinion\".\"cluster_0_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_1_id\" IS NOT NULL AND \"opinion\".\"cluster_1_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_1_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_1_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_1_id\" IS NULL AND \"opinion\".\"cluster_1_num_agrees\" IS NULL AND \"opinion\".\"cluster_1_num_disagrees\" IS NULL AND \"opinion\".\"cluster_1_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_2_id\" IS NOT NULL AND \"opinion\".\"cluster_2_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_2_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_2_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_2_id\" IS NULL AND \"opinion\".\"cluster_2_num_agrees\" IS NULL AND \"opinion\".\"cluster_2_num_disagrees\" IS NULL AND \"opinion\".\"cluster_2_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_3_id\" IS NOT NULL AND \"opinion\".\"cluster_3_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_3_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_3_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_3_id\" IS NULL AND \"opinion\".\"cluster_3_num_agrees\" IS NULL AND \"opinion\".\"cluster_3_num_disagrees\" IS NULL AND \"opinion\".\"cluster_3_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_4_id\" IS NOT NULL AND \"opinion\".\"cluster_4_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_4_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_4_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_4_id\" IS NULL AND \"opinion\".\"cluster_4_num_agrees\" IS NULL AND \"opinion\".\"cluster_4_num_disagrees\" IS NULL AND \"opinion\".\"cluster_4_num_passes\" IS NULL))\n                AND\n                ((\"opinion\".\"cluster_5_id\" IS NOT NULL AND \"opinion\".\"cluster_5_num_agrees\" IS NOT NULL AND \"opinion\".\"cluster_5_num_disagrees\" IS NOT NULL AND \"opinion\".\"cluster_5_num_passes\" IS NOT NULL) OR (\"opinion\".\"cluster_5_id\" IS NULL AND \"opinion\".\"cluster_5_num_agrees\" IS NULL AND \"opinion\".\"cluster_5_num_disagrees\" IS NULL AND \"opinion\".\"cluster_5_num_passes\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_full_image_path": {
+          "name": "is_full_image_path",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_name_unique": {
+          "name": "organization_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "organization_website_url_unique": {
+          "name": "organization_website_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_email_destination_state": {
+      "name": "otp_email_destination_state",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failed_verify_attempts": {
+          "name": "consecutive_failed_verify_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff_until": {
+          "name": "backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otp_email_destination_updated_idx": {
+          "name": "otp_email_destination_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "otp_email_destination_canonical_check": {
+          "name": "otp_email_destination_canonical_check",
+          "value": "\"otp_email_destination_state\".\"email\" = lower(btrim(\"otp_email_destination_state\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.otp_phone_destination_state": {
+      "name": "otp_phone_destination_state",
+      "schema": "",
+      "columns": {
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failed_verify_attempts": {
+          "name": "consecutive_failed_verify_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff_until": {
+          "name": "backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otp_phone_destination_updated_idx": {
+          "name": "otp_phone_destination_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phone": {
+      "name": "phone",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "phone_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phone_hash_active_unique": {
+          "name": "phone_hash_active_unique",
+          "columns": [
+            {
+              "expression": "phone_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"phone\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phone_hash_idx": {
+          "name": "phone_hash_idx",
+          "columns": [
+            {
+              "expression": "phone_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phone_user_id_user_id_fk": {
+          "name": "phone_user_id_user_id_fk",
+          "tableFrom": "phone",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster_opinion": {
+      "name": "polis_cluster_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_content_id": {
+          "name": "polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polis_cluster_id": {
+          "name": "polis_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agreement_type": {
+          "name": "agreement_type",
+          "type": "vote_enum_simple",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability_agreement": {
+          "name": "probability_agreement",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number_agreement": {
+          "name": "number_agreement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_repness": {
+          "name": "raw_repness",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "polis_cluster_opinion_opinionId_idx": {
+          "name": "polis_cluster_opinion_opinionId_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "polis_cluster_opinion_polisClusterId_idx": {
+          "name": "polis_cluster_opinion_polisClusterId_idx",
+          "columns": [
+            {
+              "expression": "polis_cluster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "polis_cluster_opinion_polis_content_id_polis_content_id_fk": {
+          "name": "polis_cluster_opinion_polis_content_id_polis_content_id_fk",
+          "tableFrom": "polis_cluster_opinion",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_opinion_polis_cluster_id_polis_cluster_id_fk": {
+          "name": "polis_cluster_opinion_polis_cluster_id_polis_cluster_id_fk",
+          "tableFrom": "polis_cluster_opinion",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "polis_cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_opinion_opinion_id_opinion_id_fk": {
+          "name": "polis_cluster_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "polis_cluster_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_perc_btwn_0_and_1": {
+          "name": "check_perc_btwn_0_and_1",
+          "value": "\"polis_cluster_opinion\".\"probability_agreement\" BETWEEN 0 and 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster": {
+      "name": "polis_cluster",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_content_id": {
+          "name": "polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "polis_key_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_users": {
+          "name": "num_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_label": {
+          "name": "ai_label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_polis_content_id_polis_content_id_fk": {
+          "name": "polis_cluster_polis_content_id_polis_content_id_fk",
+          "tableFrom": "polis_cluster",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster_translation": {
+      "name": "polis_cluster_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_cluster_id": {
+          "name": "polis_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_label": {
+          "name": "ai_label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_summary": {
+          "name": "ai_summary",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_translation_polis_cluster_id_polis_cluster_id_fk": {
+          "name": "polis_cluster_translation_polis_cluster_id_polis_cluster_id_fk",
+          "tableFrom": "polis_cluster_translation",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "polis_cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_cluster_language": {
+          "name": "unique_cluster_language",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polis_cluster_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polis_cluster_user": {
+      "name": "polis_cluster_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_cluster_user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "polis_content_id": {
+          "name": "polis_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polis_cluster_id": {
+          "name": "polis_cluster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_cluster_user_polis_content_id_polis_content_id_fk": {
+          "name": "polis_cluster_user_polis_content_id_polis_content_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "polis_content",
+          "columnsFrom": [
+            "polis_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_user_polis_cluster_id_polis_cluster_id_fk": {
+          "name": "polis_cluster_user_polis_cluster_id_polis_cluster_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "polis_cluster",
+          "columnsFrom": [
+            "polis_cluster_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "polis_cluster_user_user_id_user_id_fk": {
+          "name": "polis_cluster_user_user_id_user_id_fk",
+          "tableFrom": "polis_cluster_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_belong_per_conv_at_a_time": {
+          "name": "unique_belong_per_conv_at_a_time",
+          "nullsNotDistinct": false,
+          "columns": [
+            "polis_content_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polis_content": {
+      "name": "polis_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "polis_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "polis_content_conversation_id_conversation_id_fk": {
+          "name": "polis_content_conversation_id_conversation_id_fk",
+          "tableFrom": "polis_content",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_score_entity": {
+      "name": "ranking_score_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ranking_score_entity_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ranking_score_id": {
+          "name": "ranking_score_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug_id": {
+          "name": "entity_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_left": {
+          "name": "uncertainty_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_right": {
+          "name": "uncertainty_right",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ranking_score_entity_score_idx": {
+          "name": "ranking_score_entity_score_idx",
+          "columns": [
+            {
+              "expression": "ranking_score_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ranking_score_entity_slug_idx": {
+          "name": "ranking_score_entity_slug_idx",
+          "columns": [
+            {
+              "expression": "ranking_score_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ranking_score_entity_ranking_score_id_ranking_score_id_fk": {
+          "name": "ranking_score_entity_ranking_score_id_ranking_score_id_fk",
+          "tableFrom": "ranking_score_entity",
+          "tableTo": "ranking_score",
+          "columnsFrom": [
+            "ranking_score_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_score": {
+      "name": "ranking_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ranking_score_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_counts": {
+          "name": "participant_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_sources_snapshot": {
+          "name": "group_sources_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_weights_snapshot": {
+          "name": "user_weights_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_learning": {
+          "name": "preference_learning",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_rights": {
+          "name": "voting_rights",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregation_config": {
+          "name": "aggregation_config",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_score_conversation_id_conversation_id_fk": {
+          "name": "ranking_score_conversation_id_conversation_id_fk",
+          "tableFrom": "ranking_score",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answer_option": {
+      "name": "survey_answer_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_answer_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_answer_id": {
+          "name": "survey_answer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_answer_option_answer_option_active_uidx": {
+          "name": "survey_answer_option_answer_option_active_uidx",
+          "columns": [
+            {
+              "expression": "survey_answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "survey_question_option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_answer_option\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_option_survey_answer_id_survey_answer_id_fk": {
+          "name": "survey_answer_option_survey_answer_id_survey_answer_id_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_answer",
+          "columnsFrom": [
+            "survey_answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_answer_option_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_answer_question_fk": {
+          "name": "survey_answer_option_answer_question_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_answer",
+          "columnsFrom": [
+            "survey_answer_id",
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "survey_question_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_option_question_fk": {
+          "name": "survey_answer_option_option_question_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id",
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "survey_question_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answer": {
+      "name": "survey_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_answer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_response_id": {
+          "name": "survey_response_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_question_semantic_version": {
+          "name": "answered_question_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_value_html": {
+          "name": "text_value_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_answer_response_question_active_uidx": {
+          "name": "survey_answer_response_question_active_uidx",
+          "columns": [
+            {
+              "expression": "survey_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "survey_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_answer\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_survey_response_id_survey_response_id_fk": {
+          "name": "survey_answer_survey_response_id_survey_response_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "columnsFrom": [
+            "survey_response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_survey_question_id_survey_question_id_fk": {
+          "name": "survey_answer_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_response_conversation_fk": {
+          "name": "survey_answer_response_conversation_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "columnsFrom": [
+            "survey_response_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_question_conversation_fk": {
+          "name": "survey_answer_question_conversation_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_answer_id_question_unique": {
+          "name": "survey_answer_id_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "survey_question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_config": {
+      "name": "survey_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_config_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision": {
+          "name": "current_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_config_active_conversation_uidx": {
+          "name": "survey_config_active_conversation_uidx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_config\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_config_conversation_id_conversation_id_fk": {
+          "name": "survey_config_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_config",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_config_id_conversation_unique": {
+          "name": "survey_config_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_content": {
+      "name": "survey_question_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constraints": {
+          "name": "constraints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language_code": {
+          "name": "source_language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_language_confidence": {
+          "name": "source_language_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_content_survey_question_id_survey_question_id_fk": {
+          "name": "survey_question_content_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_question_content",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_content_translation": {
+      "name": "survey_question_content_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_content_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_content_id": {
+          "name": "survey_question_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_language_code": {
+          "name": "display_language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_question_text": {
+          "name": "translated_question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_content_translation_survey_question_content_id_survey_question_content_id_fk": {
+          "name": "survey_question_content_translation_survey_question_content_id_survey_question_content_id_fk",
+          "tableFrom": "survey_question_content_translation",
+          "tableTo": "survey_question_content",
+          "columnsFrom": [
+            "survey_question_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_content_translation_unique": {
+          "name": "survey_question_content_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_question_content_id",
+            "display_language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option_content": {
+      "name": "survey_question_option_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language_code": {
+          "name": "source_language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_language_confidence": {
+          "name": "source_language_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_option_content_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_question_option_content_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_question_option_content",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option_content_translation": {
+      "name": "survey_question_option_content_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_content_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_option_content_id": {
+          "name": "survey_question_option_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_language_code": {
+          "name": "display_language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_option_text": {
+          "name": "translated_option_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_option_content_translation_survey_question_option_content_id_survey_question_option_content_id_fk": {
+          "name": "survey_question_option_content_translation_survey_question_option_content_id_survey_question_option_content_id_fk",
+          "tableFrom": "survey_question_option_content_translation",
+          "tableTo": "survey_question_option_content",
+          "columnsFrom": [
+            "survey_question_option_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_option_content_translation_unique": {
+          "name": "survey_question_option_content_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_question_option_content_id",
+            "display_language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option": {
+      "name": "survey_question_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_option_active_question_display_order_uidx": {
+          "name": "survey_question_option_active_question_display_order_uidx",
+          "columns": [
+            {
+              "expression": "survey_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_question_option\".\"current_content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_option_survey_question_id_survey_question_id_fk": {
+          "name": "survey_question_option_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_question_option",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_option_current_content_id_survey_question_option_content_id_fk": {
+          "name": "survey_question_option_current_content_id_survey_question_option_content_id_fk",
+          "tableFrom": "survey_question_option",
+          "tableTo": "survey_question_option_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_option_slug_id_unique": {
+          "name": "survey_question_option_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "survey_question_option_current_content_id_unique": {
+          "name": "survey_question_option_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "survey_question_option_id_question_unique": {
+          "name": "survey_question_option_id_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "survey_question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question": {
+      "name": "survey_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_config_id": {
+          "name": "survey_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "choice_display": {
+          "name": "choice_display",
+          "type": "survey_choice_display",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_semantic_version": {
+          "name": "current_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_active_config_display_order_uidx": {
+          "name": "survey_question_active_config_display_order_uidx",
+          "columns": [
+            {
+              "expression": "survey_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_question\".\"current_content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_config_idx": {
+          "name": "survey_question_config_idx",
+          "columns": [
+            {
+              "expression": "survey_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_survey_config_id_survey_config_id_fk": {
+          "name": "survey_question_survey_config_id_survey_config_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_conversation_id_conversation_id_fk": {
+          "name": "survey_question_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_current_content_id_survey_question_content_id_fk": {
+          "name": "survey_question_current_content_id_survey_question_content_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_question_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_config_conversation_fk": {
+          "name": "survey_question_config_conversation_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_slug_id_unique": {
+          "name": "survey_question_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "survey_question_current_content_id_unique": {
+          "name": "survey_question_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "survey_question_id_conversation_unique": {
+          "name": "survey_question_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_response": {
+      "name": "survey_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_response_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_response_conversation_created_idx": {
+          "name": "survey_response_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_response_participant_id_user_id_fk": {
+          "name": "survey_response_participant_id_user_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_response_conversation_id_conversation_id_fk": {
+          "name": "survey_response_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_response_conversation_participant_unique": {
+          "name": "survey_response_conversation_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        },
+        "survey_response_id_conversation_unique": {
+          "name": "survey_response_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_weight": {
+          "name": "score_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_code_unique": {
+          "name": "topic_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "topic_name_unique": {
+          "name": "topic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "topic_description_unique": {
+          "name": "topic_description_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_display_language": {
+      "name": "user_display_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_display_language_user_idx": {
+          "name": "user_display_language_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_display_language_user_id_user_id_fk": {
+          "name": "user_display_language_user_id_user_id_fk",
+          "tableFrom": "user_display_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_display_language_unique": {
+          "name": "user_display_language_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mute_preference": {
+      "name": "user_mute_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_mute_preference_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_mute": {
+          "name": "user_idx_mute",
+          "columns": [
+            {
+              "expression": "source_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mute_preference_source_user_id_user_id_fk": {
+          "name": "user_mute_preference_source_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_mute_preference_target_user_id_user_id_fk": {
+          "name": "user_mute_preference_target_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_unique_mute": {
+          "name": "user_unique_mute",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_user_id",
+            "target_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organization_mapping": {
+      "name": "user_organization_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_organization_mapping_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_idx_organization": {
+          "name": "user_idx_organization",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_organization_mapping_user_id_user_id_fk": {
+          "name": "user_organization_mapping_user_id_user_id_fk",
+          "tableFrom": "user_organization_mapping",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_organization_mapping_organization_id_organization_id_fk": {
+          "name": "user_organization_mapping_organization_id_organization_id_fk",
+          "tableFrom": "user_organization_mapping",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_orgaization_mapping": {
+          "name": "unique_user_orgaization_mapping",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_spoken_languages": {
+      "name": "user_spoken_languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_spoken_languages_user_idx": {
+          "name": "user_spoken_languages_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_spoken_languages_user_id_user_id_fk": {
+          "name": "user_spoken_languages_user_id_user_id_fk",
+          "tableFrom": "user_spoken_languages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_spoken_languages_unique": {
+          "name": "user_spoken_languages_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "polis_participant_id": {
+          "name": "polis_participant_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_site_moderator": {
+          "name": "is_site_moderator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_site_org_admin": {
+          "name": "is_site_org_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_imported": {
+          "name": "is_imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_conversation_count": {
+          "name": "active_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_conversation_count": {
+          "name": "total_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_isDeleted_idx": {
+          "name": "user_isDeleted_idx",
+          "columns": [
+            {
+              "expression": "is_deleted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_content": {
+      "name": "vote_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_content_id": {
+          "name": "opinion_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "vote_enum_all",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vote_content_vote_id_vote_id_fk": {
+          "name": "vote_content_vote_id_vote_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "vote",
+          "columnsFrom": [
+            "vote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_content_opinion_content_id_opinion_content_id_fk": {
+          "name": "vote_content_opinion_content_id_opinion_content_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "opinion_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polis_vote_id": {
+          "name": "polis_vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vote_authorId_idx": {
+          "name": "vote_authorId_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_opinion_active_idx": {
+          "name": "vote_opinion_active_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_author_id_user_id_fk": {
+          "name": "vote_author_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_opinion_id_opinion_id_fk": {
+          "name": "vote_opinion_id_opinion_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_current_content_id_vote_content_id_fk": {
+          "name": "vote_current_content_id_vote_content_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "vote_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vote_author_id_opinion_id_unique": {
+          "name": "vote_author_id_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_id",
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zk_passport": {
+      "name": "zk_passport",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "zk_passport_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citizenship": {
+          "name": "citizenship",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sex": {
+          "name": "sex",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zk_passport_nullifier_active_unique": {
+          "name": "zk_passport_nullifier_active_unique",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zk_passport\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zk_passport_nullifier_idx": {
+          "name": "zk_passport_nullifier_idx",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zk_passport_user_id_user_id_fk": {
+          "name": "zk_passport_user_id_user_id_fk",
+          "tableFrom": "zk_passport",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.auth_type": {
+      "name": "auth_type",
+      "schema": "public",
+      "values": [
+        "register",
+        "login_known_device",
+        "login_new_device",
+        "merge",
+        "restore_deleted",
+        "restore_and_merge"
+      ]
+    },
+    "public.conversation_moderation_action": {
+      "name": "conversation_moderation_action",
+      "schema": "public",
+      "values": [
+        "lock"
+      ]
+    },
+    "public.conversation_type": {
+      "name": "conversation_type",
+      "schema": "public",
+      "values": [
+        "polis",
+        "maxdiff"
+      ]
+    },
+    "public.email_reachability": {
+      "name": "email_reachability",
+      "schema": "public",
+      "values": [
+        "safe",
+        "risky",
+        "invalid",
+        "unknown"
+      ]
+    },
+    "public.email_type": {
+      "name": "email_type",
+      "schema": "public",
+      "values": [
+        "primary",
+        "backup",
+        "secondary",
+        "other"
+      ]
+    },
+    "public.event_slug": {
+      "name": "event_slug",
+      "schema": "public",
+      "values": [
+        "devconnect-2025"
+      ]
+    },
+    "public.export_artifact_status_enum": {
+      "name": "export_artifact_status_enum",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.export_cancellation_reason_enum": {
+      "name": "export_cancellation_reason_enum",
+      "schema": "public",
+      "values": [
+        "duplicate_in_batch",
+        "cooldown_active"
+      ]
+    },
+    "public.export_failure_reason_enum": {
+      "name": "export_failure_reason_enum",
+      "schema": "public",
+      "values": [
+        "processing_error",
+        "timeout",
+        "server_restart"
+      ]
+    },
+    "public.export_file_audience_enum": {
+      "name": "export_file_audience_enum",
+      "schema": "public",
+      "values": [
+        "redacted",
+        "owner",
+        "requester"
+      ]
+    },
+    "public.export_file_type_enum": {
+      "name": "export_file_type_enum",
+      "schema": "public",
+      "values": [
+        "bundle",
+        "comments",
+        "votes",
+        "participants",
+        "summary",
+        "stats",
+        "survey_questions",
+        "survey_question_options",
+        "survey_participant_responses",
+        "survey_public_aggregates",
+        "survey_full_aggregates"
+      ]
+    },
+    "public.export_generation_status_enum": {
+      "name": "export_generation_status_enum",
+      "schema": "public",
+      "values": [
+        "collecting",
+        "queued",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.export_status_enum": {
+      "name": "export_status_enum",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.external_source_type": {
+      "name": "external_source_type",
+      "schema": "public",
+      "values": [
+        "github_issue"
+      ]
+    },
+    "public.import_failure_reason_enum": {
+      "name": "import_failure_reason_enum",
+      "schema": "public",
+      "values": [
+        "processing_error",
+        "timeout",
+        "server_restart",
+        "invalid_data_format"
+      ]
+    },
+    "public.import_method": {
+      "name": "import_method",
+      "schema": "public",
+      "values": [
+        "url",
+        "csv"
+      ]
+    },
+    "public.import_status_enum": {
+      "name": "import_status_enum",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.maxdiff_lifecycle_status": {
+      "name": "maxdiff_lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "in_progress",
+        "canceled"
+      ]
+    },
+    "public.moderation_reason_enum": {
+      "name": "moderation_reason_enum",
+      "schema": "public",
+      "values": [
+        "misleading",
+        "antisocial",
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "opinion_vote",
+        "new_opinion",
+        "export_started",
+        "export_completed",
+        "export_failed",
+        "export_cancelled",
+        "import_started",
+        "import_completed",
+        "import_failed"
+      ]
+    },
+    "public.opinion_moderation_action": {
+      "name": "opinion_moderation_action",
+      "schema": "public",
+      "values": [
+        "move",
+        "hide"
+      ]
+    },
+    "public.participation_mode": {
+      "name": "participation_mode",
+      "schema": "public",
+      "values": [
+        "account_required",
+        "strong_verification",
+        "email_verification",
+        "guest"
+      ]
+    },
+    "public.phone_country_code": {
+      "name": "phone_country_code",
+      "schema": "public",
+      "values": [
+        "AC",
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AO",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NU",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TA",
+        "TC",
+        "TD",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "XK",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW"
+      ]
+    },
+    "public.polis_key_enum": {
+      "name": "polis_key_enum",
+      "schema": "public",
+      "values": [
+        "0",
+        "1",
+        "2",
+        "3",
+        "4",
+        "5"
+      ]
+    },
+    "public.report_reason_enum": {
+      "name": "report_reason_enum",
+      "schema": "public",
+      "values": [
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam",
+        "misleading",
+        "antisocial"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "F",
+        "M",
+        "X"
+      ]
+    },
+    "public.survey_choice_display": {
+      "name": "survey_choice_display",
+      "schema": "public",
+      "values": [
+        "auto",
+        "list",
+        "dropdown"
+      ]
+    },
+    "public.survey_question_type": {
+      "name": "survey_question_type",
+      "schema": "public",
+      "values": [
+        "choice",
+        "free_text"
+      ]
+    },
+    "public.ticket_provider": {
+      "name": "ticket_provider",
+      "schema": "public",
+      "values": [
+        "zupass"
+      ]
+    },
+    "public.vote_enum_all": {
+      "name": "vote_enum_all",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree",
+        "pass"
+      ]
+    },
+    "public.vote_enum_simple": {
+      "name": "vote_enum_simple",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1777301654418,
       "tag": "0059_dapper_xavin",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1777396555114,
+      "tag": "0060_puzzling_spectrum",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1426,6 +1426,7 @@ server.after(() => {
                 moderationAction: request.body.moderationAction,
                 moderationExplanation: request.body.moderationExplanation,
                 userId: deviceStatus.userId,
+                isSiteModerator,
             });
         },
     });
@@ -1498,7 +1499,6 @@ server.after(() => {
             await withdrawModerationReportByCommentSlugId({
                 db: db,
                 commentSlugId: request.body.opinionSlugId,
-                callerUserId: deviceStatus.userId,
                 isSiteModerator,
             });
         },

--- a/services/api/src/service/administrator/organization.ts
+++ b/services/api/src/service/administrator/organization.ts
@@ -60,6 +60,28 @@ interface GetOrganizationsByUsernameProps {
     baseImageServiceUrl: string;
 }
 
+interface GetOrganizationsByUserIdProps {
+    db: PostgresJsDatabase;
+    userId: string;
+    baseImageServiceUrl: string;
+}
+
+interface GetOrganizationIdsByUserIdProps {
+    db: PostgresJsDatabase;
+    userId: string;
+}
+
+interface GetOrganizationMembershipsByUserIdProps {
+    db: PostgresJsDatabase;
+    userId: string;
+    baseImageServiceUrl: string;
+}
+
+export interface OrganizationMembership {
+    organizationId: number;
+    organization: OrganizationProperties;
+}
+
 export async function getOrganizationsByUsername({
     db,
     username,
@@ -71,9 +93,49 @@ export async function getOrganizationsByUsername({
         username: username,
     });
 
-    const organizationList: OrganizationProperties[] = [];
+    return await getOrganizationsByUserId({
+        db,
+        userId: targetUserId,
+        baseImageServiceUrl,
+    });
+}
+
+export async function getOrganizationsByUserId({
+    db,
+    userId,
+    baseImageServiceUrl,
+}: GetOrganizationsByUserIdProps): Promise<GetOrganizationsByUsernameResponse> {
+    const memberships = await getOrganizationMembershipsByUserId({
+        db,
+        userId,
+        baseImageServiceUrl,
+    });
+
+    return {
+        organizationList: memberships.map((membership) => membership.organization),
+    };
+}
+
+export async function getOrganizationIdsByUserId({
+    db,
+    userId,
+}: GetOrganizationIdsByUserIdProps): Promise<number[]> {
+    const organizationTableResponse = await db
+        .select({ organizationId: userOrganizationMappingTable.organizationId })
+        .from(userOrganizationMappingTable)
+        .where(eq(userOrganizationMappingTable.userId, userId));
+
+    return organizationTableResponse.map((response) => response.organizationId);
+}
+
+export async function getOrganizationMembershipsByUserId({
+    db,
+    userId,
+    baseImageServiceUrl,
+}: GetOrganizationMembershipsByUserIdProps): Promise<OrganizationMembership[]> {
     const organizationTableResponse = await db
         .select({
+            organizationId: organizationTable.id,
             name: organizationTable.name,
             description: organizationTable.description,
             imagePath: organizationTable.imagePath,
@@ -81,21 +143,18 @@ export async function getOrganizationsByUsername({
             websiteUrl: organizationTable.websiteUrl,
         })
         .from(userOrganizationMappingTable)
-        .leftJoin(
+        .innerJoin(
             organizationTable,
             eq(
                 organizationTable.id,
                 userOrganizationMappingTable.organizationId,
             ),
         )
-        .where(eq(userOrganizationMappingTable.userId, targetUserId));
-    organizationTableResponse.forEach((response) => {
-        if (
-            response.name &&
-            response.imagePath !== null &&
-            response.isFullImagePath !== null
-        ) {
-            organizationList.push({
+        .where(eq(userOrganizationMappingTable.userId, userId));
+
+    return organizationTableResponse.map((response) => ({
+        organizationId: response.organizationId,
+        organization: {
                 name: response.name,
                 description: response.description ?? "",
                 imageUrl: imagePathToUrl({
@@ -104,13 +163,8 @@ export async function getOrganizationsByUsername({
                     baseImageServiceUrl,
                 }),
                 websiteUrl: response.websiteUrl ?? "",
-            });
-        }
-    });
-
-    return {
-        organizationList: organizationList,
-    };
+        },
+    }));
 }
 
 interface RemoveUserOrganizationMappingProps {

--- a/services/api/src/service/common.ts
+++ b/services/api/src/service/common.ts
@@ -25,7 +25,7 @@ import type {
 } from "@/shared/types/zod.js";
 import { zodExternalSourceConfig } from "@/shared/types/zod.js";
 import { httpErrors } from "@fastify/sensible";
-import { eq, desc, SQL, and, sql } from "drizzle-orm";
+import { eq, desc, SQL, and, sql, isNotNull, inArray } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import sanitizeHtml from "sanitize-html";
 import { createPostModerationPropertyObject } from "./moderation.js";
@@ -201,7 +201,7 @@ export function useCommonPost() {
             )
             // whereClause = and(whereClause, lt(postTable.createdAt, lastCreatedAt));
             .where(and(where, eq(userTable.isDeleted, false)))
-            .orderBy(desc(conversationTable.createdAt));
+            .orderBy(desc(conversationTable.createdAt), desc(conversationTable.id));
         if (limit !== undefined) {
             postItems = await postItemsQuery.$dynamic().limit(limit);
         } else {
@@ -329,8 +329,11 @@ export function useCommonPost() {
                                 maxdiffItemTable.conversationId,
                                 postItem.conversationId,
                             ),
-                            sql`${maxdiffItemTable.currentContentId} IS NOT NULL`,
-                            sql`${maxdiffItemTable.lifecycleStatus} IN ('active', 'in_progress')`,
+                            isNotNull(maxdiffItemTable.currentContentId),
+                            inArray(maxdiffItemTable.lifecycleStatus, [
+                                "active",
+                                "in_progress",
+                            ]),
                         ),
                     );
                 metadata.opinionCount = itemCountResult.count;

--- a/services/api/src/service/conversationAccess.ts
+++ b/services/api/src/service/conversationAccess.ts
@@ -1,10 +1,78 @@
-import { eq } from "drizzle-orm";
+import { eq, inArray, or } from "drizzle-orm";
 import type { PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
 import { httpErrors } from "@fastify/sensible";
 import { conversationTable } from "@/shared-backend/schema.js";
 import * as authUtilService from "@/service/authUtil.js";
 
 export type ConversationViewAccessLevel = "public" | "owner";
+
+export function getConversationOwnerFilter({
+    userId,
+    organizationIds,
+}: {
+    userId: string;
+    organizationIds: number[];
+}) {
+    const authorFilter = eq(conversationTable.authorId, userId);
+    if (organizationIds.length === 0) {
+        return authorFilter;
+    }
+
+    return or(
+        authorFilter,
+        inArray(conversationTable.organizationId, organizationIds),
+    );
+}
+
+export async function isConversationOwner({
+    db,
+    userId,
+    authorId,
+    organizationId,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    authorId: string;
+    organizationId: number | null;
+}): Promise<boolean> {
+    if (authorId === userId) {
+        return true;
+    }
+
+    if (organizationId === null) {
+        return false;
+    }
+
+    return await authUtilService.isUserPartOfOrganizationById({
+        db,
+        userId,
+        organizationId,
+    });
+}
+
+export async function getConversationViewAccessLevelForConversation({
+    db,
+    userId,
+    authorId,
+    organizationId,
+}: {
+    db: PostgresDatabase;
+    userId: string | undefined;
+    authorId: string;
+    organizationId: number | null;
+}): Promise<ConversationViewAccessLevel> {
+    if (userId === undefined) {
+        return "public";
+    }
+
+    const isOwner = await isConversationOwner({
+        db,
+        userId,
+        authorId,
+        organizationId,
+    });
+    return isOwner ? "owner" : "public";
+}
 
 export async function getConversationViewAccessLevel({
     db,
@@ -15,10 +83,6 @@ export async function getConversationViewAccessLevel({
     conversationId: number;
     userId: string | undefined;
 }): Promise<ConversationViewAccessLevel> {
-    if (userId === undefined) {
-        return "public";
-    }
-
     const conversationRows = await db
         .select({
             authorId: conversationTable.authorId,
@@ -32,21 +96,10 @@ export async function getConversationViewAccessLevel({
     }
     const conversation = conversationRows[0];
 
-    if (conversation.authorId === userId) {
-        return "owner";
-    }
-
-    if (conversation.organizationId !== null) {
-        const isOrganizationMember =
-            await authUtilService.isUserPartOfOrganizationById({
-                db,
-                userId,
-                organizationId: conversation.organizationId,
-            });
-        if (isOrganizationMember) {
-            return "owner";
-        }
-    }
-
-    return "public";
+    return await getConversationViewAccessLevelForConversation({
+        db,
+        userId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
+    });
 }

--- a/services/api/src/service/conversationExport/core.ts
+++ b/services/api/src/service/conversationExport/core.ts
@@ -54,7 +54,7 @@ import {
 import { createExportNotification } from "./notifications.js";
 import { getActiveSurveyConfigRecord } from "../survey.js";
 import type { ExportAccessLevel } from "./generators/base.js";
-import { getConversationViewAccessLevel } from "@/service/conversationAccess.js";
+import { getConversationViewAccessLevelForConversation } from "@/service/conversationAccess.js";
 import { generateRandomSlugId } from "@/crypto.js";
 import type { RealtimeSSEManager } from "../realtimeSSE.js";
 
@@ -198,18 +198,28 @@ async function generateExportBundleZip({
     return await zip.generateAsync({ type: "nodebuffer" });
 }
 
+interface ConversationExportConversationRecord {
+    id: number;
+    slugId: string;
+    title: string;
+    authorId: string;
+    organizationId: number | null;
+}
+
 async function findConversationRecord({
     db,
     conversationSlugId,
 }: {
     db: PostgresDatabase;
     conversationSlugId: string;
-}): Promise<{ id: number; slugId: string; title: string } | undefined> {
+}): Promise<ConversationExportConversationRecord | undefined> {
     const conversations = await db
         .select({
             id: conversationTable.id,
             slugId: conversationTable.slugId,
             title: conversationContentTable.title,
+            authorId: conversationTable.authorId,
+            organizationId: conversationTable.organizationId,
         })
         .from(conversationTable)
         .innerJoin(
@@ -228,7 +238,7 @@ async function getConversationRecord({
 }: {
     db: PostgresDatabase;
     conversationSlugId: string;
-}): Promise<{ id: number; slugId: string; title: string }> {
+}): Promise<ConversationExportConversationRecord> {
     const conversation = await findConversationRecord({ db, conversationSlugId });
 
     if (conversation === undefined) {
@@ -694,10 +704,11 @@ export async function requestConversationExport({
         return { success: false, reason: "conversation_not_found" };
     }
 
-    const exportAccessLevel = await getConversationViewAccessLevel({
+    const exportAccessLevel = await getConversationViewAccessLevelForConversation({
         db,
-        conversationId: conversation.id,
         userId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
     });
 
     const opinionCount = await getOpinionCount({
@@ -835,6 +846,8 @@ interface RequestStatusRecord {
     status: ExportRequestStatus;
     conversationId: number;
     conversationSlugId: string;
+    conversationAuthorId: string;
+    conversationOrganizationId: number | null;
     failureReason: ExportFailureReason | null;
     cancellationReason: ExportCancellationReason | null;
     createdAt: Date;
@@ -854,6 +867,8 @@ async function getRequestStatusRecord({
             status: conversationExportRequestTable.status,
             conversationId: conversationTable.id,
             conversationSlugId: conversationTable.slugId,
+            conversationAuthorId: conversationTable.authorId,
+            conversationOrganizationId: conversationTable.organizationId,
             failureReason: conversationExportRequestTable.failureReason,
             cancellationReason: conversationExportRequestTable.cancellationReason,
             createdAt: conversationExportRequestTable.createdAt,
@@ -987,10 +1002,11 @@ export async function getConversationExportStatus({
     userId,
 }: GetConversationExportStatusParams): Promise<GetConversationExportStatusResponse> {
     const request = await getRequestStatusRecord({ db, exportSlugId, userId });
-    const exportAccessLevel = await getConversationViewAccessLevel({
+    const exportAccessLevel = await getConversationViewAccessLevelForConversation({
         db,
-        conversationId: request.conversationId,
         userId,
+        authorId: request.conversationAuthorId,
+        organizationId: request.conversationOrganizationId,
     });
 
     if (request.deletedAt !== null || request.expiresAt < new Date()) {

--- a/services/api/src/service/externalSource/github.ts
+++ b/services/api/src/service/externalSource/github.ts
@@ -18,6 +18,7 @@ import {
 } from "@/shared-app-api/html.js";
 import { marked } from "marked";
 import type { GitHubClient, GitHubIssue, SyncResult } from "./index.js";
+import { isConversationOwner } from "@/service/conversationAccess.js";
 
 // --- Pure functions ---
 
@@ -572,6 +573,7 @@ export async function syncGitHubIssues({
             id: conversationTable.id,
             currentContentId: conversationTable.currentContentId,
             authorId: conversationTable.authorId,
+            organizationId: conversationTable.organizationId,
             externalSourceConfig: conversationTable.externalSourceConfig,
             conversationType: conversationTable.conversationType,
         })
@@ -584,8 +586,14 @@ export async function syncGitHubIssues({
 
     const conversation = conversationRows[0];
 
-    if (conversation.authorId !== requestingUserId) {
-        throw new Error("Only the conversation author can trigger sync");
+    const isOwner = await isConversationOwner({
+        db,
+        userId: requestingUserId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
+    });
+    if (!isOwner) {
+        throw new Error("Only conversation owners can trigger sync");
     }
 
     if (conversation.conversationType !== "maxdiff") {

--- a/services/api/src/service/feed.ts
+++ b/services/api/src/service/feed.ts
@@ -9,30 +9,38 @@ import { useCommonPost } from "./common.js";
 import { getConversationEngagementScore } from "./recommendationSystem.js";
 import type { FetchFeedResponse } from "@/shared/types/dto.js";
 
-interface GetPostSlugIdLastCreatedAtProps {
+interface GetPostSlugIdLastCursorProps {
     lastSlugId: string | undefined;
     db: PostgresDatabase;
 }
 
-export async function getPostSlugIdLastCreatedAt({
+export interface PostCursor {
+    conversationId: number;
+    createdAt: Date;
+}
+
+export async function getPostSlugIdLastCursor({
     lastSlugId,
     db,
-}: GetPostSlugIdLastCreatedAtProps): Promise<Date | undefined> {
-    let lastCreatedAt;
+}: GetPostSlugIdLastCursorProps): Promise<PostCursor | undefined> {
+    let lastCursor;
 
     if (lastSlugId) {
         const selectResponse = await db
-            .select({ createdAt: conversationTable.createdAt })
+            .select({
+                conversationId: conversationTable.id,
+                createdAt: conversationTable.createdAt,
+            })
             .from(conversationTable)
             .where(eq(conversationTable.slugId, lastSlugId));
         if (selectResponse.length == 1) {
-            lastCreatedAt = selectResponse[0].createdAt;
+            lastCursor = selectResponse[0];
         } else {
             // Ignore the slug ID if it cannot be found
         }
     }
 
-    return lastCreatedAt;
+    return lastCursor;
 }
 
 interface FetchFeedProps {

--- a/services/api/src/service/maxdiffItem.ts
+++ b/services/api/src/service/maxdiffItem.ts
@@ -19,6 +19,7 @@ import { processUserGeneratedHtml } from "@/shared-app-api/html.js";
 import { log } from "@/app.js";
 import type { Valkey } from "@/shared-backend/valkey.js";
 import { VALKEY_QUEUE_KEYS } from "@/shared-backend/valkeyQueues.js";
+import { isConversationOwner } from "@/service/conversationAccess.js";
 
 /**
  * Mark a MaxDiff conversation as dirty so the scoring worker re-scores
@@ -264,15 +265,23 @@ export async function updateMaxdiffItemLifecycle({
             conversationSlugId,
         });
 
-    // Verify the requesting user is the conversation author
     const [conversation] = await db
-        .select({ authorId: conversationTable.authorId })
+        .select({
+            authorId: conversationTable.authorId,
+            organizationId: conversationTable.organizationId,
+        })
         .from(conversationTable)
         .where(eq(conversationTable.id, conversationId));
 
-    if (conversation.authorId !== requestingUserId) {
+    const isOwner = await isConversationOwner({
+        db,
+        userId: requestingUserId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
+    });
+    if (!isOwner) {
         throw httpErrors.forbidden(
-            "Only the conversation author can update item lifecycle",
+            "Only conversation owners can update item lifecycle",
         );
     }
 

--- a/services/api/src/service/moderation.ts
+++ b/services/api/src/service/moderation.ts
@@ -14,7 +14,7 @@ import type {
     ConversationModerationProperties,
     ModerationReason,
 } from "@/shared/types/zod.js";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { nowZeroMs } from "@/shared/util.js";
 import { httpErrors } from "@fastify/sensible";
 
@@ -77,6 +77,7 @@ interface ModerateByCommentSlugIdProps {
     moderationReason: ModerationReason;
     moderationExplanation: string;
     userId: string;
+    isSiteModerator: boolean;
 }
 
 export async function moderateByCommentSlugId({
@@ -86,24 +87,35 @@ export async function moderateByCommentSlugId({
     userId,
     moderationExplanation,
     moderationAction,
+    isSiteModerator,
 }: ModerateByCommentSlugIdProps) {
     const { getOpinionMetadataFromOpinionSlugId } = useCommonComment();
-    const { opinionId } = await getOpinionMetadataFromOpinionSlugId({
+    const { opinionId, conversationId } = await getOpinionMetadataFromOpinionSlugId({
         db: db,
-        opinionSlugId: commentSlugId,
-    });
-
-    const moderationStatus = await fetchModerationReportByCommentSlugId({
-        db: db,
-        commentSlugId: commentSlugId,
-    });
-    const { conversationId } = await getOpinionMetadataFromOpinionSlugId({
-        db,
         opinionSlugId: commentSlugId,
     });
 
     await db.transaction(async (tx) => {
-        if (moderationStatus.status == "moderated") {
+        const moderationRows = await tx
+            .select({
+                id: opinionModerationTable.id,
+                moderationAction: opinionModerationTable.moderationAction,
+            })
+            .from(opinionModerationTable)
+            .where(eq(opinionModerationTable.opinionId, opinionId))
+            .limit(1);
+
+        const existingModeration = moderationRows.at(0);
+        if (existingModeration !== undefined) {
+            if (
+                existingModeration.moderationAction === "hide" &&
+                !isSiteModerator
+            ) {
+                throw httpErrors.forbidden(
+                    "Only site moderators can modify hidden opinions",
+                );
+            }
+
             // Already moderated - just update the moderation record (no count change)
             await tx
                 .update(opinionModerationTable)
@@ -114,7 +126,7 @@ export async function moderateByCommentSlugId({
                     moderationExplanation: moderationExplanation,
                     updatedAt: nowZeroMs(),
                 })
-                .where(eq(opinionModerationTable.opinionId, opinionId));
+                .where(eq(opinionModerationTable.id, existingModeration.id));
         } else {
             // New moderation - insert record
             await tx.insert(opinionModerationTable).values({
@@ -248,14 +260,12 @@ export async function withdrawModerationReportByPostSlugId({
 interface WithdrawModerationReportByCommentSlugIdProps {
     commentSlugId: string;
     db: PostgresJsDatabase;
-    callerUserId: string;
     isSiteModerator: boolean;
 }
 
 export async function withdrawModerationReportByCommentSlugId({
     db,
     commentSlugId,
-    callerUserId,
     isSiteModerator,
 }: WithdrawModerationReportByCommentSlugIdProps) {
     const { getCommentIdFromCommentSlugId } = useCommonComment();
@@ -271,19 +281,32 @@ export async function withdrawModerationReportByCommentSlugId({
     });
 
     await db.transaction(async (tx) => {
+        const moderationRows = await tx
+            .select({
+                id: opinionModerationTable.id,
+                moderationAction: opinionModerationTable.moderationAction,
+            })
+            .from(opinionModerationTable)
+            .where(eq(opinionModerationTable.opinionId, commentId))
+            .limit(1);
+
+        if (moderationRows.length !== 1) {
+            throw httpErrors.notFound(
+                "Failed to delete moderation action for opinion slug ID: " +
+                    commentSlugId,
+            );
+        }
+
+        const moderation = moderationRows[0];
+        if (moderation.moderationAction === "hide" && !isSiteModerator) {
+            throw httpErrors.forbidden(
+                "Only site moderators can withdraw hidden opinions",
+            );
+        }
+
         const moderationCommentsTableResponse = await tx
             .delete(opinionModerationTable)
-            .where(
-                isSiteModerator
-                    ? eq(opinionModerationTable.opinionId, commentId)
-                    : and(
-                          eq(opinionModerationTable.opinionId, commentId),
-                          eq(
-                              opinionModerationTable.authorId,
-                              callerUserId,
-                          ),
-                      ),
-            )
+            .where(eq(opinionModerationTable.id, moderation.id))
             .returning();
 
         if (moderationCommentsTableResponse.length != 1) {

--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -6,7 +6,7 @@ import {
     conversationTable,
     userTable,
 } from "@/shared-backend/schema.js";
-import { eq, sql, and } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { generateRandomSlugId } from "@/crypto.js";
 import { log } from "@/app.js";
 import { useCommonPost } from "./common.js";
@@ -37,6 +37,7 @@ import {
     setSurveyConfigForConversation,
     warmSurveyTranslationsForConversation,
 } from "@/service/survey.js";
+import { isConversationOwner } from "@/service/conversationAccess.js";
 
 const MAX_CONVERSATION_SEED_ITEMS = 50;
 
@@ -351,33 +352,49 @@ export async function deletePostBySlugId({
     userId,
 }: DeletePostBySlugIdProps): Promise<void> {
     const conversationId = await db.transaction(async (tx) => {
-        // Delete the conversation
-        const updatedConversationIdResponse = await tx
+        const conversationRows = await tx
+            .select({
+                conversationId: conversationTable.id,
+                authorId: conversationTable.authorId,
+                organizationId: conversationTable.organizationId,
+                currentContentId: conversationTable.currentContentId,
+            })
+            .from(conversationTable)
+            .where(eq(conversationTable.slugId, conversationSlugId))
+            .limit(1);
+
+        if (conversationRows.length === 0) {
+            throw httpErrors.notFound("Conversation not found");
+        }
+
+        const conversation = conversationRows[0];
+        const isOwner = await isConversationOwner({
+            db: tx,
+            userId,
+            authorId: conversation.authorId,
+            organizationId: conversation.organizationId,
+        });
+        if (!isOwner) {
+            throw httpErrors.forbidden("Only conversation owners can delete it");
+        }
+        if (conversation.currentContentId === null) {
+            throw httpErrors.notFound("Conversation not found");
+        }
+
+        await tx
             .update(conversationTable)
             .set({
                 currentContentId: null,
             })
-            .where(
-                and(
-                    eq(conversationTable.authorId, userId),
-                    eq(conversationTable.slugId, conversationSlugId),
-                ),
-            )
-            .returning({ conversationId: conversationTable.id });
+            .where(eq(conversationTable.id, conversation.conversationId));
 
-        if (updatedConversationIdResponse.length != 1) {
-            tx.rollback();
-        }
-
-        const conversationId = updatedConversationIdResponse[0].conversationId;
-
-        // Update the user's active conversation count
+        // Update the original author's active conversation count
         await tx
             .update(userTable)
             .set({
                 activeConversationCount: sql`${userTable.activeConversationCount} - 1`,
             })
-            .where(eq(userTable.id, userId));
+            .where(eq(userTable.id, conversation.authorId));
 
         // Mark all of the opinions as deleted
         await tx
@@ -385,9 +402,9 @@ export async function deletePostBySlugId({
             .set({
                 currentContentId: null,
             })
-            .where(eq(opinionTable.conversationId, conversationId));
+            .where(eq(opinionTable.conversationId, conversation.conversationId));
 
-        return conversationId;
+        return conversation.conversationId;
     });
 
     // Delete all conversation exports after the transaction completes
@@ -439,18 +456,12 @@ export async function closeConversation({
         throw httpErrors.notFound("Conversation not found");
     }
 
-    // Check authorization: user must be author OR member of the conversation's organization
-    const isAuthor = conversation[0].authorId === userId;
-    let isAuthorized = isAuthor;
-
-    if (!isAuthorized && conversation[0].organizationId !== null) {
-        isAuthorized = await authUtilService.isUserPartOfOrganizationById({
-            db,
-            userId,
-            organizationId: conversation[0].organizationId,
-        });
-    }
-
+    const isAuthorized = await isConversationOwner({
+        db,
+        userId,
+        authorId: conversation[0].authorId,
+        organizationId: conversation[0].organizationId,
+    });
     if (!isAuthorized) {
         return { success: false, reason: "not_allowed" };
     }
@@ -497,18 +508,12 @@ export async function openConversation({
         throw httpErrors.notFound("Conversation not found");
     }
 
-    // Check authorization: user must be author OR member of the conversation's organization
-    const isAuthor = conversation[0].authorId === userId;
-    let isAuthorized = isAuthor;
-
-    if (!isAuthorized && conversation[0].organizationId !== null) {
-        isAuthorized = await authUtilService.isUserPartOfOrganizationById({
-            db,
-            userId,
-            organizationId: conversation[0].organizationId,
-        });
-    }
-
+    const isAuthorized = await isConversationOwner({
+        db,
+        userId,
+        authorId: conversation[0].authorId,
+        organizationId: conversation[0].organizationId,
+    });
     if (!isAuthorized) {
         return { success: false, reason: "not_allowed" };
     }

--- a/services/api/src/service/postEdit.ts
+++ b/services/api/src/service/postEdit.ts
@@ -13,6 +13,8 @@ import { toUnionUndefined } from "@/shared/shared.js";
 import { processUserGeneratedHtml } from "@/shared-app-api/html.js";
 import type { GoogleCloudCredentials } from "@/shared-backend/googleCloudAuth.js";
 import {
+    assertSurveyFeatureAllowedForConversation,
+    getActiveSurveyConfigRecord,
     getSurveyConfigForConversation,
     setSurveyConfigForConversation,
     warmSurveyTranslationsForConversation,
@@ -22,6 +24,7 @@ import type {
     UpdateConversationRequest,
     UpdateConversationResponse,
 } from "@/shared/types/dto.js";
+import { isConversationOwner } from "@/service/conversationAccess.js";
 
 interface GetConversationForEditProps {
     db: PostgresDatabase;
@@ -39,6 +42,7 @@ export async function getConversationForEdit({
             conversationId: conversationTable.id,
             conversationSlugId: conversationTable.slugId,
             authorId: conversationTable.authorId,
+            organizationId: conversationTable.organizationId,
             conversationTitle: conversationContentTable.title,
             conversationBody: conversationContentTable.body,
             isIndexed: conversationTable.isIndexed,
@@ -74,8 +78,13 @@ export async function getConversationForEdit({
 
     const conversation = results[0];
 
-    // Check if user is the author
-    if (conversation.authorId !== userId) {
+    const isOwner = await isConversationOwner({
+        db,
+        userId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
+    });
+    if (!isOwner) {
         return { success: false, reason: "not_author" };
     }
 
@@ -152,103 +161,116 @@ export async function updateConversation({
 
     let updatedConversationId: number | undefined;
 
-    const result = await db
-        .transaction(async (tx) => {
-            const now = new Date();
-            // Get conversation and check authorization
-            const conversationResults = await tx
-                .select({
-                    conversationId: conversationTable.id,
-                    authorId: conversationTable.authorId,
-                    currentContentId: conversationTable.currentContentId,
-                    moderationAction:
-                        conversationModerationTable.moderationAction,
-                })
-                .from(conversationTable)
-                .leftJoin(
-                    conversationModerationTable,
-                    eq(
-                        conversationModerationTable.conversationId,
-                        conversationTable.id,
-                    ),
-                )
-                .where(eq(conversationTable.slugId, conversationSlugId));
+    const result = await db.transaction(async (tx) => {
+        const now = new Date();
+        // Get conversation and check authorization
+        const conversationResults = await tx
+            .select({
+                conversationId: conversationTable.id,
+                authorId: conversationTable.authorId,
+                organizationId: conversationTable.organizationId,
+                organizationName: organizationTable.name,
+                currentContentId: conversationTable.currentContentId,
+                moderationAction: conversationModerationTable.moderationAction,
+            })
+            .from(conversationTable)
+            .leftJoin(
+                organizationTable,
+                eq(conversationTable.organizationId, organizationTable.id),
+            )
+            .leftJoin(
+                conversationModerationTable,
+                eq(
+                    conversationModerationTable.conversationId,
+                    conversationTable.id,
+                ),
+            )
+            .where(eq(conversationTable.slugId, conversationSlugId));
 
-            if (conversationResults.length === 0) {
-                return { success: false, reason: "not_found" } as const;
-            }
+        if (conversationResults.length === 0) {
+            return { success: false, reason: "not_found" } as const;
+        }
 
-            const conversation = conversationResults[0];
+        const conversation = conversationResults[0];
 
-            // Check if user is the author
-            if (conversation.authorId !== userId) {
-                return { success: false, reason: "not_author" } as const;
-            }
-
-            // Check if conversation is locked
-            if (conversation.moderationAction === "lock") {
-                return {
-                    success: false,
-                    reason: "conversation_locked",
-                } as const;
-            }
-
-            // Check if conversation was deleted
-            if (conversation.currentContentId === null) {
-                return { success: false, reason: "not_found" } as const;
-            }
-
-            const conversationId = conversation.conversationId;
-            updatedConversationId = conversationId;
-
-            // Create new conversation content
-            const newContentResult = await tx
-                .insert(conversationContentTable)
-                .values({
-                    conversationId: conversationId,
-                    title: conversationTitle,
-                    body: sanitizedBody,
-                })
-                .returning({
-                    conversationContentId: conversationContentTable.id,
-                });
-
-            const newContentId = newContentResult[0].conversationContentId;
-
-            // Update conversation with new content and settings
-            await tx
-                .update(conversationTable)
-                .set({
-                    currentContentId: newContentId,
-                    isIndexed: isIndexed,
-                    participationMode: participationMode,
-                    requiresEventTicket: requiresEventTicket ?? null,
-                    indexConversationAt:
-                        indexConversationAt !== undefined
-                            ? new Date(indexConversationAt)
-                            : null,
-                    updatedAt: new Date(),
-                    isEdited: true,
-                })
-                .where(eq(conversationTable.id, conversationId));
-
-            if (surveyConfig !== undefined) {
-                await setSurveyConfigForConversation({
-                    db: tx,
-                    conversationId,
-                    surveyConfig: surveyConfig ?? null,
-                    now,
-                });
-            }
-
-            return { success: true } as const;
-        })
-        .catch((error: unknown) => {
-            log.error(error, "Unexpected error updating conversation");
-            throw httpErrors.internalServerError(
-                "Failed to update conversation",
-            );
+        const isOwner = await isConversationOwner({
+            db: tx,
+            userId,
+            authorId: conversation.authorId,
+            organizationId: conversation.organizationId,
         });
+        if (!isOwner) {
+            return { success: false, reason: "not_author" } as const;
+        }
+
+        // Check if conversation is locked
+        if (conversation.moderationAction === "lock") {
+            return {
+                success: false,
+                reason: "conversation_locked",
+            } as const;
+        }
+
+        // Check if conversation was deleted
+        if (conversation.currentContentId === null) {
+            return { success: false, reason: "not_found" } as const;
+        }
+
+        const conversationId = conversation.conversationId;
+        updatedConversationId = conversationId;
+
+        // Create new conversation content
+        const newContentResult = await tx
+            .insert(conversationContentTable)
+            .values({
+                conversationId: conversationId,
+                title: conversationTitle,
+                body: sanitizedBody,
+            })
+            .returning({
+                conversationContentId: conversationContentTable.id,
+            });
+
+        const newContentId = newContentResult[0].conversationContentId;
+
+        // Update conversation with new content and settings
+        await tx
+            .update(conversationTable)
+            .set({
+                currentContentId: newContentId,
+                isIndexed: isIndexed,
+                participationMode: participationMode,
+                requiresEventTicket: requiresEventTicket ?? null,
+                indexConversationAt:
+                    indexConversationAt !== undefined
+                        ? new Date(indexConversationAt)
+                        : null,
+                updatedAt: new Date(),
+                isEdited: true,
+            })
+            .where(eq(conversationTable.id, conversationId));
+
+        if (surveyConfig !== undefined) {
+            const existingSurveyConfig = await getActiveSurveyConfigRecord({
+                db: tx,
+                conversationId,
+            });
+            assertSurveyFeatureAllowedForConversation({
+                organizationName: conversation.organizationName,
+                hasExistingSurvey: existingSurveyConfig !== undefined,
+                userId,
+            });
+
+            await setSurveyConfigForConversation({
+                db: tx,
+                conversationId,
+                surveyConfig: surveyConfig ?? null,
+                now,
+            });
+        }
+
+        return { success: true } as const;
+    });
 
     if (
         result.success &&

--- a/services/api/src/service/survey.ts
+++ b/services/api/src/service/survey.ts
@@ -65,7 +65,10 @@ import {
 } from "@/shared/languages.js";
 import { config, log } from "@/app.js";
 import { checkFeatureManagementAccess } from "@/shared-app-api/featureAccess.js";
-import { getConversationViewAccessLevel } from "@/service/conversationAccess.js";
+import {
+    getConversationViewAccessLevelForConversation,
+    isConversationOwner,
+} from "@/service/conversationAccess.js";
 import {
     PUBLIC_SURVEY_SUPPRESSION_THRESHOLD,
     buildSurveyAggregateRows,
@@ -79,6 +82,7 @@ interface ConversationAccessContext {
     conversationId: number;
     slugId: string;
     authorId: string;
+    organizationId: number | null;
     organizationName: string | null;
     participationMode: (typeof conversationTable.$inferSelect)["participationMode"];
     conversationType: (typeof conversationTable.$inferSelect)["conversationType"];
@@ -87,12 +91,12 @@ interface ConversationAccessContext {
     requiresEventTicket: (typeof conversationTable.$inferSelect)["requiresEventTicket"];
 }
 
-function assertSurveyFeatureAllowed({
-    conversation,
+export function assertSurveyFeatureAllowedForConversation({
+    organizationName,
     hasExistingSurvey,
     userId,
 }: {
-    conversation: ConversationAccessContext;
+    organizationName: string | null;
     hasExistingSurvey: boolean;
     userId: string;
 }): void {
@@ -102,8 +106,8 @@ function assertSurveyFeatureAllowed({
         isOrgOnly: config.IS_SURVEY_ORG_ONLY,
         allowedOrgs: config.SURVEY_ALLOWED_ORGS,
         allowedUsers: config.SURVEY_ALLOWED_USERS,
-        postAsOrganization: conversation.organizationName !== null,
-        organizationName: conversation.organizationName ?? "",
+        postAsOrganization: organizationName !== null,
+        organizationName: organizationName ?? "",
         userId,
     });
     if (surveyAccess.allowed) {
@@ -128,6 +132,22 @@ function assertSurveyFeatureAllowed({
                 "This user is not allowed to configure surveys",
             );
     }
+}
+
+function assertSurveyFeatureAllowed({
+    conversation,
+    hasExistingSurvey,
+    userId,
+}: {
+    conversation: ConversationAccessContext;
+    hasExistingSurvey: boolean;
+    userId: string;
+}): void {
+    assertSurveyFeatureAllowedForConversation({
+        organizationName: conversation.organizationName,
+        hasExistingSurvey,
+        userId,
+    });
 }
 
 interface SurveyConfigUpdateEffect {
@@ -847,6 +867,7 @@ async function getConversationAccessContextBySlugId({
             conversationId: conversationTable.id,
             slugId: conversationTable.slugId,
             authorId: conversationTable.authorId,
+            organizationId: conversationTable.organizationId,
             organizationName: organizationTable.name,
             participationMode: conversationTable.participationMode,
             conversationType: conversationTable.conversationType,
@@ -2275,10 +2296,11 @@ export async function fetchSurveyAggregatedResults({
         db,
         conversationSlugId,
     });
-    const accessLevel = await getConversationViewAccessLevel({
+    const accessLevel = await getConversationViewAccessLevelForConversation({
         db,
-        conversationId: conversation.conversationId,
         userId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
     });
     const context = await loadSurveyExportContext({
         db,
@@ -2332,14 +2354,15 @@ export async function fetchSurveyCompletionCounts({
         db,
         conversationSlugId,
     });
-    const accessLevel = await getConversationViewAccessLevel({
+    const accessLevel = await getConversationViewAccessLevelForConversation({
         db,
-        conversationId: conversation.conversationId,
         userId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
     });
     if (accessLevel !== "owner") {
         throw httpErrors.forbidden(
-            "Only the conversation author or facilitator can view survey completion counts",
+            "Only conversation owners can view survey completion counts",
         );
     }
 
@@ -2816,9 +2839,15 @@ export async function updateSurveyConfigByAuthor({
         db,
         conversationSlugId,
     });
-    if (conversation.authorId !== userId) {
+    const isOwner = await isConversationOwner({
+        db,
+        userId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
+    });
+    if (!isOwner) {
         throw httpErrors.forbidden(
-            "Only the conversation author can edit the survey",
+            "Only conversation owners can edit the survey",
         );
     }
     const existingSurveyConfig = await getActiveSurveyConfigRecord({
@@ -2896,9 +2925,15 @@ export async function deleteSurveyConfigByAuthor({
         db,
         conversationSlugId,
     });
-    if (conversation.authorId !== userId) {
+    const isOwner = await isConversationOwner({
+        db,
+        userId,
+        authorId: conversation.authorId,
+        organizationId: conversation.organizationId,
+    });
+    if (!isOwner) {
         throw httpErrors.forbidden(
-            "Only the conversation author can delete the survey",
+            "Only conversation owners can delete the survey",
         );
     }
     const existingSurveyConfig = await getActiveSurveyConfigRecord({

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -16,14 +16,28 @@ import type {
     ExtendedOpinionWithConvId,
 } from "@/shared/types/zod.js";
 import { httpErrors } from "@fastify/sensible";
-import { and, eq, lt, desc, inArray, isNotNull } from "drizzle-orm";
+import {
+    and,
+    count,
+    eq,
+    lt,
+    or,
+    ne,
+    desc,
+    inArray,
+    isNotNull,
+} from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { useCommonPost } from "./common.js";
-import { getPostSlugIdLastCreatedAt } from "./feed.js";
+import { getPostSlugIdLastCursor } from "./feed.js";
 import { getCommentSlugIdLastCreatedAt } from "./comment.js";
 import { fetchPostBySlugId } from "./post.js";
 import { createCommentModerationPropertyObject } from "./moderation.js";
-import { getOrganizationsByUsername } from "./administrator/organization.js";
+import {
+    getOrganizationIdsByUserId,
+    getOrganizationMembershipsByUserId,
+} from "./administrator/organization.js";
+import { getConversationOwnerFilter } from "./conversationAccess.js";
 import type { ImportPolisResults } from "@/shared/types/polis.js";
 import { generateUUID } from "@/crypto.js";
 import type { UserIdPerParticipantId } from "@/utils/dataStructure.js";
@@ -222,6 +236,49 @@ interface GetUserPostProps {
     limit?: number;
 }
 
+async function getOwnedActiveConversationCount({
+    db,
+    userId,
+    organizationIds,
+}: {
+    db: PostgresJsDatabase;
+    userId: string;
+    organizationIds: number[];
+}): Promise<number> {
+    const authorCountRows = await db
+        .select({ count: count() })
+        .from(conversationTable)
+        .innerJoin(userTable, eq(userTable.id, conversationTable.authorId))
+        .where(
+            and(
+                eq(conversationTable.authorId, userId),
+                eq(conversationTable.isImporting, false),
+                isNotNull(conversationTable.currentContentId),
+                eq(userTable.isDeleted, false),
+            ),
+        );
+
+    if (organizationIds.length === 0) {
+        return authorCountRows[0].count;
+    }
+
+    const organizationCountRows = await db
+        .select({ count: count() })
+        .from(conversationTable)
+        .innerJoin(userTable, eq(userTable.id, conversationTable.authorId))
+        .where(
+            and(
+                inArray(conversationTable.organizationId, organizationIds),
+                ne(conversationTable.authorId, userId),
+                eq(conversationTable.isImporting, false),
+                isNotNull(conversationTable.currentContentId),
+                eq(userTable.isDeleted, false),
+            ),
+        );
+
+    return authorCountRows[0].count + organizationCountRows[0].count;
+}
+
 export async function getUserPosts({
     db,
     userId,
@@ -232,21 +289,37 @@ export async function getUserPosts({
     try {
         const { fetchPostItems } = useCommonPost();
 
-        const lastCreatedAt = await getPostSlugIdLastCreatedAt({
+        const lastCursor = await getPostSlugIdLastCursor({
             lastSlugId: lastPostSlugId,
             db: db,
         });
+        const organizationIds = await getOrganizationIdsByUserId({ db, userId });
+        const ownershipFilter = getConversationOwnerFilter({
+            userId,
+            organizationIds,
+        });
 
         const whereClause =
-            lastCreatedAt !== undefined
+            lastCursor !== undefined
                 ? and(
-                      eq(conversationTable.authorId, userId),
+                      ownershipFilter,
                       eq(conversationTable.isImporting, false),
-                      lt(conversationTable.createdAt, lastCreatedAt),
+                      isNotNull(conversationTable.currentContentId),
+                      or(
+                          lt(conversationTable.createdAt, lastCursor.createdAt),
+                          and(
+                              eq(conversationTable.createdAt, lastCursor.createdAt),
+                              lt(
+                                  conversationTable.id,
+                                  lastCursor.conversationId,
+                              ),
+                          ),
+                      ),
                   )
                 : and(
-                      eq(conversationTable.authorId, userId),
+                      ownershipFilter,
                       eq(conversationTable.isImporting, false),
+                      isNotNull(conversationTable.currentContentId),
                   );
 
         const conversations: ExtendedConversationPerSlugId =
@@ -337,7 +410,6 @@ export async function getUserProfile({
     try {
         const userTableResponse = await db
             .select({
-                activePostCount: userTable.activeConversationCount,
                 createdAt: userTable.createdAt,
                 username: userTable.username,
                 isSiteModerator: userTable.isSiteModerator,
@@ -349,10 +421,18 @@ export async function getUserProfile({
         if (userTableResponse.length == 0) {
             throw httpErrors.notFound("Failed to locate user profile");
         } else {
-            const organizationNamesResponse = await getOrganizationsByUsername({
+            const organizationMemberships = await getOrganizationMembershipsByUserId({
                 db: db,
-                username: userTableResponse[0].username,
+                userId,
                 baseImageServiceUrl,
+            });
+            const organizationIds = organizationMemberships.map(
+                (membership) => membership.organizationId,
+            );
+            const activePostCount = await getOwnedActiveConversationCount({
+                db,
+                userId,
+                organizationIds,
             });
 
             // Fetch verified event tickets for this user
@@ -373,12 +453,14 @@ export async function getUserProfile({
             );
 
             return {
-                activePostCount: userTableResponse[0].activePostCount,
+                activePostCount,
                 createdAt: userTableResponse[0].createdAt,
                 username: userTableResponse[0].username,
                 isSiteModerator: userTableResponse[0].isSiteModerator,
                 isSiteOrgAdmin: userTableResponse[0].isSiteOrgAdmin,
-                organizationList: organizationNamesResponse.organizationList,
+                organizationList: organizationMemberships.map(
+                    (membership) => membership.organization,
+                ),
                 verifiedEventTickets: verifiedEventTickets,
             };
         }

--- a/services/api/src/shared-backend/schema.ts
+++ b/services/api/src/shared-backend/schema.ts
@@ -20,6 +20,7 @@ import {
     serial,
     foreignKey,
 } from "drizzle-orm/pg-core";
+import { isNotNull } from "drizzle-orm";
 import { sql } from "drizzle-orm/sql";
 // import { MAX_LENGTH_TITLE, MAX_LENGTH_OPINION, MAX_LENGTH_BODY } from "./shared/shared.js"; // unfortunately it breaks drizzle generate... :o TODO: find a way
 // WARNING: when you modify these limits, change this in shared.ts as well
@@ -1388,6 +1389,10 @@ export const conversationTable = pgTable(
             table.isImporting,
             table.createdAt,
         ),
+        // Composite for organization conversation timeline: filters organizationId + isImporting, sorts by createdAt
+        index("conversation_organization_timeline_idx")
+            .on(table.organizationId, table.isImporting, table.createdAt, table.id)
+            .where(isNotNull(table.currentContentId)),
     ],
 );
 

--- a/services/math-updater/src/shared-backend/schema.ts
+++ b/services/math-updater/src/shared-backend/schema.ts
@@ -20,6 +20,7 @@ import {
     serial,
     foreignKey,
 } from "drizzle-orm/pg-core";
+import { isNotNull } from "drizzle-orm";
 import { sql } from "drizzle-orm/sql";
 // import { MAX_LENGTH_TITLE, MAX_LENGTH_OPINION, MAX_LENGTH_BODY } from "./shared/shared.js"; // unfortunately it breaks drizzle generate... :o TODO: find a way
 // WARNING: when you modify these limits, change this in shared.ts as well
@@ -1388,6 +1389,10 @@ export const conversationTable = pgTable(
             table.isImporting,
             table.createdAt,
         ),
+        // Composite for organization conversation timeline: filters organizationId + isImporting, sorts by createdAt
+        index("conversation_organization_timeline_idx")
+            .on(table.organizationId, table.isImporting, table.createdAt, table.id)
+            .where(isNotNull(table.currentContentId)),
     ],
 );
 

--- a/services/shared-backend/src/schema.ts
+++ b/services/shared-backend/src/schema.ts
@@ -19,6 +19,7 @@ import {
     serial,
     foreignKey,
 } from "drizzle-orm/pg-core";
+import { isNotNull } from "drizzle-orm";
 import { sql } from "drizzle-orm/sql";
 // import { MAX_LENGTH_TITLE, MAX_LENGTH_OPINION, MAX_LENGTH_BODY } from "./shared/shared.js"; // unfortunately it breaks drizzle generate... :o TODO: find a way
 // WARNING: when you modify these limits, change this in shared.ts as well
@@ -1387,6 +1388,10 @@ export const conversationTable = pgTable(
             table.isImporting,
             table.createdAt,
         ),
+        // Composite for organization conversation timeline: filters organizationId + isImporting, sorts by createdAt
+        index("conversation_organization_timeline_idx")
+            .on(table.organizationId, table.isImporting, table.createdAt, table.id)
+            .where(isNotNull(table.currentContentId)),
     ],
 );
 


### PR DESCRIPTION
## Summary
- Treat organization-owned conversations as owner-accessible to organization members across edit/delete, surveys, exports, moderation, MaxDiff lifecycle changes, and GitHub sync.
- Include organization-owned active conversations in user profiles with soft-delete filtering and stable created_at/id pagination.
- Add a generated Flyway/Drizzle migration for a plain non-concurrent organization timeline index.

## Tests
- `cd services/api && pnpm typecheck`
- `cd services/api && pnpm lint`
- `cd services/api && pnpm test`