### PR TITLE
fix(api): backfill hidden Polis snapshots

### DIFF
--- a/services/api/database/flyway/V0062.2__backfill_legacy_polis_analysis.sql
+++ b/services/api/database/flyway/V0062.2__backfill_legacy_polis_analysis.sql
@@ -9,37 +9,38 @@
 -- - replace owner full survey rows via survey_aggregate_owner_current
 DO $$
 DECLARE
-    default_opinion_group_spec_id integer;
+    v_default_opinion_group_spec_id integer;
     placeholder_input_hash constant text := '679ed49101719a0e1b7780f9a7dc5649107a4c24b245791029fcb19e15def7c4';
     placeholder_input_payload constant bytea := decode(
         '28b52ffd20863d0300f205141890296d985537d9402bf1b0d15fbaa7c0fe8f45aac8ef6ecd8b81c054c2dea44ac08e40c3a5d6a3bc6c3e6a45f634d1564184dbd4395938dc0996b81f7818150f7bdfa8023065a4e9663f3126ba578a0700550870433039cd3375faae6c6e360b15e613',
         'hex'
     );
     backfill_conversation record;
-    snapshot_input_id integer;
-    analysis_snapshot_id integer;
-    snapshot_result_id integer;
-    lineage_scope_id integer;
-    candidate_id integer;
-    view_snapshot_id integer;
-    new_survey_aggregate_snapshot_id integer;
-    active_survey_config_id integer;
-    active_survey_current_revision integer;
-    active_survey_is_optional boolean;
-    owner_current_rows jsonb;
+    v_snapshot_input_id integer;
+    v_analysis_snapshot_id integer;
+    v_snapshot_result_id integer;
+    v_lineage_scope_id integer;
+    v_candidate_id integer;
+    v_view_snapshot_id integer;
+    v_new_survey_aggregate_snapshot_id integer;
+    v_active_survey_config_id integer;
+    v_active_survey_current_revision integer;
+    v_active_survey_is_optional boolean;
+    v_is_displayable_analysis boolean;
+    v_owner_current_rows jsonb;
     legacy_cluster record;
-    description_id integer;
-    lineage_id integer;
-    new_opinion_group_id integer;
+    v_description_id integer;
+    v_lineage_id integer;
+    v_new_opinion_group_id integer;
 BEGIN
     SELECT id
-    INTO default_opinion_group_spec_id
+    INTO v_default_opinion_group_spec_id
     FROM opinion_group_spec
     WHERE key = 'default' AND version = 1
     ORDER BY id
     LIMIT 1;
 
-    IF default_opinion_group_spec_id IS NULL THEN
+    IF v_default_opinion_group_spec_id IS NULL THEN
         RAISE EXCEPTION 'Missing default opinion_group_spec key=default version=1. Run V0062.1__seed_default_opinion_group_spec.sql first.';
     END IF;
 
@@ -169,18 +170,14 @@ BEGIN
             variant.id AS opinion_group_variant_id
         FROM current_group_stats stats
         JOIN opinion_group_variant variant
-            ON variant.opinion_group_spec_id = default_opinion_group_spec_id
+            ON variant.opinion_group_spec_id = v_default_opinion_group_spec_id
            AND variant.group_count = stats.group_count
         WHERE stats.group_count BETWEEN 2 AND 6
-          AND NOT (
-              stats.group_count = 2
-              AND stats.min_group_num_users = 1
-          )
           AND NOT EXISTS (
               SELECT 1
               FROM conversation_view_snapshot existing_view_snapshot
               WHERE existing_view_snapshot.conversation_id = stats.conversation_id
-                AND existing_view_snapshot.opinion_group_spec_id = default_opinion_group_spec_id
+                AND existing_view_snapshot.opinion_group_spec_id = v_default_opinion_group_spec_id
                 AND existing_view_snapshot.analysis_snapshot_id IS NOT NULL
           )
         ORDER BY stats.conversation_id
@@ -196,11 +193,15 @@ BEGIN
         TRUNCATE tmp_survey_overall_option_count;
         TRUNCATE tmp_survey_group_option_count;
 
