### PR TITLE
feat(agora): add report all statements

### DIFF
--- a/services/agora/src/components/post/report/AnalysisReport.i18n.ts
+++ b/services/agora/src/components/post/report/AnalysisReport.i18n.ts
@@ -5,19 +5,24 @@ export interface AnalysisReportTranslations {
   agreements: string;
   disagreements: string;
   divisive: string;
+  allStatements: string;
   surveyTitle: string;
   surveyOverallLabel: string;
   agreementsLong: string;
   disagreementsLong: string;
   divisiveLong: string;
+  allStatementsLong: string;
   surveySubtitle: string;
   surveyGroupSubtitle: string;
   agreementsSubtitle: string;
   disagreementsSubtitle: string;
   divisiveSubtitle: string;
+  allStatementsSubtitle: string;
+  allStatementsOrderLabel: string;
   noAgreementsMessage: string;
   noDisagreementsMessage: string;
   noDivisiveMessage: string;
+  noAllStatementsMessage: string;
   noSurveyResultsMessage: string;
   suppressed: string;
 }
@@ -31,11 +36,13 @@ export const analysisReportTranslations: Record<
     agreements: "Approved",
     disagreements: "Rejected",
     divisive: "Divisive",
+    allStatements: "All statements",
     surveyTitle: "Survey",
     surveyOverallLabel: "Overall",
     agreementsLong: "Which statements are approved by all groups?",
     disagreementsLong: "Which statements are rejected by all groups?",
     divisiveLong: "What divides people across groups?",
+    allStatementsLong: "All statements",
     surveySubtitle:
       "See how each survey question is answered overall or within each opinion group.",
     surveyGroupSubtitle: "Only responses from this opinion group are included here.",
@@ -45,9 +52,12 @@ export const analysisReportTranslations: Record<
       "Cross-group consensus, not simple majority. Only the most statistically significant are shown first.",
     divisiveSubtitle:
       "Statements that split opinion groups against each other. Only the most statistically significant are shown first.",
+    allStatementsSubtitle: "All statements included in the analysis, ordered by the selected report setting.",
+    allStatementsOrderLabel: "Order by",
     noAgreementsMessage: "No consensus has emerged yet.",
     noDisagreementsMessage: "No consensus has emerged yet.",
     noDivisiveMessage: "No significant divisive statements found yet.",
+    noAllStatementsMessage: "No statements are available yet.",
     noSurveyResultsMessage: "No survey results are available yet.",
     suppressed: "Suppressed",
   },
@@ -56,11 +66,13 @@ export const analysisReportTranslations: Record<
     agreements: "معتمدة",
     disagreements: "مرفوضة",
     divisive: "مثير للجدل",
+    allStatements: "كل المقترحات",
     surveyTitle: "الاستبيان",
     surveyOverallLabel: "إجمالي",
     agreementsLong: "ما المقترحات المعتمدة من جميع المجموعات؟",
     disagreementsLong: "ما المقترحات المرفوضة من جميع المجموعات؟",
     divisiveLong: "ما الذي يقسم المشاركين عبر مجموعات الرأي؟",
+    allStatementsLong: "كل المقترحات",
     surveySubtitle:
       "اطّلع على إجابات كل سؤال في الاستبيان على مستوى الجميع أو داخل كل مجموعة رأي.",
     surveyGroupSubtitle: "تُعرض هنا فقط إجابات المشاركين ضمن مجموعة الرأي هذه.",
@@ -70,9 +82,12 @@ export const analysisReportTranslations: Record<
       "إجماع بين المجموعات وليس أغلبية بسيطة. تُعرض الأكثر دلالة إحصائياً أولاً.",
     divisiveSubtitle:
       "مقترحات تفرّق مجموعات الرأي. تُعرض الأكثر دلالة إحصائياً أولاً.",
+    allStatementsSubtitle: "كل المقترحات المدرجة في التحليل، مرتبة حسب إعداد التقرير المحدد.",
+    allStatementsOrderLabel: "ترتيب حسب",
     noAgreementsMessage: "لم يظهر أي إجماع بعد.",
     noDisagreementsMessage: "لم يظهر أي إجماع بعد.",
     noDivisiveMessage: "لم يتم العثور على مقترحات مثيرة للجدل ذات دلالة بعد.",
+    noAllStatementsMessage: "لا توجد مقترحات متاحة بعد.",
     noSurveyResultsMessage: "لا توجد نتائج استبيان متاحة بعد.",
     suppressed: "محجوب",
   },
@@ -81,12 +96,14 @@ export const analysisReportTranslations: Record<
     agreements: "Aprobados",
     disagreements: "Rechazados",
     divisive: "Divisivo",
+    allStatements: "Todas las afirmaciones",
     surveyTitle: "Encuesta",
     surveyOverallLabel: "General",
     agreementsLong: "¿Qué afirmaciones son aprobadas por todos los grupos?",
     disagreementsLong: "¿Qué afirmaciones son rechazadas por todos los grupos?",
     divisiveLong:
       "¿Qué divide a los participantes entre los grupos de opinión?",
+    allStatementsLong: "Todas las afirmaciones",
     surveySubtitle:
       "Consulta cómo se responde cada pregunta de la encuesta en general o dentro de cada grupo de opinión.",
     surveyGroupSubtitle: "Aquí solo se incluyen las respuestas de este grupo de opinión.",
@@ -96,10 +113,14 @@ export const analysisReportTranslations: Record<
       "Consenso entre grupos, no una mayoría simple. Solo se muestran las más significativas estadísticamente primero.",
     divisiveSubtitle:
       "Afirmaciones que dividen a los grupos de opinión entre sí. Solo se muestran las más significativas estadísticamente primero.",
+    allStatementsSubtitle:
+      "Todas las afirmaciones incluidas en el análisis, ordenadas según la configuración seleccionada del informe.",
+    allStatementsOrderLabel: "Ordenar por",
     noAgreementsMessage: "Aún no ha surgido ningún consenso.",
     noDisagreementsMessage: "Aún no ha surgido ningún consenso.",
     noDivisiveMessage:
       "Aún no se encontraron proposiciones divisivas significativas.",
