### PR TITLE
fix(app): deploy relevant main changes

### DIFF
--- a/services/app/netlify.toml
+++ b/services/app/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "pnpm build"
 publish = "build"
-ignore = "test -n \"$CACHED_COMMIT_REF\" && git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- ."
+ignore = 'if [ "$CONTEXT" = "production" ]; then git diff --quiet "$COMMIT_REF^" "$COMMIT_REF" -- .; else test -n "$CACHED_COMMIT_REF" && git diff --quiet "$CACHED_COMMIT_REF" "$COMMIT_REF" -- .; fi'
 
 [build.environment]
 NODE_VERSION = "24"


### PR DESCRIPTION
## Summary
- Compare production deploys against the current commit's first parent so merged landing-page changes deploy even if a PR preview already built the same tree.
- Keep the existing CACHED_COMMIT_REF ignore optimization for non-production deploys.

## Testing
- cd services/app && pnpm build