-        new_survey_aggregate_snapshot_id := NULL;
-        active_survey_config_id := NULL;
-        active_survey_current_revision := NULL;
-        active_survey_is_optional := NULL;
-        owner_current_rows := '[]'::jsonb;
+        v_new_survey_aggregate_snapshot_id := NULL;
+        v_active_survey_config_id := NULL;
+        v_active_survey_current_revision := NULL;
+        v_active_survey_is_optional := NULL;
+        v_is_displayable_analysis := NOT (
+            backfill_conversation.group_count = 2
+            AND backfill_conversation.min_group_num_users = 1
+        );
+        v_owner_current_rows := '[]'::jsonb;
 
         INSERT INTO analysis_input_snapshot (
             conversation_id,
@@ -224,7 +225,7 @@ BEGIN
             placeholder_input_payload,
             backfill_conversation.polis_content_created_at
         )
-        RETURNING id INTO snapshot_input_id;
+        RETURNING id INTO v_snapshot_input_id;
 
         INSERT INTO analysis_snapshot (
             conversation_id,
@@ -237,12 +238,12 @@ BEGIN
         VALUES (
             backfill_conversation.conversation_id,
             backfill_conversation.conversation_content_id,
-            snapshot_input_id,
+            v_snapshot_input_id,
             0,
             backfill_conversation.polis_content_created_at,
             backfill_conversation.polis_content_created_at
         )
-        RETURNING id INTO analysis_snapshot_id;
+        RETURNING id INTO v_analysis_snapshot_id;
 
         INSERT INTO analysis_snapshot_result (
             conversation_id,
@@ -254,13 +255,13 @@ BEGIN
         )
         VALUES (
             backfill_conversation.conversation_id,
-            analysis_snapshot_id,
-            default_opinion_group_spec_id,
+            v_analysis_snapshot_id,
+            v_default_opinion_group_spec_id,
             'success',
             NULL,
             backfill_conversation.polis_content_created_at
         )
-        RETURNING id INTO snapshot_result_id;
+        RETURNING id INTO v_snapshot_result_id;
 
         INSERT INTO opinion_group_lineage_scope (
             conversation_id,
@@ -275,7 +276,7 @@ BEGIN
         ON CONFLICT (conversation_id, opinion_group_variant_id) DO NOTHING;
 
         SELECT id
-        INTO lineage_scope_id
+        INTO v_lineage_scope_id
         FROM opinion_group_lineage_scope
         WHERE conversation_id = backfill_conversation.conversation_id
           AND opinion_group_variant_id = backfill_conversation.opinion_group_variant_id;
@@ -290,9 +291,9 @@ BEGIN
             created_at
         )
         VALUES (
-            snapshot_result_id,
+            v_snapshot_result_id,
             backfill_conversation.opinion_group_variant_id,
-            lineage_scope_id,
+            v_lineage_scope_id,
             'success',
             NULL,
             jsonb_build_object(
@@ -305,17 +306,16 @@ BEGIN
             ),
             backfill_conversation.polis_content_created_at
         )
-        RETURNING id INTO candidate_id;
+        RETURNING id INTO v_candidate_id;
 
-        IF backfill_conversation.group_count = 2
-           AND backfill_conversation.min_group_num_users = 1 THEN
+        IF NOT v_is_displayable_analysis THEN
             INSERT INTO opinion_group_candidate_assessment (
                 candidate_id,
                 hidden_reason,
                 created_at
             )
             VALUES (
-                candidate_id,
+                v_candidate_id,
                 'singleton_group',
                 backfill_conversation.polis_content_created_at
             );
@@ -327,7 +327,7 @@ BEGIN
                 created_at
             )
             VALUES (
-                candidate_id,
+                v_candidate_id,
                 1.0,
                 backfill_conversation.polis_content_created_at
             );
@@ -346,7 +346,7 @@ BEGIN
                 created_at
             )
             SELECT
-                analysis_snapshot_id,
+                v_analysis_snapshot_id,
                 opinion.id,
                 opinion.current_content_id,
                 row_number() OVER (ORDER BY opinion.id) - 1,
@@ -378,7 +378,7 @@ BEGIN
             created_at
         )
         SELECT