+    noAllStatementsMessage: "Todavía no hay afirmaciones disponibles.",
     noSurveyResultsMessage:
       "Todavía no hay resultados de la encuesta disponibles.",
     suppressed: "Suprimido",
@@ -109,11 +130,13 @@ export const analysisReportTranslations: Record<
     agreements: "تأیید شده",
     disagreements: "رد شده",
     divisive: "اختلاف‌برانگیز",
+    allStatements: "همه گزاره‌ها",
     surveyTitle: "نظرسنجی",
     surveyOverallLabel: "کلی",
     agreementsLong: "کدام گزاره‌ها توسط همه گروه‌ها تأیید شده‌اند؟",
     disagreementsLong: "کدام گزاره‌ها توسط همه گروه‌ها رد شده‌اند؟",
     divisiveLong: "چه چیزی افراد را در بین گروه‌ها تفرقه می‌اندازد؟",
+    allStatementsLong: "همه گزاره‌ها",
     surveySubtitle:
       "ببینید هر پرسش نظرسنجی به صورت کلی یا درون هر گروه نظر چگونه پاسخ داده شده است.",
     surveyGroupSubtitle: "فقط پاسخ‌های این گروه نظر در اینجا نشان داده می‌شود.",
@@ -123,9 +146,12 @@ export const analysisReportTranslations: Record<
       "اجماع بین‌گروهی، نه اکثریت ساده. ابتدا فقط مهم‌ترین موارد از نظر آماری نمایش داده می‌شوند.",
     divisiveSubtitle:
       "گزاره‌هایی که گروه‌های نظر را در برابر یکدیگر قرار می‌دهند. ابتدا فقط مهم‌ترین موارد از نظر آماری نمایش داده می‌شوند.",
+    allStatementsSubtitle: "همه گزاره‌های موجود در تحلیل، مرتب‌شده بر اساس تنظیم انتخاب‌شده گزارش.",
+    allStatementsOrderLabel: "مرتب‌سازی بر اساس",
     noAgreementsMessage: "هنوز اجماعی شکل نگرفته است.",
     noDisagreementsMessage: "هنوز اجماعی شکل نگرفته است.",
     noDivisiveMessage: "هنوز گزاره اختلاف‌برانگیز مهمی یافت نشده است.",
+    noAllStatementsMessage: "هنوز گزاره‌ای در دسترس نیست.",
     noSurveyResultsMessage: "هنوز نتیجه‌ای از نظرسنجی در دسترس نیست.",
     suppressed: "پنهان‌شده",
   },
@@ -134,6 +160,7 @@ export const analysisReportTranslations: Record<
     agreements: "Approuvés",
     disagreements: "Rejetés",
     divisive: "Controversé",
+    allStatements: "Toutes les propositions",
     surveyTitle: "Questionnaire",
     surveyOverallLabel: "Global",
     agreementsLong:
@@ -142,6 +169,7 @@ export const analysisReportTranslations: Record<
       "Quelles propositions sont rejetées par tous les groupes ?",
     divisiveLong:
       "Qu'est-ce qui divise les participants entre les groupes d'opinion ?",
+    allStatementsLong: "Toutes les propositions",
     surveySubtitle:
       "Voyez comment chaque question du questionnaire est répondue globalement ou dans chaque groupe d'opinion.",
     surveyGroupSubtitle: "Seules les réponses de ce groupe d'opinion sont incluses ici.",
@@ -151,10 +179,14 @@ export const analysisReportTranslations: Record<
       "Consensus entre groupes, pas une simple majorité. Seules les plus significatives statistiquement sont affichées en premier.",
     divisiveSubtitle:
       "Propositions qui divisent les groupes d'opinion entre eux. Seules les plus significatives statistiquement sont affichées en premier.",
+    allStatementsSubtitle:
+      "Toutes les propositions incluses dans l'analyse, triées selon le réglage sélectionné du rapport.",
+    allStatementsOrderLabel: "Trier par",
     noAgreementsMessage: "Aucun consensus n'a encore émergé.",
     noDisagreementsMessage: "Aucun consensus n'a encore émergé.",
     noDivisiveMessage:
       "Aucune proposition controversée significative trouvée pour le moment.",
+    noAllStatementsMessage: "Aucune proposition n'est encore disponible.",
     noSurveyResultsMessage:
       "Aucun résultat de questionnaire n'est encore disponible.",
     suppressed: "Masqué",
@@ -164,19 +196,24 @@ export const analysisReportTranslations: Record<
     agreements: "通过",
     disagreements: "否决",
     divisive: "分歧",
+    allStatements: "所有观点",
     surveyTitle: "问卷",
     surveyOverallLabel: "整体",
     agreementsLong: "哪些观点被所有群组认可？",
     disagreementsLong: "哪些观点被所有群组否决？",
     divisiveLong: "什么使参与者在各意见群组之间产生分歧？",
+    allStatementsLong: "所有观点",
     surveySubtitle: "查看每个问卷问题在整体人群或各意见群组内的回答分布。",
     surveyGroupSubtitle: "此处仅包含该意见群组的回答结果。",
     agreementsSubtitle: "跨群组共识，非简单多数。仅先显示统计上最显著的结果。",
     disagreementsSubtitle: "跨群组共识，非简单多数。仅先显示统计上最显著的结果。",
     divisiveSubtitle: "使意见群组相互对立的观点。仅先显示统计上最显著的结果。",
+    allStatementsSubtitle: "分析中包含的所有观点，按所选报告设置排序。",
+    allStatementsOrderLabel: "排序方式",
     noAgreementsMessage: "尚未形成共识。",
     noDisagreementsMessage: "尚未形成共识。",
     noDivisiveMessage: "尚未找到显著的分歧观点。",
+    noAllStatementsMessage: "暂时没有可用的观点。",
     noSurveyResultsMessage: "暂时没有可用的问卷结果。",
     suppressed: "已隐藏",
   },
@@ -185,19 +222,24 @@ export const analysisReportTranslations: Record<
     agreements: "通過",
     disagreements: "否決",
     divisive: "分歧",
