### PR TITLE
feat(agora): outline title and body editor fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Agora is written by:
+
 - Nicolas Gimenez <nicolas.gimenez@zkorum.com>
-- Robin Marien  <robin.marien@hotmail.fr>
+- Robin Marien <robin.marien@hotmail.fr>
 - Hazim Benslimane <hazim_benslimane@hotmail.com>
 - Edmund Wong <edmundwongh@gmail.com>
 - Hanaan Shafi <hanaan.sh@protonmail.com>
@@ -8,8 +9,10 @@ Agora is written by:
 - Phoebe Choudy-Lartisant <phoebe.contactme@protonmail.com>
 - Dima Alrahaife <dalrahaife@sfcg.org> (reviewed Arabic translations)
 - Takeru Fukushima <takeru.f.2004@gmail.com> (proofread Japanese translations)
+- Christophe Bruchansky <christophe@bruchansky.xyz> (minimal UI update)
 
 With help from many libraries and frameworks including:
+
 - Rarimo SDK
 - UCAN
 - WebCrypto API
@@ -20,9 +23,9 @@ With help from many libraries and frameworks including:
 - Vite
 - pnpm
 - eventsource-parser (MIT; SSE parser reference): https://github.com/rexxars/eventsource-parser
-...
 
 Algorithm inspiration:
+
 - MaxDiff scoring: Bradley-Terry MLE via MM algorithm
   - choix (MIT): https://github.com/lucasmaystre/choix
   - Solidago/Tournesol (LGPL): https://github.com/tournesol-app/tournesol

--- a/services/agora/src/pages/conversation/[conversationSlugId]/edit/index.vue
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/edit/index.vue
@@ -496,15 +496,14 @@ onMounted(async () => {
 </script>
 
 <style scoped lang="scss">
-.title-style {
-  font-size: 1.1rem;
-  font-weight: var(--font-weight-semibold);
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+.title-editor,
+.editor-style {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
 }
 
 .editor-style {
-  padding-bottom: 2rem;
+  margin-bottom: 2rem;
   font-size: 1rem;
 }
 

--- a/services/agora/src/pages/conversation/new/create/index.vue
+++ b/services/agora/src/pages/conversation/new/create/index.vue
@@ -512,15 +512,14 @@ onMounted(() => {
 </script>
 
 <style scoped lang="scss">
-.title-style {
-  font-size: 1.1rem;
-  font-weight: var(--font-weight-semibold);
-  padding-left: 0.5rem;
-  padding-right: 0.5rem;
+.title-editor,
+.editor-style {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
 }
 
 .editor-style {
-  padding-bottom: 2rem;
+  margin-bottom: 2rem;
   font-size: 1rem;
 }
 


### PR DESCRIPTION
## Summary

- Add a subtle border (1px solid #e0e0e0, 6px border-radius) around the title and description editor inputs on the create and edit conversation pages
- The border makes it visually clear that the formatting toolbar buttons (bold, italic, lists, etc.) apply to the description field below them, rather than floating independently on the page
- Fix character count position: `padding-bottom` on the description wrapper replaced with `margin-bottom` so the count sits flush at the bottom of the border

## Test plan

- [ ] Create conversation page: title and description both show a light rounded border
- [ ] Edit conversation page: same borders applied
- [ ] Character count for the description appears at the bottom edge of the border with no extra space below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)