-            candidate_id,
+            v_candidate_id,
             snapshot_map.analysis_snapshot_opinion_id,
             opinion.polis_ga_consensus_pa,
             opinion.polis_ga_consensus_pd,
@@ -409,7 +409,7 @@ BEGIN
             WHERE cluster.polis_content_id = backfill_conversation.polis_content_id
             ORDER BY cluster.key
         LOOP
-            description_id := NULL;
+            v_description_id := NULL;
 
             IF legacy_cluster.ai_label IS NOT NULL
                AND legacy_cluster.ai_summary IS NOT NULL THEN
@@ -425,7 +425,7 @@ BEGIN
                     legacy_cluster.ai_summary,
                     legacy_cluster.updated_at
                 )
-                RETURNING id INTO description_id;
+                RETURNING id INTO v_description_id;
 
                 INSERT INTO opinion_group_description_translation (
                     description_id,
@@ -435,7 +435,7 @@ BEGIN
                     created_at
                 )
                 SELECT
-                    description_id,
+                    v_description_id,
                     translation.language_code,
                     translation.ai_label,
                     translation.ai_summary,
@@ -454,12 +454,12 @@ BEGIN
                 created_at
             )
             VALUES (
-                lineage_scope_id,
-                description_id,
+                v_lineage_scope_id,
+                v_description_id,
                 NULL,
                 legacy_cluster.created_at
             )
-            RETURNING id INTO lineage_id;
+            RETURNING id INTO v_lineage_id;
 
             INSERT INTO opinion_group (
                 candidate_id,
@@ -471,18 +471,18 @@ BEGIN
                 created_at
             )
             VALUES (
-                candidate_id,
-                lineage_scope_id,
-                lineage_id,
+                v_candidate_id,
+                v_lineage_scope_id,
+                v_lineage_id,
                 legacy_cluster.key::text,
                 legacy_cluster.external_id,
                 legacy_cluster.num_users,
                 legacy_cluster.created_at
             )
-            RETURNING id INTO new_opinion_group_id;
+            RETURNING id INTO v_new_opinion_group_id;
 
             INSERT INTO tmp_group_map (legacy_cluster_id, group_id)
-            VALUES (legacy_cluster.legacy_cluster_id, new_opinion_group_id);
+            VALUES (legacy_cluster.legacy_cluster_id, v_new_opinion_group_id);
         END LOOP;
 
         INSERT INTO opinion_group_user (
@@ -492,7 +492,7 @@ BEGIN
             created_at
         )
         SELECT
-            candidate_id,
+            v_candidate_id,
             group_map.group_id,
             cluster_user.user_id,
             cluster_user.created_at
@@ -572,16 +572,16 @@ BEGIN
             survey_config.current_revision,
             survey_config.is_optional
         INTO
-            active_survey_config_id,
-            active_survey_current_revision,
-            active_survey_is_optional
+            v_active_survey_config_id,
+            v_active_survey_current_revision,
+            v_active_survey_is_optional
         FROM survey_config
         WHERE survey_config.conversation_id = backfill_conversation.conversation_id
           AND survey_config.deleted_at IS NULL
         ORDER BY survey_config.id
         LIMIT 1;
 