+    allStatements: "所有觀點",
     surveyTitle: "問卷",
     surveyOverallLabel: "整體",
     agreementsLong: "哪些觀點被所有群組認可？",
     disagreementsLong: "哪些觀點被所有群組否決？",
     divisiveLong: "什麼使參與者在各意見群組之間產生分歧？",
+    allStatementsLong: "所有觀點",
     surveySubtitle: "查看每個問卷問題在整體或各意見群組內的回答分布。",
     surveyGroupSubtitle: "此處僅包含此意見群組的回答結果。",
     agreementsSubtitle: "跨群組共識，非簡單多數。僅先顯示統計上最顯著的結果。",
     disagreementsSubtitle: "跨群組共識，非簡單多數。僅先顯示統計上最顯著的結果。",
     divisiveSubtitle: "使意見群組相互對立的觀點。僅先顯示統計上最顯著的結果。",
+    allStatementsSubtitle: "分析中包含的所有觀點，按所選報告設定排序。",
+    allStatementsOrderLabel: "排序方式",
     noAgreementsMessage: "尚未形成共識。",
     noDisagreementsMessage: "尚未形成共識。",
     noDivisiveMessage: "尚未找到顯著的分歧觀點。",
+    noAllStatementsMessage: "目前沒有可用的觀點。",
     noSurveyResultsMessage: "目前沒有可用的問卷結果。",
     suppressed: "已隱藏",
   },
@@ -206,11 +248,13 @@ export const analysisReportTranslations: Record<
     agreements: "אושרו",
     disagreements: "נדחו",
     divisive: "מפלג",
+    allStatements: "כל ההצהרות",
     surveyTitle: "סקר",
     surveyOverallLabel: "כללי",
     agreementsLong: "אילו הצהרות אושרו על ידי כל הקבוצות?",
     disagreementsLong: "אילו הצהרות נדחו על ידי כל הקבוצות?",
     divisiveLong: "מה מפלג את המשתתפים בין הקבוצות?",
+    allStatementsLong: "כל ההצהרות",
     surveySubtitle:
       "ראו כיצד נענית כל שאלה בסקר בכלל המשתתפים או בתוך כל קבוצת דעה.",
     surveyGroupSubtitle: "כאן מוצגות רק התשובות של קבוצת הדעה הזו.",
@@ -220,9 +264,12 @@ export const analysisReportTranslations: Record<
       "קונצנזוס בין-קבוצתי, לא רוב פשוט. רק המובהקות ביותר מבחינה סטטיסטית מוצגות תחילה.",
     divisiveSubtitle:
       "הצהרות שמפלגות בין קבוצות הדעה. רק המובהקות ביותר מבחינה סטטיסטית מוצגות תחילה.",
+    allStatementsSubtitle: "כל ההצהרות שנכללות בניתוח, מסודרות לפי הגדרת הדוח שנבחרה.",
+    allStatementsOrderLabel: "סידור לפי",
     noAgreementsMessage: "טרם התגבש קונצנזוס.",
     noDisagreementsMessage: "טרם התגבש קונצנזוס.",
     noDivisiveMessage: "טרם נמצאו הצהרות מפלגות מובהקות.",
+    noAllStatementsMessage: "עדיין אין הצהרות זמינות.",
     noSurveyResultsMessage: "עדיין אין תוצאות סקר זמינות.",
     suppressed: "מוסתר",
   },
@@ -231,11 +278,13 @@ export const analysisReportTranslations: Record<
     agreements: "承認",
     disagreements: "否決",
     divisive: "分断",
+    allStatements: "すべての意見",
     surveyTitle: "アンケート",
     surveyOverallLabel: "全体",
     agreementsLong: "すべてのグループに承認された意見は？",
     disagreementsLong: "すべてのグループに否決された意見は？",
     divisiveLong: "意見グループ間で参加者を分断しているものは何ですか？",
+    allStatementsLong: "すべての意見",
     surveySubtitle:
       "各アンケート設問への回答が全体または各意見グループ内でどう分かれているかを確認できます。",
     surveyGroupSubtitle: "ここにはこの意見グループの回答のみが表示されます。",
@@ -245,9 +294,12 @@ export const analysisReportTranslations: Record<
       "グループ間の合意であり、単純多数決ではありません。統計的に最も有意なものが最初に表示されます。",
     divisiveSubtitle:
       "意見グループを対立させる意見。統計的に最も有意なものが最初に表示されます。",
+    allStatementsSubtitle: "分析に含まれるすべての意見を、選択したレポート設定で並べます。",
+    allStatementsOrderLabel: "並び順",
     noAgreementsMessage: "まだ合意は形成されていません。",
     noDisagreementsMessage: "まだ合意は形成されていません。",
     noDivisiveMessage: "有意な分断的意見はまだ見つかりません。",
+    noAllStatementsMessage: "利用可能な意見はまだありません。",
     noSurveyResultsMessage: "利用可能なアンケート結果はまだありません。",
     suppressed: "非表示",
   },
@@ -256,11 +308,13 @@ export const analysisReportTranslations: Record<
     agreements: "Жактырылган",
     disagreements: "Четке кагылган",
     divisive: "Талаштуу",
+    allStatements: "Бардык пикирлер",
     surveyTitle: "Сурамжылоо",
     surveyOverallLabel: "Жалпы",
     agreementsLong: "Кайсы пикирлер бардык топтор тарабынан жактырылган?",
     disagreementsLong: "Кайсы пикирлер бардык топтор тарабынан четке кагылган?",
     divisiveLong: "Топтор аралык катышуучуларды эмне бөлөт?",
+    allStatementsLong: "Бардык пикирлер",
     surveySubtitle:
       "Ар бир сурамжылоо суроосуна жооптор жалпы же ар бир пикир тобунун ичинде кандай бөлүнгөнүн көрүңүз.",
     surveyGroupSubtitle: "Бул жерде ушул пикир тобунун жооптору гана көрсөтүлөт.",
