### PR TITLE
fix(agora): redirect after account deletion

### DIFF
--- a/services/agora/src/pages/settings/index.vue
+++ b/services/agora/src/pages/settings/index.vue
@@ -258,6 +258,7 @@ function processDeleteAccount() {
           await deleteUserAccount();
           await updateAuthState({ partialLoginStatus: { isKnown: false } });
           showNotifyMessage(t("accountDeleted"));
+          await router.push({ name: "/welcome/" });
         } catch (e) {
           console.error("Failed to delete user account", e);
           showNotifyMessage(t("accountDeletionFailed"));


### PR DESCRIPTION
## Summary
- Redirect users to the `/welcome` login page after successful account deletion.
- Keep the existing auth cleanup and success notification behavior intact.

## Testing
- `cd services/agora && pnpm lint`