-        IF active_survey_config_id IS NOT NULL THEN
+        IF v_active_survey_config_id IS NOT NULL THEN
             INSERT INTO tmp_survey_question_meta (
                 question_id,
                 question_slug_id,
@@ -616,7 +616,7 @@ BEGIN
             FROM survey_question
             JOIN survey_question_content
                 ON survey_question.current_content_id = survey_question_content.id
-            WHERE survey_question.survey_config_id = active_survey_config_id
+            WHERE survey_question.survey_config_id = v_active_survey_config_id
               AND survey_question.current_content_id IS NOT NULL
               AND survey_question.question_type = 'choice'
             ORDER BY survey_question.display_order, survey_question.slug_id;
@@ -668,7 +668,7 @@ BEGIN
             FROM survey_question
             JOIN survey_question_content
                 ON survey_question.current_content_id = survey_question_content.id
-            WHERE survey_question.survey_config_id = active_survey_config_id
+            WHERE survey_question.survey_config_id = v_active_survey_config_id
               AND survey_question.current_content_id IS NOT NULL
               AND survey_question.is_required = true
             ORDER BY survey_question.display_order, survey_question.slug_id;
@@ -706,7 +706,7 @@ BEGIN
                 base_responses.response_id,
                 base_responses.participant_id
             FROM base_responses
-            WHERE active_survey_is_optional
+            WHERE v_active_survey_is_optional
                OR NOT EXISTS (
                    SELECT 1
                    FROM tmp_required_survey_question_meta required_question
@@ -749,13 +749,13 @@ BEGIN
             )
             VALUES (
                 backfill_conversation.conversation_id,
-                analysis_snapshot_id,
-                active_survey_config_id,
-                active_survey_current_revision,
+                v_analysis_snapshot_id,
+                v_active_survey_config_id,
+                v_active_survey_current_revision,
                 5,
                 backfill_conversation.polis_content_updated_at
             )
-            RETURNING id INTO new_survey_aggregate_snapshot_id;
+            RETURNING id INTO v_new_survey_aggregate_snapshot_id;
 
             INSERT INTO survey_aggregate_question (
                 survey_aggregate_snapshot_id,
@@ -769,7 +769,7 @@ BEGIN
                 created_at
             )
             SELECT
-                new_survey_aggregate_snapshot_id,
+                v_new_survey_aggregate_snapshot_id,
                 question_id,
                 question_slug_id,
                 question_order,
@@ -799,7 +799,7 @@ BEGIN
             JOIN tmp_survey_question_meta question_meta
                 ON question_meta.question_id = option_meta.question_id
             JOIN survey_aggregate_question aggregate_question
-                ON aggregate_question.survey_aggregate_snapshot_id = new_survey_aggregate_snapshot_id
+                ON aggregate_question.survey_aggregate_snapshot_id = v_new_survey_aggregate_snapshot_id
                AND aggregate_question.question_slug_id = question_meta.question_slug_id;
 
             WITH eligible_responses AS (
@@ -916,130 +916,132 @@ BEGIN
             LEFT JOIN overall_question_suppression
                 ON overall_question_suppression.question_id = overall_option_counts.question_id;
 
-            WITH eligible_responses AS (
-                SELECT
-                    response_id,
-                    participant_id
-                FROM tmp_counted_survey_response
-            ),
-            valid_choice_answers AS (
-                SELECT
-                    eligible_responses.response_id,
-                    eligible_responses.participant_id,
-                    question_meta.question_id
-                FROM eligible_responses
-                JOIN tmp_survey_question_meta question_meta
-                    ON TRUE
-                JOIN survey_answer
-                    ON survey_answer.survey_response_id = eligible_responses.response_id
-                   AND survey_answer.survey_question_id = question_meta.question_id
-                   AND survey_answer.deleted_at IS NULL
-                LEFT JOIN survey_answer_option
-                    ON survey_answer_option.survey_answer_id = survey_answer.id
-                   AND survey_answer_option.deleted_at IS NULL
-                LEFT JOIN tmp_survey_option_meta option_meta
-                    ON option_meta.survey_question_option_id = survey_answer_option.survey_question_option_id
-                   AND option_meta.question_id = question_meta.question_id
-                GROUP BY
-                    eligible_responses.response_id,
-                    eligible_responses.participant_id,
-                    question_meta.question_id,
-                    survey_answer.answered_question_semantic_version,
-                    question_meta.question_semantic_version,
-                    question_meta.min_selections,
-                    question_meta.max_selections
-                HAVING survey_answer.answered_question_semantic_version = question_meta.question_semantic_version
-                   AND count(survey_answer_option.id) = count(option_meta.survey_question_option_id)
-                   AND count(survey_answer_option.id) = count(DISTINCT survey_answer_option.survey_question_option_id)
-                   AND count(survey_answer_option.id) >= question_meta.min_selections
-                   AND (
-                       question_meta.max_selections IS NULL
-                       OR count(survey_answer_option.id) <= question_meta.max_selections
-                   )
-            ),
-            selected_options AS (
-                SELECT
-                    valid_choice_answers.response_id,
-                    valid_choice_answers.participant_id,
-                    valid_choice_answers.question_id,
-                    option_meta.survey_question_option_id
-                FROM valid_choice_answers
-                JOIN survey_answer
-                    ON survey_answer.survey_response_id = valid_choice_answers.response_id
-                   AND survey_answer.survey_question_id = valid_choice_answers.question_id
-                   AND survey_answer.deleted_at IS NULL
-                JOIN survey_answer_option
-                    ON survey_answer_option.survey_answer_id = survey_answer.id
-                   AND survey_answer_option.deleted_at IS NULL
-                JOIN tmp_survey_option_meta option_meta
-                    ON option_meta.survey_question_option_id = survey_answer_option.survey_question_option_id
-                   AND option_meta.question_id = valid_choice_answers.question_id
-            ),
-            group_option_counts AS (
-                SELECT
-                    group_map.group_id,
-                    question_meta.question_id,
-                    option_meta.survey_question_option_id,
-                    option_meta.option_slug_id,
-                    option_meta.option_order,
-                    option_meta.option_text,
-                    count(selected_options.response_id)::integer AS option_count,
-                    count(DISTINCT valid_choice_answers.response_id)::integer AS denominator
-                FROM tmp_group_map group_map
-                JOIN tmp_survey_question_meta question_meta
-                    ON TRUE
-                JOIN tmp_survey_option_meta option_meta
-                    ON option_meta.question_id = question_meta.question_id
-                LEFT JOIN tmp_group_participant_map group_participant
-                    ON group_participant.group_id = group_map.group_id
-                LEFT JOIN valid_choice_answers
-                    ON valid_choice_answers.question_id = question_meta.question_id
-                   AND valid_choice_answers.participant_id = group_participant.participant_id
-                LEFT JOIN selected_options
-                    ON selected_options.response_id = valid_choice_answers.response_id
-                   AND selected_options.question_id = question_meta.question_id
-                   AND selected_options.survey_question_option_id = option_meta.survey_question_option_id
-                GROUP BY
-                    group_map.group_id,
-                    question_meta.question_id,
-                    option_meta.survey_question_option_id,
-                    option_meta.option_slug_id,
-                    option_meta.option_order,
-                    option_meta.option_text
-            ),
-            group_question_suppression AS (
-                SELECT
+            IF v_is_displayable_analysis THEN
+                WITH eligible_responses AS (
+                    SELECT
+                        response_id,
+                        participant_id
+                    FROM tmp_counted_survey_response
+                ),
+                valid_choice_answers AS (
+                    SELECT
+                        eligible_responses.response_id,
+                        eligible_responses.participant_id,
+                        question_meta.question_id
+                    FROM eligible_responses
+                    JOIN tmp_survey_question_meta question_meta
+                        ON TRUE
+                    JOIN survey_answer
+                        ON survey_answer.survey_response_id = eligible_responses.response_id
+                       AND survey_answer.survey_question_id = question_meta.question_id
+                       AND survey_answer.deleted_at IS NULL
+                    LEFT JOIN survey_answer_option
+                        ON survey_answer_option.survey_answer_id = survey_answer.id
+                       AND survey_answer_option.deleted_at IS NULL
+                    LEFT JOIN tmp_survey_option_meta option_meta
+                        ON option_meta.survey_question_option_id = survey_answer_option.survey_question_option_id
+                       AND option_meta.question_id = question_meta.question_id
+                    GROUP BY
+                        eligible_responses.response_id,
+                        eligible_responses.participant_id,
+                        question_meta.question_id,
+                        survey_answer.answered_question_semantic_version,
+                        question_meta.question_semantic_version,
+                        question_meta.min_selections,
+                        question_meta.max_selections
+                    HAVING survey_answer.answered_question_semantic_version = question_meta.question_semantic_version
+                       AND count(survey_answer_option.id) = count(option_meta.survey_question_option_id)
+                       AND count(survey_answer_option.id) = count(DISTINCT survey_answer_option.survey_question_option_id)
+                       AND count(survey_answer_option.id) >= question_meta.min_selections
+                       AND (
+                           question_meta.max_selections IS NULL
+                           OR count(survey_answer_option.id) <= question_meta.max_selections
+                       )
+                ),
+                selected_options AS (
+                    SELECT
+                        valid_choice_answers.response_id,
+                        valid_choice_answers.participant_id,
+                        valid_choice_answers.question_id,
+                        option_meta.survey_question_option_id
+                    FROM valid_choice_answers
+                    JOIN survey_answer
+                        ON survey_answer.survey_response_id = valid_choice_answers.response_id
+                       AND survey_answer.survey_question_id = valid_choice_answers.question_id
+                       AND survey_answer.deleted_at IS NULL
+                    JOIN survey_answer_option
+                        ON survey_answer_option.survey_answer_id = survey_answer.id
+                       AND survey_answer_option.deleted_at IS NULL
+                    JOIN tmp_survey_option_meta option_meta
+                        ON option_meta.survey_question_option_id = survey_answer_option.survey_question_option_id
+                       AND option_meta.question_id = valid_choice_answers.question_id
+                ),
+                group_option_counts AS (
+                    SELECT
+                        group_map.group_id,
+                        question_meta.question_id,
+                        option_meta.survey_question_option_id,
+                        option_meta.option_slug_id,
+                        option_meta.option_order,
+                        option_meta.option_text,
+                        count(selected_options.response_id)::integer AS option_count,
+                        count(DISTINCT valid_choice_answers.response_id)::integer AS denominator
+                    FROM tmp_group_map group_map
+                    JOIN tmp_survey_question_meta question_meta
+                        ON TRUE
+                    JOIN tmp_survey_option_meta option_meta
+                        ON option_meta.question_id = question_meta.question_id
+                    LEFT JOIN tmp_group_participant_map group_participant
+                        ON group_participant.group_id = group_map.group_id
+                    LEFT JOIN valid_choice_answers
+                        ON valid_choice_answers.question_id = question_meta.question_id
+                       AND valid_choice_answers.participant_id = group_participant.participant_id
+                    LEFT JOIN selected_options
+                        ON selected_options.response_id = valid_choice_answers.response_id
+                       AND selected_options.question_id = question_meta.question_id
+                       AND selected_options.survey_question_option_id = option_meta.survey_question_option_id
+                    GROUP BY
+                        group_map.group_id,
+                        question_meta.question_id,
+                        option_meta.survey_question_option_id,
+                        option_meta.option_slug_id,
+                        option_meta.option_order,
+                        option_meta.option_text
+                ),
+                group_question_suppression AS (
+                    SELECT
+                        group_id,
+                        question_id,
+                        bool_or(option_count > 0 AND option_count < 5) AS is_suppressed
+                    FROM group_option_counts
+                    GROUP BY group_id, question_id
+                )
+                INSERT INTO tmp_survey_group_option_count (
                     group_id,
                     question_id,
-                    bool_or(option_count > 0 AND option_count < 5) AS is_suppressed
+                    survey_question_option_id,
+                    option_slug_id,
+                    option_order,
+                    option_text,
+                    option_count,
+                    denominator,
+                    is_suppressed
+                )
+                SELECT
+                    group_option_counts.group_id,
+                    group_option_counts.question_id,
+                    group_option_counts.survey_question_option_id,
+                    group_option_counts.option_slug_id,
+                    group_option_counts.option_order,
+                    group_option_counts.option_text,
+                    group_option_counts.option_count,
+                    group_option_counts.denominator,
+                    COALESCE(group_question_suppression.is_suppressed, false)
                 FROM group_option_counts
-                GROUP BY group_id, question_id
-            )
-            INSERT INTO tmp_survey_group_option_count (
-                group_id,
-                question_id,
-                survey_question_option_id,
-                option_slug_id,
-                option_order,
-                option_text,
-                option_count,
-                denominator,
-                is_suppressed
-            )
-            SELECT
-                group_option_counts.group_id,
-                group_option_counts.question_id,
-                group_option_counts.survey_question_option_id,
-                group_option_counts.option_slug_id,
-                group_option_counts.option_order,
-                group_option_counts.option_text,
-                group_option_counts.option_count,
-                group_option_counts.denominator,
-                COALESCE(group_question_suppression.is_suppressed, false)
-            FROM group_option_counts
-            LEFT JOIN group_question_suppression
-                ON group_question_suppression.group_id = group_option_counts.group_id
-               AND group_question_suppression.question_id = group_option_counts.question_id;
+                LEFT JOIN group_question_suppression
+                    ON group_question_suppression.group_id = group_option_counts.group_id
+                   AND group_question_suppression.question_id = group_option_counts.question_id;
+            END IF;
 
             INSERT INTO survey_aggregate_result (
                 survey_aggregate_snapshot_id,
@@ -1055,7 +1057,7 @@ BEGIN
                 created_at
             )
             SELECT
-                new_survey_aggregate_snapshot_id,
+                v_new_survey_aggregate_snapshot_id,
                 NULL,
                 NULL,
                 'overall',
@@ -1083,7 +1085,7 @@ BEGIN
                 backfill_conversation.polis_content_updated_at
             FROM tmp_survey_overall_option_count overall_count
             JOIN survey_aggregate_question aggregate_question
-                ON aggregate_question.survey_aggregate_snapshot_id = new_survey_aggregate_snapshot_id
+                ON aggregate_question.survey_aggregate_snapshot_id = v_new_survey_aggregate_snapshot_id
                AND aggregate_question.survey_question_id = overall_count.question_id
             JOIN survey_aggregate_option aggregate_option
                 ON aggregate_option.survey_aggregate_question_id = aggregate_question.id
@@ -1103,8 +1105,8 @@ BEGIN
                 created_at
             )
             SELECT
-                new_survey_aggregate_snapshot_id,
-                candidate_id,
+                v_new_survey_aggregate_snapshot_id,
+                v_candidate_id,
                 group_count.group_id,
                 'opinion_group',
                 aggregate_question.id,
@@ -1131,7 +1133,7 @@ BEGIN
                 backfill_conversation.polis_content_updated_at
             FROM tmp_survey_group_option_count group_count
             JOIN survey_aggregate_question aggregate_question
-                ON aggregate_question.survey_aggregate_snapshot_id = new_survey_aggregate_snapshot_id
+                ON aggregate_question.survey_aggregate_snapshot_id = v_new_survey_aggregate_snapshot_id
                AND aggregate_question.survey_question_id = group_count.question_id
             JOIN survey_aggregate_option aggregate_option
                 ON aggregate_option.survey_aggregate_question_id = aggregate_question.id
@@ -1150,7 +1152,7 @@ BEGIN
                 ),
                 '[]'::jsonb
             )