@@ -270,9 +324,12 @@ export const analysisReportTranslations: Record<
       "Топтор аралык консенсус, жөнөкөй көпчүлүк эмес. Алгач статистикалык жактан эң маанилүүлөрү көрсөтүлөт.",
     divisiveSubtitle:
       "Пикир топторун бири-бирине каршы коюучу пикирлер. Алгач статистикалык жактан эң маанилүүлөрү көрсөтүлөт.",
+    allStatementsSubtitle: "Талдоого кирген бардык пикирлер тандалган отчет жөндөөсү боюнча иреттелген.",
+    allStatementsOrderLabel: "Иреттөө",
     noAgreementsMessage: "Азырынча консенсус түзүлө элек.",
     noDisagreementsMessage: "Азырынча консенсус түзүлө элек.",
     noDivisiveMessage: "Азырынча маанилүү талаштуу пикирлер табылган жок.",
+    noAllStatementsMessage: "Азырынча жеткиликтүү пикирлер жок.",
     noSurveyResultsMessage:
       "Азырынча сурамжылоонун жыйынтыктары жеткиликтүү эмес.",
     suppressed: "Жашырылган",
@@ -282,11 +339,13 @@ export const analysisReportTranslations: Record<
     agreements: "Одобрено",
     disagreements: "Отклонено",
     divisive: "Спорные",
+    allStatements: "Все высказывания",
     surveyTitle: "Опрос",
     surveyOverallLabel: "В целом",
     agreementsLong: "Какие высказывания одобрены всеми группами?",
     disagreementsLong: "Какие высказывания отклонены всеми группами?",
     divisiveLong: "Что разделяет участников между группами?",
+    allStatementsLong: "Все высказывания",
     surveySubtitle:
       "Смотрите, как отвечают на каждый вопрос опроса в целом или внутри каждой группы мнений.",
     surveyGroupSubtitle: "Здесь показаны только ответы этой группы мнений.",
@@ -296,9 +355,13 @@ export const analysisReportTranslations: Record<
       "Межгрупповой консенсус, а не простое большинство. Сначала показаны наиболее статистически значимые.",
     divisiveSubtitle:
       "Высказывания, по которым группы мнений расходятся. Сначала показаны наиболее статистически значимые.",
+    allStatementsSubtitle:
+      "Все высказывания, включенные в анализ, отсортированы по выбранной настройке отчёта.",
+    allStatementsOrderLabel: "Сортировать по",
     noAgreementsMessage: "Консенсус пока не сформирован.",
     noDisagreementsMessage: "Консенсус пока не сформирован.",
     noDivisiveMessage: "Значимых спорных высказываний пока не найдено.",
+    noAllStatementsMessage: "Высказывания пока недоступны.",
     noSurveyResultsMessage: "Результаты опроса пока недоступны.",
     suppressed: "Скрыто",
   },

--- a/services/agora/src/components/post/report/AnalysisReport.vue
+++ b/services/agora/src/components/post/report/AnalysisReport.vue
@@ -494,6 +494,102 @@
       />
     </div>
 
+    <div
+      v-if="allChunks.length === 0"
+      ref="allEmptyRef"
+      class="report-section-block detail-section"
+    >
+      <div class="detail-context capture-only">
+        <span class="detail-branding">Agora Citizen Network</span>
+        <span class="detail-separator">·</span>
+        <span class="detail-title">{{ conversationTitle }}</span>
+        <span class="detail-separator">·</span>
+        <span class="detail-section-name">{{ t("allStatements") }}</span>
+      </div>
+      <ReportSectionHeader
+        :title="t('allStatementsLong')"
+        :subtitle="t('allStatementsSubtitle')"
+      >
+        <template #action>
+          <ZKSelect
+            :model-value="allStatementsOrderSelectValue"
+            class="all-statements-order-select"
+            :label="t('allStatementsOrderLabel')"
+            :options="allStatementsOrderOptions"
+            @update:model-value="handleAllStatementsOrderUpdate"
+          />
+        </template>
+      </ReportSectionHeader>
+      <ReportOpinionList
+        :title="t('allStatementsLong')"
+        title-color="#333238"
+        :items="[]"
+        :clusters="clusters"
+        :total-participants="participantCount"
+        :hide-title="true"
+        :empty-message="t('noAllStatementsMessage')"
+      />
+      <ReportFooter
+        :conversation-slug-id="conversationSlugId"
+        class="capture-footer"
+      />
+    </div>
+    <div
+      v-for="(chunk, chunkIdx) in allChunks"
+      :key="`all-${chunkIdx}`"
+      :ref="(el) => setAllRef({ el, index: chunkIdx })"
+      class="report-section-block detail-section"
+    >
+      <div class="detail-context capture-only">
+        <span class="detail-branding">Agora Citizen Network</span>
+        <span class="detail-separator">·</span>
+        <span class="detail-title">{{ conversationTitle }}</span>
+        <span class="detail-separator">·</span>
+        <span class="detail-section-name">{{
+          getPagedSectionLabel({
+            baseLabel: t("allStatements"),
+            pageIndex: chunkIdx,
+            pageCount: allChunks.length,
+          })
+        }}</span>
+      </div>
+      <ReportSectionHeader
+        v-if="chunkIdx === 0"
+        :title="t('allStatementsLong')"
+        :subtitle="t('allStatementsSubtitle')"
+      >
+        <template #action>
+          <ZKSelect
+            :model-value="allStatementsOrderSelectValue"
+            class="all-statements-order-select"
+            :label="t('allStatementsOrderLabel')"
+            :options="allStatementsOrderOptions"
+            @update:model-value="handleAllStatementsOrderUpdate"
+          />
+        </template>
+      </ReportSectionHeader>
+      <ReportOpinionList
+        :title="t('allStatementsLong')"
+        title-color="#333238"
+        :items="chunk"
+        :clusters="clusters"
+        :total-participants="participantCount"
+        :start-rank="chunkIdx * effectiveItemsPerPage"
+        :hide-title="true"
+      >
+        <template v-if="clusterCount >= 2" #after-subtitle>
+          <VoteLegend
+            :items="reportLegendItems"
+            style="margin-bottom: 0.75rem"
+          />
+        </template>
+      </ReportOpinionList>
+      <ReportFooter
+        :conversation-slug-id="conversationSlugId"
+        class="capture-footer"
+      />
+    </div>
+
     <!-- Footer -->
     <div class="report-section-block">
       <div ref="footerRef">