-            INTO owner_current_rows
+            INTO v_owner_current_rows
             FROM (
                 SELECT
                     question_meta.question_order,
@@ -1193,7 +1195,7 @@ BEGIN
                     group_count.option_slug_id,
                     jsonb_build_object(
                         'scope', 'cluster',
-                        'candidateId', candidate_id,
+                        'candidateId', v_candidate_id,
                         'groupId', group_count.group_id,
                         'questionId', question_meta.question_slug_id,
                         'questionType', question_meta.question_type::text,
@@ -1228,10 +1230,10 @@ BEGIN
             )
             VALUES (
                 backfill_conversation.conversation_id,
-                new_survey_aggregate_snapshot_id,
-                active_survey_config_id,
-                active_survey_current_revision,
-                owner_current_rows,
+                v_new_survey_aggregate_snapshot_id,
+                v_active_survey_config_id,
+                v_active_survey_current_revision,
+                v_owner_current_rows,
                 backfill_conversation.polis_content_updated_at,
                 backfill_conversation.polis_content_updated_at
             )
@@ -1265,9 +1267,9 @@ BEGIN
         )
         VALUES (
             backfill_conversation.conversation_id,
-            default_opinion_group_spec_id,
-            analysis_snapshot_id,
-            new_survey_aggregate_snapshot_id,
+            v_default_opinion_group_spec_id,
+            v_analysis_snapshot_id,
+            v_new_survey_aggregate_snapshot_id,
             backfill_conversation.conversation_content_id,
             'analysis_completed',
             backfill_conversation.is_closed,
@@ -1282,7 +1284,7 @@ BEGIN
             backfill_conversation.polis_content_updated_at,
             backfill_conversation.polis_content_updated_at
         )
-        RETURNING id INTO view_snapshot_id;
+        RETURNING id INTO v_view_snapshot_id;
 
         INSERT INTO opinion_group_description_locale_status (
             conversation_view_snapshot_id,
@@ -1295,10 +1297,10 @@ BEGIN
             updated_at
         )
         SELECT
-            view_snapshot_id,
+            v_view_snapshot_id,
             backfill_conversation.conversation_id,
-            default_opinion_group_spec_id,
-            snapshot_result_id,
+            v_default_opinion_group_spec_id,
+            v_snapshot_result_id,
             supported_locale.locale,
             'fallback',
             backfill_conversation.polis_content_updated_at,
@@ -1319,39 +1321,7 @@ BEGIN
         ) AS supported_locale(locale)
         ON CONFLICT (conversation_view_snapshot_id, locale) DO NOTHING;
 
-        INSERT INTO conversation_view_snapshot_checkpoint_reason (
-            conversation_view_snapshot_id,
-            conversation_id,
-            opinion_group_spec_id,
-            reason,
-            created_at
-        )
-        VALUES (
-            view_snapshot_id,
-            backfill_conversation.conversation_id,
-            default_opinion_group_spec_id,
-            'first_displayable_analysis',
-            backfill_conversation.polis_content_updated_at
-        );
-
-        INSERT INTO conversation_view_snapshot_checkpoint_reason (
-            conversation_view_snapshot_id,
-            conversation_id,
-            opinion_group_spec_id,
-            reason,
-            group_count,
-            created_at
-        )
-        VALUES (
-            view_snapshot_id,
-            backfill_conversation.conversation_id,
-            default_opinion_group_spec_id,
-            'first_group_count_available',
-            backfill_conversation.group_count,
-            backfill_conversation.polis_content_updated_at
-        );
-
-        IF backfill_conversation.is_closed THEN
+        IF v_is_displayable_analysis THEN
             INSERT INTO conversation_view_snapshot_checkpoint_reason (
                 conversation_view_snapshot_id,
                 conversation_id,
@@ -1360,12 +1330,46 @@ BEGIN
                 created_at
             )
             VALUES (
-                view_snapshot_id,
+                v_view_snapshot_id,
                 backfill_conversation.conversation_id,
-                default_opinion_group_spec_id,
-                'conversation_closed',
+                v_default_opinion_group_spec_id,
+                'first_displayable_analysis',
                 backfill_conversation.polis_content_updated_at
             );