@@ -512,6 +608,7 @@ import {
   voteLegendTranslations,
 } from "src/components/ui/VoteLegend.i18n";
 import VoteLegend from "src/components/ui/VoteLegend.vue";
+import ZKSelect from "src/components/ui-library/ZKSelect.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import type {
   AnalysisOpinionItem,
@@ -521,7 +618,10 @@ import type {
 } from "src/shared/types/zod";
 import { formatAmount, formatPercentage } from "src/utils/common";
 import { formatClusterLabel } from "src/utils/component/opinion";
-import { REPORT_ITEMS_PER_CAPTURE_PAGE } from "src/utils/component/report/reportData";
+import {
+  REPORT_ITEMS_PER_CAPTURE_PAGE,
+  type ReportAllStatementsOrder,
+} from "src/utils/component/report/reportData";
 import {
   groupSurveyRowsByQuestion,
   type SurveyResultsDisplayMode,
@@ -555,6 +655,11 @@ const props = defineProps<{
   agreementItems: AnalysisOpinionItem[];
   disagreementItems: AnalysisOpinionItem[];
   divisiveItems: AnalysisOpinionItem[];
+  allItems: AnalysisOpinionItem[];
+  allStatementsOrderOptions: ReadonlyArray<{
+    label: string;
+    value: ReportAllStatementsOrder;
+  }>;
   hasSurvey: boolean;
   surveyRows: SurveyAggregateRow[];
   showSurveyToggle?: boolean;
@@ -567,6 +672,37 @@ const surveyDisplayMode = defineModel<SurveyResultsDisplayMode>(
     default: "suppressed",
   }
 );
+
+const allStatementsOrder = defineModel<ReportAllStatementsOrder>(
+  "allStatementsOrder",
+  { required: true }
+);
+
+function isReportAllStatementsOrder(
+  value: string | string[] | null
+): value is ReportAllStatementsOrder {
+  return (
+    value === "newest" ||
+    value === "agreement" ||
+    value === "disagreement" ||
+    value === "divisive"
+  );
+}
+
+const allStatementsOrderSelectValue = computed<string | null>({
+  get: () => allStatementsOrder.value,
+  set: (value) => {
+    if (isReportAllStatementsOrder(value)) {
+      allStatementsOrder.value = value;
+    }
+  },
+});
+
+function handleAllStatementsOrderUpdate(value: string | string[] | null): void {
+  if (isReportAllStatementsOrder(value)) {
+    allStatementsOrder.value = value;
+  }
+}
 
 const effectiveItemsPerPage = computed(
   () => props.itemsPerPage ?? REPORT_ITEMS_PER_CAPTURE_PAGE
@@ -610,6 +746,9 @@ const disagreementChunks = computed(() =>
 );
 const divisiveChunks = computed(() =>
   chunkArray(props.divisiveItems, effectiveItemsPerPage.value)
+);
+const allChunks = computed(() =>
+  chunkArray(props.allItems, effectiveItemsPerPage.value)
 );
 
 const surveyOverallChunks = computed(() => {
@@ -699,6 +838,7 @@ const footerRef = ref<HTMLElement | null>(null);
 const agreementEmptyRef = ref<HTMLElement | null>(null);
 const disagreementEmptyRef = ref<HTMLElement | null>(null);
 const divisiveEmptyRef = ref<HTMLElement | null>(null);
+const allEmptyRef = ref<HTMLElement | null>(null);
 const surveyEmptyRef = ref<HTMLElement | null>(null);
 
 // Dynamic arrays of refs
@@ -706,6 +846,7 @@ const groupsAndRepresentativeRefs = ref<HTMLElement[]>([]);
 const agreementRefs = ref<HTMLElement[]>([]);
 const disagreementRefs = ref<HTMLElement[]>([]);
 const divisiveRefs = ref<HTMLElement[]>([]);
+const allRefs = ref<HTMLElement[]>([]);
 const surveyRefs = ref<HTMLElement[]>([]);
 
 function createRefSetter(target: Ref<HTMLElement[]>) {
@@ -723,6 +864,7 @@ const setGroupRepRef = createRefSetter(groupsAndRepresentativeRefs);
 const setAgreementRef = createRefSetter(agreementRefs);
 const setDisagreementRef = createRefSetter(disagreementRefs);
 const setDivisiveRef = createRefSetter(divisiveRefs);
+const setAllRef = createRefSetter(allRefs);
 const setSurveyRef = createRefSetter(surveyRefs);
 
 function getPagedSectionLabel({
@@ -748,10 +890,12 @@ defineExpose({
   agreementEmptyRef,
   disagreementEmptyRef,
   divisiveEmptyRef,
+  allEmptyRef,
   surveyEmptyRef,
   agreementRefs,
   disagreementRefs,
   divisiveRefs,
+  allRefs,
   surveyRefs,
   footerRef,
 });
@@ -789,6 +933,10 @@ defineExpose({
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.all-statements-order-select {
+  min-width: 220px;
 }
 
 .survey-cluster-viz-wrapper {

--- a/services/agora/src/components/post/report/ReportVoteCell.vue
+++ b/services/agora/src/components/post/report/ReportVoteCell.vue
@@ -35,9 +35,16 @@ const props = defineProps<{
   numUsers: number;
 }>();
 
-const agreePct = computed(() => calculatePercentage(props.numAgrees, props.numUsers));
-const passPct = computed(() => calculatePercentage(props.numPasses, props.numUsers));
-const disagreePct = computed(() => calculatePercentage(props.numDisagrees, props.numUsers));
+const denominator = computed(() =>
+  Math.max(
+    props.numUsers,
+    props.numAgrees + props.numPasses + props.numDisagrees
+  )
+);
+
+const agreePct = computed(() => calculatePercentage(props.numAgrees, denominator.value));
+const passPct = computed(() => calculatePercentage(props.numPasses, denominator.value));
+const disagreePct = computed(() => calculatePercentage(props.numDisagrees, denominator.value));
 
 const agreeStr = computed(() => formatPercentage(agreePct.value));
 const passStr = computed(() => formatPercentage(passPct.value));

--- a/services/agora/src/pages/conversation/[conversationSlugId]/report.i18n.ts
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/report.i18n.ts
@@ -10,6 +10,10 @@ export interface ReportPageTranslations {
   narrowScreenTitle: string;
   narrowScreenMessage: string;
   goBack: string;
+  allStatementsOrderNewest: string;
+  allStatementsOrderAgreement: string;
+  allStatementsOrderDisagreement: string;
+  allStatementsOrderDivisive: string;
 }
 
 export const reportPageTranslations: Record<
@@ -27,6 +31,10 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "This report is designed for larger screens. Please open it on a desktop or tablet.",
     goBack: "Go back",
+    allStatementsOrderNewest: "Newest first",
+    allStatementsOrderAgreement: "Most approved first",
+    allStatementsOrderDisagreement: "Most rejected first",
+    allStatementsOrderDivisive: "Most divisive first",
   },
   ar: {
     pageTitle: "تقرير التحليل",
@@ -39,6 +47,10 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "هذا التقرير مصمم للشاشات الكبيرة. يرجى فتحه على جهاز مكتبي أو جهاز لوحي.",
     goBack: "العودة",
+    allStatementsOrderNewest: "الأحدث أولاً",
+    allStatementsOrderAgreement: "الأكثر اعتماداً أولاً",
+    allStatementsOrderDisagreement: "الأكثر رفضاً أولاً",
+    allStatementsOrderDivisive: "الأكثر إثارة للجدل أولاً",
   },
   es: {
     pageTitle: "Informe de análisis",
@@ -51,6 +63,10 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "Este informe está diseñado para pantallas más grandes. Ábrelo en un ordenador o tableta.",
     goBack: "Volver",
+    allStatementsOrderNewest: "Más recientes primero",
+    allStatementsOrderAgreement: "Más aprobadas primero",
+    allStatementsOrderDisagreement: "Más rechazadas primero",
+    allStatementsOrderDivisive: "Más divisivas primero",
   },
   fa: {
     pageTitle: "گزارش تحلیل",
@@ -63,6 +79,10 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "این گزارش برای صفحه‌های بزرگ‌تر طراحی شده است. لطفاً آن را در رایانه رومیزی یا تبلت باز کنید.",
     goBack: "بازگشت",
+    allStatementsOrderNewest: "جدیدترین‌ها اول",
+    allStatementsOrderAgreement: "تأییدشده‌ترین‌ها اول",
+    allStatementsOrderDisagreement: "ردشده‌ترین‌ها اول",
+    allStatementsOrderDivisive: "اختلاف‌برانگیزترین‌ها اول",
   },
   he: {
     pageTitle: "דוח ניתוח",
@@ -75,6 +95,10 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "דוח זה מיועד למסכים גדולים יותר. אנא פתחו אותו במחשב שולחני או טאבלט.",
     goBack: "חזרה",
+    allStatementsOrderNewest: "החדשות תחילה",
+    allStatementsOrderAgreement: "המאושרות ביותר תחילה",
+    allStatementsOrderDisagreement: "הנדחות ביותר תחילה",
+    allStatementsOrderDivisive: "המפלגות ביותר תחילה",
   },
   fr: {
     pageTitle: "Rapport d'analyse",
@@ -87,6 +111,10 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "Ce rapport est conçu pour les grands écrans. Veuillez l'ouvrir sur un ordinateur ou une tablette.",
     goBack: "Retour",
+    allStatementsOrderNewest: "Plus récentes d'abord",
+    allStatementsOrderAgreement: "Plus approuvées d'abord",
+    allStatementsOrderDisagreement: "Plus rejetées d'abord",
+    allStatementsOrderDivisive: "Plus controversées d'abord",
   },
   "zh-Hans": {
     pageTitle: "分析报告",
@@ -98,6 +126,10 @@ export const reportPageTranslations: Record<
     narrowScreenTitle: "需要更大的屏幕",
     narrowScreenMessage: "此报告适用于大屏幕。请在桌面设备或平板电脑上打开。",
     goBack: "返回",
+    allStatementsOrderNewest: "最新优先",
+    allStatementsOrderAgreement: "最受认可优先",
+    allStatementsOrderDisagreement: "最受否决优先",
+    allStatementsOrderDivisive: "最具分歧优先",
   },
   "zh-Hant": {
     pageTitle: "分析報告",
@@ -109,6 +141,10 @@ export const reportPageTranslations: Record<
     narrowScreenTitle: "需要更大的螢幕",
     narrowScreenMessage: "此報告適用於大螢幕。請在桌面裝置或平板電腦上開啟。",
     goBack: "返回",
+    allStatementsOrderNewest: "最新優先",
+    allStatementsOrderAgreement: "最受認可優先",
+    allStatementsOrderDisagreement: "最受否決優先",
+    allStatementsOrderDivisive: "最具分歧優先",
   },
   ja: {
     pageTitle: "分析レポート",
@@ -121,6 +157,10 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "このレポートは大きな画面用に設計されています。デスクトップまたはタブレットで開いてください。",
     goBack: "戻る",
+    allStatementsOrderNewest: "新しい順",
+    allStatementsOrderAgreement: "承認度が高い順",
+    allStatementsOrderDisagreement: "否決度が高い順",
+    allStatementsOrderDivisive: "分断度が高い順",
   },
   ky: {
     pageTitle: "Анализ отчету",
@@ -133,6 +173,10 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "Бул отчет чоң экрандар үчүн иштелип чыккан. Компьютерде же планшетте ачыңыз.",
     goBack: "Артка",
+    allStatementsOrderNewest: "Эң жаңылары биринчи",
+    allStatementsOrderAgreement: "Эң жактырылгандары биринчи",
+    allStatementsOrderDisagreement: "Эң четке кагылгандары биринчи",
+    allStatementsOrderDivisive: "Эң талаштуулары биринчи",
   },
   ru: {
     pageTitle: "Аналитический отчёт",
@@ -145,5 +189,9 @@ export const reportPageTranslations: Record<
     narrowScreenMessage:
       "Этот отчёт предназначен для больших экранов. Пожалуйста, откройте его на компьютере или планшете.",
     goBack: "Назад",
+    allStatementsOrderNewest: "Сначала новые",
+    allStatementsOrderAgreement: "Сначала самые одобренные",
+    allStatementsOrderDisagreement: "Сначала самые отклонённые",
+    allStatementsOrderDivisive: "Сначала самые спорные",
   },
 };

--- a/services/agora/src/pages/conversation/[conversationSlugId]/report.vue
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/report.vue
@@ -70,6 +70,7 @@
                 "
                 ref="analysisReportRef"
                 v-model:survey-display-mode="surveyDisplayMode"
+                v-model:all-statements-order="allStatementsOrder"
                 :items-per-page="itemsPerPage"
                 :conversation-slug-id="conversationSlugId"
                 :conversation-title="conversationQuery.data.value.payload.title"
@@ -97,6 +98,8 @@
                 :agreement-items="agreementItems"
                 :disagreement-items="disagreementItems"
                 :divisive-items="divisiveItems"
+                :all-items="allItems"
+                :all-statements-order-options="allStatementsOrderOptions"
                 :has-survey="surveyResultsQuery.data.value.hasSurvey"
                 :survey-rows="reportSurveyRows"
                 :show-survey-toggle="showSurveyToggle"
@@ -126,9 +129,11 @@ import { useAnalysisQuery } from "src/utils/api/comment/useCommentQueries";
 import { useConversationQuery } from "src/utils/api/post/useConversationQuery";
 import { useSurveyResultsAggregatedQuery } from "src/utils/api/survey/useSurveyQueries";
 import {
+  getReportAllOpinions,
   getReportOpinions,
   REPORT_ITEMS_PER_CAPTURE_PAGE,
   REPORT_ITEMS_PER_PDF_PAGE,
+  type ReportAllStatementsOrder,
 } from "src/utils/component/report/reportData";
 import { useGoBackButtonHandler } from "src/utils/nav/goBackButton";
 import { getSingleRouteParam } from "src/utils/router/params";
@@ -186,6 +191,14 @@ const surveyResultsQuery = useSurveyResultsAggregatedQuery({
 });
 
 const surveyDisplayMode = ref<SurveyResultsDisplayMode>("suppressed");
+const allStatementsOrder = ref<ReportAllStatementsOrder>("newest");
+
+const allStatementsOrderOptions = computed(() => [
+  { label: t("allStatementsOrderNewest"), value: "newest" as const },
+  { label: t("allStatementsOrderAgreement"), value: "agreement" as const },
+  { label: t("allStatementsOrderDisagreement"), value: "disagreement" as const },
+  { label: t("allStatementsOrderDivisive"), value: "divisive" as const },
+]);
 
 const polisClusters = computed<Partial<PolisClusters>>(
   () => analysisQuery.data.value?.polisClusters ?? {}
@@ -245,6 +258,17 @@ const divisiveItems = computed(() => {
   });
 });
 
+const allItems = computed(() =>
+  getReportAllOpinions({
+    order: allStatementsOrder.value,
+    items: [
+      ...(analysisQuery.data.value?.consensusAgree ?? []),
+      ...(analysisQuery.data.value?.consensusDisagree ?? []),
+      ...(analysisQuery.data.value?.controversial ?? []),
+    ],
+  })
+);
+
 const hasData = computed(
   () =>
     conversationQuery.data.value !== undefined &&
@@ -264,9 +288,11 @@ interface AnalysisReportExposed {
   agreementEmptyRef: HTMLElement | null;
   disagreementEmptyRef: HTMLElement | null;
   divisiveEmptyRef: HTMLElement | null;
+  allEmptyRef: HTMLElement | null;
   agreementRefs: HTMLElement[];
   disagreementRefs: HTMLElement[];
   divisiveRefs: HTMLElement[];
+  allRefs: HTMLElement[];
   surveyEmptyRef: HTMLElement | null;
   surveyRefs: HTMLElement[];
   footerRef: HTMLElement | null;
@@ -348,6 +374,15 @@ function buildCaptures(): Array<{ element: HTMLElement; name: string }> {
     const el = report.surveyRefs[j];
     if (el?.isConnected) {
       captures.push({ element: el, name: `survey-${j}` });
+    }
+  }
+  if (report.allEmptyRef?.isConnected) {
+    captures.push({ element: report.allEmptyRef, name: "all-empty" });
+  }
+  for (let j = 0; j < report.allRefs.length; j++) {
+    const el = report.allRefs[j];
+    if (el?.isConnected) {
+      captures.push({ element: el, name: `all-${j}` });
     }
   }
 

--- a/services/agora/src/pages/dev/analysis-report-test.vue
+++ b/services/agora/src/pages/dev/analysis-report-test.vue
@@ -91,6 +91,19 @@
               class="control-select"
             />
           </div>
+          <div class="control-item">
+            <label for="all-statements-order" class="control-label">
+              All statements order
+            </label>
+            <PrimeSelect
+              id="all-statements-order"
+              v-model="allStatementsOrder"
+              :options="allStatementsOrderOptions"
+              option-label="label"
+              option-value="value"
+              class="control-select"
+            />
+          </div>
         </div>
       </template>
     </PrimeCard>
@@ -113,8 +126,9 @@
     <div class="report-preview">
       <AnalysisReport
         ref="analysisReportRef"
-        :key="`${selectedClusterCount}-${aiLabelMode}-${emptySectionsMode}-${numberScale}-${surveyViewerAccess}-${surveyScenario}-${reportSurveyDisplayMode}`"
+        :key="`${selectedClusterCount}-${aiLabelMode}-${emptySectionsMode}-${numberScale}-${surveyViewerAccess}-${surveyScenario}-${reportSurveyDisplayMode}-${allStatementsOrder}`"
         v-model:survey-display-mode="reportSurveyDisplayMode"
+        v-model:all-statements-order="allStatementsOrder"
         :items-per-page="itemsPerPage"
         :conversation-slug-id="mockConversationSlugId"
         :conversation-title="mockConversationTitle"
@@ -130,6 +144,8 @@
         :agreement-items="mockAgreementItems"
         :disagreement-items="mockDisagreementItems"
         :divisive-items="mockDivisiveItems"
+        :all-items="mockAllItems"
+        :all-statements-order-options="allStatementsOrderOptions"
         :has-survey="hasMockSurvey"
         :survey-rows="reportSurveyRows"
         :show-survey-toggle="showReportSurveyToggle"
@@ -154,8 +170,10 @@ import type {
   PolisClusters,
 } from "src/shared/types/zod";
 import {
+  getReportAllOpinions,
   REPORT_ITEMS_PER_CAPTURE_PAGE,
   REPORT_ITEMS_PER_PDF_PAGE,
+  type ReportAllStatementsOrder,
 } from "src/utils/component/report/reportData";
 import {
   canViewFullSurveyResults,
@@ -205,6 +223,7 @@ const numberScale = ref<"normal" | "large" | "veryLarge">("large");
 const surveyViewerAccess = ref<"public" | "owner">("owner");
 const surveyScenario = ref<SurveyScenario>("visible");
 const reportSurveyDisplayMode = ref<SurveyResultsDisplayMode>("suppressed");
+const allStatementsOrder = ref<ReportAllStatementsOrder>("newest");
 
 const mockConversationSlugId = "dev-test-report";
 const mockConversationTitle =
@@ -272,6 +291,13 @@ const surveyScenarioOptions = computed(() => [
   { label: "Mixed groups", value: "mixed" as const },
   { label: "No results yet", value: "empty" as const },
 ]);
+
+const allStatementsOrderOptions = [
+  { label: "Newest first", value: "newest" as const },
+  { label: "Most approved first", value: "agreement" as const },
+  { label: "Most rejected first", value: "disagreement" as const },
+  { label: "Most divisive first", value: "divisive" as const },
+];
 
 const emptySectionsOptions = computed(() => [
   { label: t("emptySectionsNone"), value: "none" as const },
@@ -461,6 +487,17 @@ const mockDivisiveItems = computed(() => {
   return items;
 });
 
+const mockAllItems = computed(() =>
+  getReportAllOpinions({
+    order: allStatementsOrder.value,
+    items: [
+      ...mockAgreementItems.value,
+      ...mockDisagreementItems.value,
+      ...mockDivisiveItems.value,
+    ],
+  })
+);
+
 const surveyResultsQuery = useQuery({
   queryKey: computed(() => [
     "dev-survey-results",
@@ -504,9 +541,11 @@ interface AnalysisReportExposed {
   agreementEmptyRef: HTMLElement | null;
   disagreementEmptyRef: HTMLElement | null;
   divisiveEmptyRef: HTMLElement | null;
+  allEmptyRef: HTMLElement | null;
   agreementRefs: HTMLElement[];
   disagreementRefs: HTMLElement[];
   divisiveRefs: HTMLElement[];
+  allRefs: HTMLElement[];
   surveyEmptyRef: HTMLElement | null;
   surveyRefs: HTMLElement[];
   footerRef: HTMLElement | null;
@@ -579,6 +618,15 @@ function buildCaptures(): Array<{ element: HTMLElement; name: string }> {
     const el = report.surveyRefs[j];
     if (el?.isConnected) {
       captures.push({ element: el, name: `survey-${j}` });
+    }
+  }
+  if (report.allEmptyRef?.isConnected) {
+    captures.push({ element: report.allEmptyRef, name: "all-empty" });
+  }
+  for (let j = 0; j < report.allRefs.length; j++) {
+    const el = report.allRefs[j];
+    if (el?.isConnected) {
+      captures.push({ element: el, name: `all-${j}` });
     }
   }
 

--- a/services/agora/src/utils/component/report/reportData.ts
+++ b/services/agora/src/utils/component/report/reportData.ts
@@ -5,6 +5,11 @@ export const SUMMARY_MAX_ITEMS = 3;
 export const REPORT_MAX_REPRESENTATIVE_ITEMS = 5;
 export const REPORT_ITEMS_PER_CAPTURE_PAGE = 5;
 export const REPORT_ITEMS_PER_PDF_PAGE = 8;
+export type ReportAllStatementsOrder =
+  | "newest"
+  | "agreement"
+  | "disagreement"
+  | "divisive";
 const MIN_SCORE = 0.6;
 
 export function getReportOpinions({
@@ -19,4 +24,36 @@ export function getReportOpinions({
   return items
     .filter((item) => getScore(item) >= MIN_SCORE)
     .slice(0, maxItems);
+}
+
+export function getReportAllOpinions({
+  items,
+  order,
+}: {
+  items: AnalysisOpinionItem[];
+  order: ReportAllStatementsOrder;
+}): AnalysisOpinionItem[] {
+  const itemsBySlugId = new Map<string, AnalysisOpinionItem>();
+  for (const item of items) {
+    itemsBySlugId.set(item.opinionSlugId, item);
+  }
+
+  switch (order) {
+    case "newest":
+      return Array.from(itemsBySlugId.values()).sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      );
+    case "agreement":
+      return Array.from(itemsBySlugId.values()).sort(
+        (a, b) => b.groupAwareConsensusAgree - a.groupAwareConsensusAgree
+      );
+    case "disagreement":
+      return Array.from(itemsBySlugId.values()).sort(
+        (a, b) => b.groupAwareConsensusDisagree - a.groupAwareConsensusDisagree
+      );
+    case "divisive":
+      return Array.from(itemsBySlugId.values()).sort(
+        (a, b) => b.divisiveScore - a.divisiveScore
+      );
+  }
 }


### PR DESCRIPTION
## Summary
- Adds an all-statements section to analysis reports using existing analysis data.
- Lets users order all statements by newest, approval, rejection, or divisiveness.
- Includes the section in report downloads and fixes report vote percentages exceeding 100%.

## Verification
- pnpm exec vue-tsc --noEmit
- pnpm lint

Deploy: agora