+
+            INSERT INTO conversation_view_snapshot_checkpoint_reason (
+                conversation_view_snapshot_id,
+                conversation_id,
+                opinion_group_spec_id,
+                reason,
+                group_count,
+                created_at
+            )
+            VALUES (
+                v_view_snapshot_id,
+                backfill_conversation.conversation_id,
+                v_default_opinion_group_spec_id,
+                'first_group_count_available',
+                backfill_conversation.group_count,
+                backfill_conversation.polis_content_updated_at
+            );
+
+            IF backfill_conversation.is_closed THEN
+                INSERT INTO conversation_view_snapshot_checkpoint_reason (
+                    conversation_view_snapshot_id,
+                    conversation_id,
+                    opinion_group_spec_id,
+                    reason,
+                    created_at
+                )
+                VALUES (
+                    v_view_snapshot_id,
+                    backfill_conversation.conversation_id,
+                    v_default_opinion_group_spec_id,
+                    'conversation_closed',
+                    backfill_conversation.polis_content_updated_at
+                );
+            END IF;
         END IF;
     END LOOP;
 END $$;


### PR DESCRIPTION
## Summary
- Prefix PL/pgSQL variables in the legacy Polis backfill to avoid collisions with SQL column names.
- Include singleton-hidden legacy Polis analyses so they receive activated `analysis_completed` view snapshots for counts.
- Keep singleton-hidden candidates non-displayable by skipping selection scores, display checkpoint reasons, and group-level survey aggregate rows.

## Testing
- `git diff --check`
- Static migration review for remaining PL/pgSQL variable/column name collisions.