### PR TITLE
refactor(api): move conversations to project ownership

### DIFF
--- a/services/api/database/flyway/V0071.1__backfill_org_project_ownership.sql
+++ b/services/api/database/flyway/V0071.1__backfill_org_project_ownership.sql
@@ -1,0 +1,278 @@
+UPDATE "user"
+SET first_name = username
+WHERE first_name IS NULL;
+
+WITH normalized AS (
+    SELECT
+        organization.id,
+        organization.name AS display_name,
+        lower(
+            trim(
+                both '-' from regexp_replace(
+                    regexp_replace(organization.name, '[^[:alnum:]]+', '-', 'g'),
+                    '-+',
+                    '-',
+                    'g'
+                )
+            )
+        ) AS raw_slug
+    FROM organization
+    WHERE organization.auto_provisioned_for_user_id IS NULL
+), slug_candidates AS (
+    SELECT
+        normalized.id,
+        normalized.display_name,
+        CASE
+            WHEN normalized.raw_slug = '' THEN 'org-' || normalized.id::text
+            ELSE left(normalized.raw_slug, 65)
+        END AS base_slug
+    FROM normalized
+), slugged AS (
+    SELECT
+        slug_candidates.id,
+        slug_candidates.display_name,
+        CASE
+            WHEN row_number() OVER (
+                PARTITION BY slug_candidates.base_slug
+                ORDER BY slug_candidates.id
+            ) = 1 THEN slug_candidates.base_slug
+            ELSE left(slug_candidates.base_slug, 58) || '-' || row_number() OVER (
+                PARTITION BY slug_candidates.base_slug
+                ORDER BY slug_candidates.id
+            )::text
+        END AS slug
+    FROM slug_candidates
+)
+UPDATE organization
+SET
+    slug = slugged.slug,
+    display_name = slugged.display_name,
+    directory_visibility = 'listed'::directory_visibility
+FROM slugged
+WHERE organization.id = slugged.id;
+
+INSERT INTO organization (
+    name,
+    slug,
+    display_name,
+    directory_visibility,
+    auto_provisioned_for_user_id,
+    image_path,
+    is_full_image_path,
+    created_at,
+    updated_at
+)
+SELECT
+    'user-' || replace("user".id::text, '-', '') AS name,
+    'user-' || replace("user".id::text, '-', '') AS slug,
+    "user".first_name AS display_name,
+    'unlisted'::directory_visibility AS directory_visibility,
+    "user".id AS auto_provisioned_for_user_id,
+    '' AS image_path,
+    false AS is_full_image_path,
+    now() AS created_at,
+    now() AS updated_at
+FROM "user"
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM organization existing
+    WHERE existing.auto_provisioned_for_user_id = "user".id
+);
+
+INSERT INTO organization_membership (
+    user_id,
+    organization_id,
+    created_at,
+    updated_at
+)
+SELECT
+    user_organization_mapping.user_id,
+    user_organization_mapping.organization_id,
+    user_organization_mapping.created_at,
+    user_organization_mapping.created_at AS updated_at
+FROM user_organization_mapping
+ON CONFLICT (user_id, organization_id) DO NOTHING;
+
+INSERT INTO organization_membership (
+    user_id,
+    organization_id,
+    created_at,
+    updated_at
+)
+SELECT
+    organization.auto_provisioned_for_user_id,
+    organization.id,
+    now(),
+    now()
+FROM organization
+WHERE organization.auto_provisioned_for_user_id IS NOT NULL
+ON CONFLICT (user_id, organization_id) DO NOTHING;
+
+INSERT INTO project (
+    slug,
+    display_name,
+    directory_visibility,
+    auto_provisioned_for_organization_id,
+    created_at,
+    updated_at
+)
+SELECT
+    'org-' || organization.id::text || '-default' AS slug,
+    organization.display_name,
+    'unlisted'::directory_visibility AS directory_visibility,
+    organization.id AS auto_provisioned_for_organization_id,
+    now() AS created_at,
+    now() AS updated_at
+FROM organization
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM project existing
+    WHERE existing.auto_provisioned_for_organization_id = organization.id
+);
+
+INSERT INTO project_organization_ownership (
+    project_id,
+    organization_id,
+    created_at
+)
+SELECT
+    project.id,
+    project.auto_provisioned_for_organization_id,
+    now()
+FROM project
+WHERE project.auto_provisioned_for_organization_id IS NOT NULL
+ON CONFLICT (project_id, organization_id) DO NOTHING;
+
+UPDATE conversation
+SET project_id = project.id
+FROM project
+WHERE conversation.organization_id IS NOT NULL
+  AND project.auto_provisioned_for_organization_id = conversation.organization_id
+  AND conversation.project_id IS NULL;
+
+UPDATE conversation
+SET project_id = project.id
+FROM organization
+JOIN project
+    ON project.auto_provisioned_for_organization_id = organization.id
+WHERE conversation.organization_id IS NULL
+  AND conversation.author_id = organization.auto_provisioned_for_user_id
+  AND conversation.project_id IS NULL;
+
+INSERT INTO organization_membership_capability (
+    organization_membership_id,
+    capability,
+    created_at
+)
+SELECT
+    organization_membership.id,
+    capability.capability,
+    now()
+FROM organization_membership
+CROSS JOIN unnest(ARRAY[
+    'organization_manage_members'::organization_membership_capability_enum,
+    'organization_manage_profile'::organization_membership_capability_enum,
+    'project_create'::organization_membership_capability_enum
+]) AS capability(capability)
+ON CONFLICT (organization_membership_id, capability) DO NOTHING;
+
+INSERT INTO organization_membership_all_project_capability (
+    organization_membership_id,
+    capability,
+    created_at
+)
+SELECT
+    organization_membership.id,
+    capability.capability,
+    now()
+FROM organization_membership
+CROSS JOIN unnest(ARRAY[
+    'project_update'::organization_membership_all_project_capability_enum,
+    'project_delete'::organization_membership_all_project_capability_enum,
+    'project_manage_owner_organizations'::organization_membership_all_project_capability_enum,
+    'conversation_create'::organization_membership_all_project_capability_enum,
+    'conversation_update'::organization_membership_all_project_capability_enum,
+    'conversation_delete'::organization_membership_all_project_capability_enum,
+    'conversation_view_private_results'::organization_membership_all_project_capability_enum,
+    'conversation_export_owner_data'::organization_membership_all_project_capability_enum,
+    'conversation_moderate'::organization_membership_all_project_capability_enum,
+    'conversation_manage_integrations'::organization_membership_all_project_capability_enum
+]) AS capability(capability)
+ON CONFLICT (organization_membership_id, capability) DO NOTHING;
+
+UPDATE premium_feature_entitlement
+SET
+    organization_id = organization.id,
+    user_id = NULL,
+    updated_at = now()
+FROM organization
+WHERE premium_feature_entitlement.user_id = organization.auto_provisioned_for_user_id
+  AND premium_feature_entitlement.organization_id IS NULL;
+
+DO $$
+DECLARE
+    missing_first_names integer;
+    missing_organization_fields integer;
+    missing_personal_memberships integer;
+    missing_project_ownerships integer;
+    missing_conversation_projects integer;
+    missing_entitlement_organizations integer;
+BEGIN
+    SELECT count(*) INTO missing_first_names
+    FROM "user"
+    WHERE first_name IS NULL;
+
+    IF missing_first_names > 0 THEN
+        RAISE EXCEPTION 'org/project backfill failed: % users still have null first_name', missing_first_names;
+    END IF;
+
+    SELECT count(*) INTO missing_organization_fields
+    FROM organization
+    WHERE slug IS NULL
+       OR display_name IS NULL
+       OR directory_visibility IS NULL;
+
+    IF missing_organization_fields > 0 THEN
+        RAISE EXCEPTION 'org/project backfill failed: % organizations still have missing identity fields', missing_organization_fields;
+    END IF;
+
+    SELECT count(*) INTO missing_personal_memberships
+    FROM organization
+    LEFT JOIN organization_membership
+      ON organization_membership.organization_id = organization.id
+     AND organization_membership.user_id = organization.auto_provisioned_for_user_id
+    WHERE organization.auto_provisioned_for_user_id IS NOT NULL
+      AND organization_membership.id IS NULL;
+
+    IF missing_personal_memberships > 0 THEN
+        RAISE EXCEPTION 'org/project backfill failed: % personal organizations lack owner membership', missing_personal_memberships;
+    END IF;
+
+    SELECT count(*) INTO missing_project_ownerships
+    FROM project
+    LEFT JOIN project_organization_ownership
+      ON project_organization_ownership.project_id = project.id
+     AND project_organization_ownership.organization_id = project.auto_provisioned_for_organization_id
+    WHERE project.auto_provisioned_for_organization_id IS NOT NULL
+      AND project_organization_ownership.id IS NULL;
+
+    IF missing_project_ownerships > 0 THEN
+        RAISE EXCEPTION 'org/project backfill failed: % auto-provisioned projects lack ownership rows', missing_project_ownerships;
+    END IF;
+
+    SELECT count(*) INTO missing_conversation_projects
+    FROM conversation
+    WHERE project_id IS NULL;
+
+    IF missing_conversation_projects > 0 THEN
+        RAISE EXCEPTION 'org/project backfill failed: % conversations still have null project_id', missing_conversation_projects;
+    END IF;
+
+    SELECT count(*) INTO missing_entitlement_organizations
+    FROM premium_feature_entitlement
+    WHERE organization_id IS NULL;
+
+    IF missing_entitlement_organizations > 0 THEN
+        RAISE EXCEPTION 'org/project backfill failed: % premium entitlements still have null organization_id', missing_entitlement_organizations;
+    END IF;
+END $$;

--- a/services/api/database/flyway/V0071__abnormal_dakota_north.sql
+++ b/services/api/database/flyway/V0071__abnormal_dakota_north.sql
@@ -1,0 +1,69 @@
+CREATE TYPE "public"."directory_visibility" AS ENUM('listed', 'unlisted');--> statement-breakpoint
+CREATE TYPE "public"."organization_membership_all_project_capability_enum" AS ENUM('project_update', 'project_delete', 'project_manage_owner_organizations', 'conversation_create', 'conversation_update', 'conversation_delete', 'conversation_view_private_results', 'conversation_export_owner_data', 'conversation_moderate', 'conversation_manage_integrations');--> statement-breakpoint
+CREATE TYPE "public"."organization_membership_capability_enum" AS ENUM('organization_manage_members', 'organization_manage_profile', 'project_create');--> statement-breakpoint
+CREATE TABLE "organization_membership_all_project_capability" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "organization_membership_all_project_capability_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"organization_membership_id" integer NOT NULL,
+	"capability" "organization_membership_all_project_capability_enum" NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "organization_membership_all_project_capability_unique" UNIQUE("organization_membership_id","capability")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_membership_capability" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "organization_membership_capability_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"organization_membership_id" integer NOT NULL,
+	"capability" "organization_membership_capability_enum" NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "organization_membership_capability_unique" UNIQUE("organization_membership_id","capability")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_membership" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "organization_membership_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"user_id" uuid NOT NULL,
+	"organization_id" integer NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	"updated_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "organization_membership_user_organization_unique" UNIQUE("user_id","organization_id")
+);
+--> statement-breakpoint
+CREATE TABLE "project_organization_ownership" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "project_organization_ownership_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"project_id" integer NOT NULL,
+	"organization_id" integer NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "project_organization_ownership_project_org_unique" UNIQUE("project_id","organization_id")
+);
+--> statement-breakpoint
+CREATE TABLE "project" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "project_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"slug" varchar(65) NOT NULL,
+	"display_name" varchar(65) NOT NULL,
+	"directory_visibility" "directory_visibility" NOT NULL,
+	"auto_provisioned_for_organization_id" integer,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	"updated_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "project_slug_unique" UNIQUE("slug"),
+	CONSTRAINT "project_auto_provisioned_for_organization_id_unique" UNIQUE("auto_provisioned_for_organization_id")
+);
+--> statement-breakpoint
+ALTER TABLE "conversation" ADD COLUMN "project_id" integer;--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "slug" varchar(65);--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "display_name" varchar(65);--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "directory_visibility" "directory_visibility";--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "auto_provisioned_for_user_id" uuid;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "first_name" varchar(65);--> statement-breakpoint
+ALTER TABLE "organization_membership_all_project_capability" ADD CONSTRAINT "organization_membership_all_project_capability_organization_membership_id_organization_membership_id_fk" FOREIGN KEY ("organization_membership_id") REFERENCES "public"."organization_membership"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_membership_capability" ADD CONSTRAINT "organization_membership_capability_organization_membership_id_organization_membership_id_fk" FOREIGN KEY ("organization_membership_id") REFERENCES "public"."organization_membership"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_membership" ADD CONSTRAINT "organization_membership_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_membership" ADD CONSTRAINT "organization_membership_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_organization_ownership" ADD CONSTRAINT "project_organization_ownership_project_id_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."project"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_organization_ownership" ADD CONSTRAINT "project_organization_ownership_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project" ADD CONSTRAINT "project_auto_provisioned_for_organization_id_organization_id_fk" FOREIGN KEY ("auto_provisioned_for_organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "organization_membership_organization_idx" ON "organization_membership" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "project_organization_ownership_organization_idx" ON "project_organization_ownership" USING btree ("organization_id");--> statement-breakpoint
+ALTER TABLE "conversation" ADD CONSTRAINT "conversation_project_id_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."project"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_auto_provisioned_for_user_id_user_id_fk" FOREIGN KEY ("auto_provisioned_for_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "conversation_project_id_idx" ON "conversation" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "conversation_project_timeline_idx" ON "conversation" USING btree ("project_id","is_importing","created_at" DESC,"id" DESC) WHERE "conversation"."current_content_id" is not null;--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_slug_unique" UNIQUE("slug");--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_auto_provisioned_for_user_id_unique" UNIQUE("auto_provisioned_for_user_id");

--- a/services/api/database/flyway/V0072__nervous_killraven.sql
+++ b/services/api/database/flyway/V0072__nervous_killraven.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "user_organization_mapping" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "user_organization_mapping" CASCADE;--> statement-breakpoint
+ALTER TABLE "organization" DROP CONSTRAINT "organization_name_unique";--> statement-breakpoint
+ALTER TABLE "premium_feature_entitlement" DROP CONSTRAINT "premium_feature_entitlement_single_subject_check";--> statement-breakpoint
+ALTER TABLE "conversation" DROP CONSTRAINT "conversation_author_id_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "conversation" DROP CONSTRAINT "conversation_organization_id_organization_id_fk";
+--> statement-breakpoint
+ALTER TABLE "premium_feature_entitlement" DROP CONSTRAINT "premium_feature_entitlement_user_id_user_id_fk";
+--> statement-breakpoint
+DROP INDEX "conversation_author_timeline_idx";--> statement-breakpoint
+DROP INDEX "conversation_organization_timeline_idx";--> statement-breakpoint
+DROP INDEX "premium_feature_entitlement_user_idx";--> statement-breakpoint
+ALTER TABLE "conversation" ALTER COLUMN "project_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "organization" ALTER COLUMN "slug" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "organization" ALTER COLUMN "display_name" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "organization" ALTER COLUMN "directory_visibility" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "premium_feature_entitlement" ALTER COLUMN "organization_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "first_name" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation" DROP COLUMN "author_id";--> statement-breakpoint
+ALTER TABLE "conversation" DROP COLUMN "organization_id";--> statement-breakpoint
+ALTER TABLE "organization" DROP COLUMN "name";--> statement-breakpoint
+ALTER TABLE "premium_feature_entitlement" DROP COLUMN "user_id";

--- a/services/api/drizzle/0070_abnormal_dakota_north.sql
+++ b/services/api/drizzle/0070_abnormal_dakota_north.sql
@@ -1,0 +1,69 @@
+CREATE TYPE "public"."directory_visibility" AS ENUM('listed', 'unlisted');--> statement-breakpoint
+CREATE TYPE "public"."organization_membership_all_project_capability_enum" AS ENUM('project_update', 'project_delete', 'project_manage_owner_organizations', 'conversation_create', 'conversation_update', 'conversation_delete', 'conversation_view_private_results', 'conversation_export_owner_data', 'conversation_moderate', 'conversation_manage_integrations');--> statement-breakpoint
+CREATE TYPE "public"."organization_membership_capability_enum" AS ENUM('organization_manage_members', 'organization_manage_profile', 'project_create');--> statement-breakpoint
+CREATE TABLE "organization_membership_all_project_capability" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "organization_membership_all_project_capability_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"organization_membership_id" integer NOT NULL,
+	"capability" "organization_membership_all_project_capability_enum" NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "organization_membership_all_project_capability_unique" UNIQUE("organization_membership_id","capability")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_membership_capability" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "organization_membership_capability_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"organization_membership_id" integer NOT NULL,
+	"capability" "organization_membership_capability_enum" NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "organization_membership_capability_unique" UNIQUE("organization_membership_id","capability")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_membership" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "organization_membership_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"user_id" uuid NOT NULL,
+	"organization_id" integer NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	"updated_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "organization_membership_user_organization_unique" UNIQUE("user_id","organization_id")
+);
+--> statement-breakpoint
+CREATE TABLE "project_organization_ownership" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "project_organization_ownership_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"project_id" integer NOT NULL,
+	"organization_id" integer NOT NULL,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "project_organization_ownership_project_org_unique" UNIQUE("project_id","organization_id")
+);
+--> statement-breakpoint
+CREATE TABLE "project" (
+	"id" integer PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "project_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 2147483647 START WITH 1 CACHE 1),
+	"slug" varchar(65) NOT NULL,
+	"display_name" varchar(65) NOT NULL,
+	"directory_visibility" "directory_visibility" NOT NULL,
+	"auto_provisioned_for_organization_id" integer,
+	"created_at" timestamp (0) DEFAULT now() NOT NULL,
+	"updated_at" timestamp (0) DEFAULT now() NOT NULL,
+	CONSTRAINT "project_slug_unique" UNIQUE("slug"),
+	CONSTRAINT "project_auto_provisioned_for_organization_id_unique" UNIQUE("auto_provisioned_for_organization_id")
+);
+--> statement-breakpoint
+ALTER TABLE "conversation" ADD COLUMN "project_id" integer;--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "slug" varchar(65);--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "display_name" varchar(65);--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "directory_visibility" "directory_visibility";--> statement-breakpoint
+ALTER TABLE "organization" ADD COLUMN "auto_provisioned_for_user_id" uuid;--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "first_name" varchar(65);--> statement-breakpoint
+ALTER TABLE "organization_membership_all_project_capability" ADD CONSTRAINT "organization_membership_all_project_capability_organization_membership_id_organization_membership_id_fk" FOREIGN KEY ("organization_membership_id") REFERENCES "public"."organization_membership"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_membership_capability" ADD CONSTRAINT "organization_membership_capability_organization_membership_id_organization_membership_id_fk" FOREIGN KEY ("organization_membership_id") REFERENCES "public"."organization_membership"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_membership" ADD CONSTRAINT "organization_membership_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_membership" ADD CONSTRAINT "organization_membership_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_organization_ownership" ADD CONSTRAINT "project_organization_ownership_project_id_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."project"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_organization_ownership" ADD CONSTRAINT "project_organization_ownership_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project" ADD CONSTRAINT "project_auto_provisioned_for_organization_id_organization_id_fk" FOREIGN KEY ("auto_provisioned_for_organization_id") REFERENCES "public"."organization"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "organization_membership_organization_idx" ON "organization_membership" USING btree ("organization_id");--> statement-breakpoint
+CREATE INDEX "project_organization_ownership_organization_idx" ON "project_organization_ownership" USING btree ("organization_id");--> statement-breakpoint
+ALTER TABLE "conversation" ADD CONSTRAINT "conversation_project_id_project_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."project"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_auto_provisioned_for_user_id_user_id_fk" FOREIGN KEY ("auto_provisioned_for_user_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "conversation_project_id_idx" ON "conversation" USING btree ("project_id");--> statement-breakpoint
+CREATE INDEX "conversation_project_timeline_idx" ON "conversation" USING btree ("project_id","is_importing","created_at" DESC,"id" DESC) WHERE "conversation"."current_content_id" is not null;--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_slug_unique" UNIQUE("slug");--> statement-breakpoint
+ALTER TABLE "organization" ADD CONSTRAINT "organization_auto_provisioned_for_user_id_unique" UNIQUE("auto_provisioned_for_user_id");

--- a/services/api/drizzle/0071_nervous_killraven.sql
+++ b/services/api/drizzle/0071_nervous_killraven.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "user_organization_mapping" DISABLE ROW LEVEL SECURITY;--> statement-breakpoint
+DROP TABLE "user_organization_mapping" CASCADE;--> statement-breakpoint
+ALTER TABLE "organization" DROP CONSTRAINT "organization_name_unique";--> statement-breakpoint
+ALTER TABLE "premium_feature_entitlement" DROP CONSTRAINT "premium_feature_entitlement_single_subject_check";--> statement-breakpoint
+ALTER TABLE "conversation" DROP CONSTRAINT "conversation_author_id_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "conversation" DROP CONSTRAINT "conversation_organization_id_organization_id_fk";
+--> statement-breakpoint
+ALTER TABLE "premium_feature_entitlement" DROP CONSTRAINT "premium_feature_entitlement_user_id_user_id_fk";
+--> statement-breakpoint
+DROP INDEX "conversation_author_timeline_idx";--> statement-breakpoint
+DROP INDEX "conversation_organization_timeline_idx";--> statement-breakpoint
+DROP INDEX "premium_feature_entitlement_user_idx";--> statement-breakpoint
+ALTER TABLE "conversation" ALTER COLUMN "project_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "organization" ALTER COLUMN "slug" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "organization" ALTER COLUMN "display_name" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "organization" ALTER COLUMN "directory_visibility" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "premium_feature_entitlement" ALTER COLUMN "organization_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "first_name" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "conversation" DROP COLUMN "author_id";--> statement-breakpoint
+ALTER TABLE "conversation" DROP COLUMN "organization_id";--> statement-breakpoint
+ALTER TABLE "organization" DROP COLUMN "name";--> statement-breakpoint
+ALTER TABLE "premium_feature_entitlement" DROP COLUMN "user_id";

--- a/services/api/drizzle/meta/0070_snapshot.json
+++ b/services/api/drizzle/meta/0070_snapshot.json
@@ -1,0 +1,12500 @@
+{
+  "id": "b4151289-cd82-4269-b057-4905bca6bdf5",
+  "prevId": "e7ec5c0a-95ba-40db-a5f1-02aa2195cae9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analysis_input_snapshot": {
+      "name": "analysis_input_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_input_snapshot_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_generation": {
+          "name": "data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_count": {
+          "name": "opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compression": {
+          "name": "compression",
+          "type": "analysis_compression_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_input_snapshot_conversation_idx": {
+          "name": "analysis_input_snapshot_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_input_snapshot_conversation_id_conversation_id_fk": {
+          "name": "analysis_input_snapshot_conversation_id_conversation_id_fk",
+          "tableFrom": "analysis_input_snapshot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_input_snapshot_hash_unique": {
+          "name": "analysis_input_snapshot_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "data_generation",
+            "input_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "analysis_input_snapshot_counts_check": {
+          "name": "analysis_input_snapshot_counts_check",
+          "value": "\"analysis_input_snapshot\".\"opinion_count\" >= 0 AND \"analysis_input_snapshot\".\"participant_count\" >= 0 AND \"analysis_input_snapshot\".\"vote_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_snapshot_opinion": {
+      "name": "analysis_snapshot_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_snapshot_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_snapshot_id": {
+          "name": "analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_content_id": {
+          "name": "opinion_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_opinion_index": {
+          "name": "local_opinion_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_passes": {
+          "name": "num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "routing_priority": {
+          "name": "routing_priority",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "analysis_snapshot_opinion_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "analysis_snapshot_opinion_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "analysis_snapshot_opinion",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_opinion_opinion_id_opinion_id_fk": {
+          "name": "analysis_snapshot_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "analysis_snapshot_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_opinion_opinion_content_id_opinion_content_id_fk": {
+          "name": "analysis_snapshot_opinion_opinion_content_id_opinion_content_id_fk",
+          "tableFrom": "analysis_snapshot_opinion",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "opinion_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_snapshot_opinion_unique": {
+          "name": "analysis_snapshot_opinion_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_snapshot_id",
+            "opinion_id"
+          ]
+        },
+        "analysis_snapshot_opinion_local_idx_unique": {
+          "name": "analysis_snapshot_opinion_local_idx_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_snapshot_id",
+            "local_opinion_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_snapshot_result": {
+      "name": "analysis_snapshot_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_snapshot_result_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_id": {
+          "name": "analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "analysis_result_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_reason": {
+          "name": "outcome_reason",
+          "type": "analysis_insufficient_data_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variants_enabled": {
+          "name": "variants_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "analysis_snapshot_result_conversation_id_conversation_id_fk": {
+          "name": "analysis_snapshot_result_conversation_id_conversation_id_fk",
+          "tableFrom": "analysis_snapshot_result",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_result_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "analysis_snapshot_result_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "analysis_snapshot_result",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_result_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "analysis_snapshot_result_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "analysis_snapshot_result",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_snapshot_result_spec_unique": {
+          "name": "analysis_snapshot_result_spec_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_snapshot_id",
+            "opinion_group_spec_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "analysis_snapshot_result_reason_check": {
+          "name": "analysis_snapshot_result_reason_check",
+          "value": "(\"analysis_snapshot_result\".\"outcome\" = 'insufficient_data' AND \"analysis_snapshot_result\".\"outcome_reason\" IS NOT NULL) OR (\"analysis_snapshot_result\".\"outcome\" = 'success' AND \"analysis_snapshot_result\".\"outcome_reason\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_snapshot": {
+      "name": "analysis_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_snapshot_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_snapshot_id": {
+          "name": "input_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_generation": {
+          "name": "data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_snapshot_latest_idx": {
+          "name": "analysis_snapshot_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_snapshot_conversation_id_conversation_id_fk": {
+          "name": "analysis_snapshot_conversation_id_conversation_id_fk",
+          "tableFrom": "analysis_snapshot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_conversation_content_id_conversation_content_id_fk": {
+          "name": "analysis_snapshot_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "analysis_snapshot",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_input_snapshot_id_analysis_input_snapshot_id_fk": {
+          "name": "analysis_snapshot_input_snapshot_id_analysis_input_snapshot_id_fk",
+          "tableFrom": "analysis_snapshot",
+          "tableTo": "analysis_input_snapshot",
+          "columnsFrom": [
+            "input_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_spec": {
+      "name": "analysis_spec",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_spec_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_family": {
+          "name": "analysis_family",
+          "type": "analysis_family_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_work_state": {
+      "name": "analysis_work_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_work_state_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_completed_data_generation": {
+          "name": "last_completed_data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "running_data_generation": {
+          "name": "running_data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persisted_analysis_snapshot_id": {
+          "name": "persisted_analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dirty_since": {
+          "name": "dirty_since",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_generation": {
+          "name": "attempt_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "non_retryable_generation": {
+          "name": "non_retryable_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_retryable_analysis_engine_epoch": {
+          "name": "non_retryable_analysis_engine_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_kind": {
+          "name": "last_error_kind",
+          "type": "analysis_work_error_kind_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_stack_hash": {
+          "name": "last_error_stack_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_work_state_lease_expiry_idx": {
+          "name": "analysis_work_state_lease_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"analysis_work_state\".\"running_data_generation\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_work_state_running_conversation_unique": {
+          "name": "analysis_work_state_running_conversation_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"analysis_work_state\".\"running_data_generation\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_work_state_conversation_id_conversation_id_fk": {
+          "name": "analysis_work_state_conversation_id_conversation_id_fk",
+          "tableFrom": "analysis_work_state",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_work_state_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "analysis_work_state_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "analysis_work_state",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_work_state_persisted_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "analysis_work_state_persisted_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "analysis_work_state",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "persisted_analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_work_state_conversation_spec_unique": {
+          "name": "analysis_work_state_conversation_spec_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "opinion_group_spec_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "analysis_work_state_running_lease_check": {
+          "name": "analysis_work_state_running_lease_check",
+          "value": "((\"analysis_work_state\".\"running_data_generation\" is null AND \"analysis_work_state\".\"lease_owner\" is null AND \"analysis_work_state\".\"lease_token\" is null AND \"analysis_work_state\".\"lease_expires_at\" is null) OR (\"analysis_work_state\".\"running_data_generation\" is not null AND \"analysis_work_state\".\"lease_owner\" is not null AND \"analysis_work_state\".\"lease_token\" is not null AND \"analysis_work_state\".\"lease_expires_at\" is not null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_attempt_email": {
+      "name": "auth_attempt_email",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_reachability": {
+          "name": "email_reachability",
+          "type": "email_reachability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_attempt_email_canonical_check": {
+          "name": "auth_attempt_email_canonical_check",
+          "value": "\"auth_attempt_email\".\"email\" = lower(btrim(\"auth_attempt_email\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_attempt_phone": {
+      "name": "auth_attempt_phone",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"auth_attempt_phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_content": {
+      "name": "conversation_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_content_conversation_id_conversation_id_fk": {
+          "name": "conversation_content_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_content",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_artifact": {
+      "name": "conversation_export_artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_artifact_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "export_file_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "export_file_audience_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "export_artifact_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_artifact_generation_idx": {
+          "name": "conversation_export_artifact_generation_idx",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_artifact_shared_unique": {
+          "name": "conversation_export_artifact_shared_unique",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_artifact\".\"subject_user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_artifact_requester_unique": {
+          "name": "conversation_export_artifact_requester_unique",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_artifact\".\"subject_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_artifact_generation_id_conversation_export_generation_id_fk": {
+          "name": "conversation_export_artifact_generation_id_conversation_export_generation_id_fk",
+          "tableFrom": "conversation_export_artifact",
+          "tableTo": "conversation_export_generation",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_artifact_subject_user_id_user_id_fk": {
+          "name": "conversation_export_artifact_subject_user_id_user_id_fk",
+          "tableFrom": "conversation_export_artifact",
+          "tableTo": "user",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_generation": {
+      "name": "conversation_export_generation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_generation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_generation_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collecting'"
+        },
+        "collecting_ends_at": {
+          "name": "collecting_ends_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_generation_conversation_idx": {
+          "name": "conversation_export_generation_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_collecting_due_idx": {
+          "name": "conversation_export_generation_collecting_due_idx",
+          "columns": [
+            {
+              "expression": "collecting_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_generation\".\"status\" = 'collecting'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_queued_due_idx": {
+          "name": "conversation_export_generation_queued_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_generation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_collecting_unique": {
+          "name": "conversation_export_generation_collecting_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_generation\".\"status\" = 'collecting'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_processing_unique": {
+          "name": "conversation_export_generation_processing_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_generation\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_generation_conversation_id_conversation_id_fk": {
+          "name": "conversation_export_generation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_export_generation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_export_generation_slug_id_unique": {
+          "name": "conversation_export_generation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_request_file": {
+      "name": "conversation_export_request_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_request_file_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "export_file_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "export_file_audience_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_request_file_artifact_idx": {
+          "name": "conversation_export_request_file_artifact_idx",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_file_unique": {
+          "name": "conversation_export_request_file_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_request_file_request_id_conversation_export_request_id_fk": {
+          "name": "conversation_export_request_file_request_id_conversation_export_request_id_fk",
+          "tableFrom": "conversation_export_request_file",
+          "tableTo": "conversation_export_request",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_file_artifact_id_conversation_export_artifact_id_fk": {
+          "name": "conversation_export_request_file_artifact_id_conversation_export_artifact_id_fk",
+          "tableFrom": "conversation_export_request_file",
+          "tableTo": "conversation_export_artifact",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_request": {
+      "name": "conversation_export_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_request_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "export_cancellation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_notified_at": {
+          "name": "started_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_notified_at": {
+          "name": "completed_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_notified_at": {
+          "name": "failed_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_request_conversation_idx": {
+          "name": "conversation_export_request_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_generation_idx": {
+          "name": "conversation_export_request_generation_idx",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_active_history_idx": {
+          "name": "conversation_export_request_active_history_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_expiry_idx": {
+          "name": "conversation_export_request_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_active_unique": {
+          "name": "conversation_export_request_active_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_request\".\"status\" = 'processing' AND \"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_request_conversation_id_conversation_id_fk": {
+          "name": "conversation_export_request_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_generation_id_conversation_export_generation_id_fk": {
+          "name": "conversation_export_request_generation_id_conversation_export_generation_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "conversation_export_generation",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_user_id_user_id_fk": {
+          "name": "conversation_export_request_user_id_user_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_export_request_slug_id_unique": {
+          "name": "conversation_export_request_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_import": {
+      "name": "conversation_import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_import_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "import_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "import_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csv_file_metadata": {
+          "name": "csv_file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_import_status_idx": {
+          "name": "conversation_import_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_created_idx": {
+          "name": "conversation_import_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_user_idx": {
+          "name": "conversation_import_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_active_user_unique": {
+          "name": "conversation_import_active_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_import\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_import_conversation_id_conversation_id_fk": {
+          "name": "conversation_import_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_import",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_import_user_id_user_id_fk": {
+          "name": "conversation_import_user_id_user_id_fk",
+          "tableFrom": "conversation_import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_import_slug_id_unique": {
+          "name": "conversation_import_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_import_conversation_id_unique": {
+          "name": "conversation_import_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_moderation": {
+      "name": "conversation_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "conversation_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_moderation_conversation_id_conversation_id_fk": {
+          "name": "conversation_moderation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_moderation_author_id_user_id_fk": {
+          "name": "conversation_moderation_author_id_user_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_moderation_conversation_id_unique": {
+          "name": "conversation_moderation_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_report": {
+      "name": "conversation_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_id_idx": {
+          "name": "conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_report_conversation_id_conversation_id_fk": {
+          "name": "conversation_report_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_report_author_id_user_id_fk": {
+          "name": "conversation_report_author_id_user_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_ranking_score_id": {
+          "name": "current_ranking_score_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexed": {
+          "name": "is_indexed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "participation_mode": {
+          "name": "participation_mode",
+          "type": "participation_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'account_required'"
+        },
+        "conversation_type": {
+          "name": "conversation_type",
+          "type": "conversation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polis'"
+        },
+        "is_importing": {
+          "name": "is_importing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_event_ticket": {
+          "name": "requires_event_ticket",
+          "type": "event_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_labeling_enabled": {
+          "name": "ai_labeling_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "analysis_data_generation": {
+          "name": "analysis_data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_opinion_group_count": {
+          "name": "preferred_opinion_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_url": {
+          "name": "import_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_conversation_url": {
+          "name": "import_conversation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_export_url": {
+          "name": "import_export_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_created_at": {
+          "name": "import_created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_author": {
+          "name": "import_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_method": {
+          "name": "import_method",
+          "type": "import_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source_config": {
+          "name": "external_source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_feed_idx": {
+          "name": "conversation_feed_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation\".\"is_indexed\" = true AND \"conversation\".\"is_importing\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_type_importing_idx": {
+          "name": "conversation_type_importing_idx",
+          "columns": [
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_author_timeline_idx": {
+          "name": "conversation_author_timeline_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_organization_timeline_idx": {
+          "name": "conversation_organization_timeline_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_project_id_idx": {
+          "name": "conversation_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_project_timeline_idx": {
+          "name": "conversation_project_timeline_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_author_id_user_id_fk": {
+          "name": "conversation_author_id_user_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_organization_id_organization_id_fk": {
+          "name": "conversation_organization_id_organization_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_project_id_project_id_fk": {
+          "name": "conversation_project_id_project_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_content_id_conversation_content_id_fk": {
+          "name": "conversation_current_content_id_conversation_content_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_ranking_score_id_ranking_score_id_fk": {
+          "name": "conversation_current_ranking_score_id_ranking_score_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ranking_score",
+          "columnsFrom": [
+            "current_ranking_score_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_slug_id_unique": {
+          "name": "conversation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_current_content_id_unique": {
+          "name": "conversation_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "conversation_current_ranking_score_id_unique": {
+          "name": "conversation_current_ranking_score_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_ranking_score_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversation_preferred_opinion_group_count_check": {
+          "name": "conversation_preferred_opinion_group_count_check",
+          "value": "\"conversation\".\"preferred_opinion_group_count\" IS NULL OR \"conversation\".\"preferred_opinion_group_count\" >= 2"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_topic": {
+      "name": "conversation_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_topic_conversation_id_conversation_id_fk": {
+          "name": "conversation_topic_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_topic_topic_id_topic_id_fk": {
+          "name": "conversation_topic_topic_id_topic_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_topic_unique": {
+          "name": "conversation_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_view_snapshot_checkpoint_reason": {
+      "name": "conversation_view_snapshot_checkpoint_reason",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_view_snapshot_checkpoint_reason_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_view_snapshot_id": {
+          "name": "conversation_view_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "conversation_view_snapshot_checkpoint_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_count": {
+          "name": "group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_group_count": {
+          "name": "previous_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_milestone": {
+          "name": "participant_milestone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_milestone": {
+          "name": "vote_milestone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_view_snapshot_checkpoint_reason_snapshot_idx": {
+          "name": "conversation_view_snapshot_checkpoint_reason_snapshot_idx",
+          "columns": [
+            {
+              "expression": "conversation_view_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_first_displayable_unique": {
+          "name": "conversation_view_snapshot_checkpoint_first_displayable_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'first_displayable_analysis'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_group_count_unique": {
+          "name": "conversation_view_snapshot_checkpoint_group_count_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'first_group_count_available'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_default_change_unique": {
+          "name": "conversation_view_snapshot_checkpoint_default_change_unique",
+          "columns": [
+            {
+              "expression": "conversation_view_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'default_group_count_changed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_participant_unique": {
+          "name": "conversation_view_snapshot_checkpoint_participant_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "participant_milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'major_participation_milestone'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_vote_unique": {
+          "name": "conversation_view_snapshot_checkpoint_vote_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vote_milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'major_vote_milestone'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_closed_unique": {
+          "name": "conversation_view_snapshot_checkpoint_closed_unique",
+          "columns": [
+            {
+              "expression": "conversation_view_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'conversation_closed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_view_snapshot_checkpoint_reason_conversation_view_snapshot_id_conversation_view_snapshot_id_fk": {
+          "name": "conversation_view_snapshot_checkpoint_reason_conversation_view_snapshot_id_conversation_view_snapshot_id_fk",
+          "tableFrom": "conversation_view_snapshot_checkpoint_reason",
+          "tableTo": "conversation_view_snapshot",
+          "columnsFrom": [
+            "conversation_view_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_checkpoint_reason_conversation_id_conversation_id_fk": {
+          "name": "conversation_view_snapshot_checkpoint_reason_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_view_snapshot_checkpoint_reason",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_checkpoint_reason_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "conversation_view_snapshot_checkpoint_reason_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "conversation_view_snapshot_checkpoint_reason",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_view_snapshot_checkpoint_reason_group_count_check": {
+          "name": "conversation_view_snapshot_checkpoint_reason_group_count_check",
+          "value": "((\"conversation_view_snapshot_checkpoint_reason\".\"reason\" IN ('first_group_count_available', 'default_group_count_changed') AND \"conversation_view_snapshot_checkpoint_reason\".\"group_count\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"group_count\" >= 2 AND (\"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL OR \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" >= 2)) OR (\"conversation_view_snapshot_checkpoint_reason\".\"reason\" NOT IN ('first_group_count_available', 'default_group_count_changed') AND \"conversation_view_snapshot_checkpoint_reason\".\"group_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL))"
+        },
+        "conversation_view_snapshot_checkpoint_reason_milestone_check": {
+          "name": "conversation_view_snapshot_checkpoint_reason_milestone_check",
+          "value": "((\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'major_participation_milestone' AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" >= \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" > 0) OR (\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'major_vote_milestone' AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" >= \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" > 0) OR (\"conversation_view_snapshot_checkpoint_reason\".\"reason\" NOT IN ('major_participation_milestone', 'major_vote_milestone') AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" IS NULL))"
+        },
+        "conversation_view_snapshot_checkpoint_reason_previous_check": {
+          "name": "conversation_view_snapshot_checkpoint_reason_previous_check",
+          "value": "((\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'default_group_count_changed' AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" <> \"conversation_view_snapshot_checkpoint_reason\".\"group_count\" AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" IS NULL) OR (\"conversation_view_snapshot_checkpoint_reason\".\"reason\" <> 'default_group_count_changed' AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_view_snapshot": {
+      "name": "conversation_view_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_view_snapshot_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_id": {
+          "name": "analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survey_aggregate_snapshot_id": {
+          "name": "survey_aggregate_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_reason": {
+          "name": "view_reason",
+          "type": "conversation_view_snapshot_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_opinion_group_count": {
+          "name": "preferred_opinion_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_count": {
+          "name": "opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_vote_count": {
+          "name": "total_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_participant_count": {
+          "name": "total_participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderated_opinion_count": {
+          "name": "moderated_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden_opinion_count": {
+          "name": "hidden_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_view_snapshot_latest_idx": {
+          "name": "conversation_view_snapshot_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_latest_active_idx": {
+          "name": "conversation_view_snapshot_latest_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_view_snapshot\".\"activated_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_latest_spec_active_idx": {
+          "name": "conversation_view_snapshot_latest_spec_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_view_snapshot\".\"activated_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_analysis_snapshot_idx": {
+          "name": "conversation_view_snapshot_analysis_snapshot_idx",
+          "columns": [
+            {
+              "expression": "analysis_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_view_snapshot\".\"analysis_snapshot_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_view_snapshot_conversation_id_conversation_id_fk": {
+          "name": "conversation_view_snapshot_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "conversation_view_snapshot_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "conversation_view_snapshot_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk": {
+          "name": "conversation_view_snapshot_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "survey_aggregate_snapshot",
+          "columnsFrom": [
+            "survey_aggregate_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_conversation_content_id_conversation_content_id_fk": {
+          "name": "conversation_view_snapshot_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_view_snapshot_counts_check": {
+          "name": "conversation_view_snapshot_counts_check",
+          "value": "\"conversation_view_snapshot\".\"opinion_count\" >= 0 AND \"conversation_view_snapshot\".\"vote_count\" >= 0 AND \"conversation_view_snapshot\".\"participant_count\" >= 0 AND \"conversation_view_snapshot\".\"total_opinion_count\" >= 0 AND \"conversation_view_snapshot\".\"total_vote_count\" >= 0 AND \"conversation_view_snapshot\".\"total_participant_count\" >= 0 AND \"conversation_view_snapshot\".\"moderated_opinion_count\" >= 0 AND \"conversation_view_snapshot\".\"hidden_opinion_count\" >= 0"
+        },
+        "conversation_view_snapshot_preferred_opinion_group_count_check": {
+          "name": "conversation_view_snapshot_preferred_opinion_group_count_check",
+          "value": "\"conversation_view_snapshot\".\"preferred_opinion_group_count\" IS NULL OR (\"conversation_view_snapshot\".\"preferred_opinion_group_count\" >= 2 AND \"conversation_view_snapshot\".\"preferred_opinion_group_count\" <= 6)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device": {
+      "name": "device",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_expiry": {
+          "name": "session_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_user_id_user_id_fk": {
+          "name": "device_user_id_user_id_fk",
+          "tableFrom": "device",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email": {
+      "name": "email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "email_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_reachability": {
+          "name": "email_reachability",
+          "type": "email_reachability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_active_unique": {
+          "name": "email_active_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_user_id_user_id_fk": {
+          "name": "email_user_id_user_id_fk",
+          "tableFrom": "email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_canonical_check": {
+          "name": "email_canonical_check",
+          "value": "\"email\".\"email\" = lower(btrim(\"email\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_ticket": {
+      "name": "event_ticket",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_ticket_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "ticket_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_slug": {
+          "name": "event_slug",
+          "type": "event_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pcd_type": {
+          "name": "pcd_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_event_idx": {
+          "name": "user_event_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_ticket_nullifier_event_active_unique": {
+          "name": "event_ticket_nullifier_event_active_unique",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_ticket\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nullifier_idx": {
+          "name": "nullifier_idx",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_ticket_user_id_user_id_fk": {
+          "name": "event_ticket_user_id_user_id_fk",
+          "tableFrom": "event_ticket",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followed_topic": {
+      "name": "followed_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "followed_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "followed_topic_user_id_user_id_fk": {
+          "name": "followed_topic_user_id_user_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "followed_topic_topic_id_topic_id_fk": {
+          "name": "followed_topic_topic_id_topic_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followed_topic_unique": {
+          "name": "followed_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_comparison": {
+      "name": "maxdiff_comparison",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_comparison_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_result_id": {
+          "name": "maxdiff_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "best_slug_id": {
+          "name": "best_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worst_slug_id": {
+          "name": "worst_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_set": {
+          "name": "candidate_set",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "maxdiff_comparison_result_idx": {
+          "name": "maxdiff_comparison_result_idx",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_comparison_active_result_position_unique": {
+          "name": "maxdiff_comparison_active_result_position_unique",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"maxdiff_comparison\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_comparison_maxdiff_result_id_maxdiff_result_id_fk": {
+          "name": "maxdiff_comparison_maxdiff_result_id_maxdiff_result_id_fk",
+          "tableFrom": "maxdiff_comparison",
+          "tableTo": "maxdiff_result",
+          "columnsFrom": [
+            "maxdiff_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item_content": {
+      "name": "maxdiff_item_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_item_id": {
+          "name": "maxdiff_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maxdiff_item_content_maxdiff_item_id_maxdiff_item_id_fk": {
+          "name": "maxdiff_item_content_maxdiff_item_id_maxdiff_item_id_fk",
+          "tableFrom": "maxdiff_item_content",
+          "tableTo": "maxdiff_item",
+          "columnsFrom": [
+            "maxdiff_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "maxdiff_item_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "maxdiff_item_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item_external_source": {
+      "name": "maxdiff_item_external_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_external_source_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_item_id": {
+          "name": "maxdiff_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "external_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_metadata": {
+          "name": "external_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_external_source_dedup_idx": {
+          "name": "maxdiff_external_source_dedup_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_item_external_source_maxdiff_item_id_maxdiff_item_id_fk": {
+          "name": "maxdiff_item_external_source_maxdiff_item_id_maxdiff_item_id_fk",
+          "tableFrom": "maxdiff_item_external_source",
+          "tableTo": "maxdiff_item",
+          "columnsFrom": [
+            "maxdiff_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_external_source_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_item_external_source_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_item_external_source",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_item_external_source_maxdiff_item_id_unique": {
+          "name": "maxdiff_item_external_source_maxdiff_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "maxdiff_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item": {
+      "name": "maxdiff_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "maxdiff_lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "snapshot_score": {
+          "name": "snapshot_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_rank": {
+          "name": "snapshot_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_participant_count": {
+          "name": "snapshot_participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_item_conversation_active_idx": {
+          "name": "maxdiff_item_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_item_lifecycle_idx": {
+          "name": "maxdiff_item_lifecycle_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_item_author_id_user_id_fk": {
+          "name": "maxdiff_item_author_id_user_id_fk",
+          "tableFrom": "maxdiff_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_item_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_item",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_item_slug_id_unique": {
+          "name": "maxdiff_item_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_result": {
+      "name": "maxdiff_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_result_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ranking": {
+          "name": "ranking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comparisons": {
+          "name": "comparisons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_result_complete_idx": {
+          "name": "maxdiff_result_complete_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_complete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_result_conversation_idx": {
+          "name": "maxdiff_result_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_result_participant_id_user_id_fk": {
+          "name": "maxdiff_result_participant_id_user_id_fk",
+          "tableFrom": "maxdiff_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_result_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_result_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_result",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_result_participant_id_conversation_id_unique": {
+          "name": "maxdiff_result_participant_id_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_user_entity_score": {
+      "name": "maxdiff_user_entity_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_user_entity_score_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_result_id": {
+          "name": "maxdiff_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug_id": {
+          "name": "entity_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_left": {
+          "name": "uncertainty_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_right": {
+          "name": "uncertainty_right",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "maxdiff_user_entity_score_result_score_idx": {
+          "name": "maxdiff_user_entity_score_result_score_idx",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"score\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_user_entity_score_maxdiff_result_id_maxdiff_result_id_fk": {
+          "name": "maxdiff_user_entity_score_maxdiff_result_id_maxdiff_result_id_fk",
+          "tableFrom": "maxdiff_user_entity_score",
+          "tableTo": "maxdiff_result",
+          "columnsFrom": [
+            "maxdiff_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_user_entity_score_maxdiff_result_id_entity_slug_id_unique": {
+          "name": "maxdiff_user_entity_score_maxdiff_result_id_entity_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "maxdiff_result_id",
+            "entity_slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_export": {
+      "name": "notification_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_export_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_request_id": {
+          "name": "export_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_slug_id": {
+          "name": "export_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "export_cancellation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_export_notification_idx": {
+          "name": "notification_export_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_export_notification_id_notification_id_fk": {
+          "name": "notification_export_notification_id_notification_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_export_export_request_id_conversation_export_request_id_fk": {
+          "name": "notification_export_export_request_id_conversation_export_request_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "conversation_export_request",
+          "columnsFrom": [
+            "export_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_export_conversation_id_conversation_id_fk": {
+          "name": "notification_export_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_import": {
+      "name": "notification_import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_import_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_id": {
+          "name": "import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_import_notification_idx": {
+          "name": "notification_import_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_import_notification_id_notification_id_fk": {
+          "name": "notification_import_notification_id_notification_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_import_import_id_conversation_import_id_fk": {
+          "name": "notification_import_import_id_conversation_import_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "conversation_import",
+          "columnsFrom": [
+            "import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_import_conversation_id_conversation_id_fk": {
+          "name": "notification_import_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_new_opinion": {
+      "name": "notification_new_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_new_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_new_opinion_notification_idx": {
+          "name": "notification_new_opinion_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_new_opinion_notification_id_notification_id_fk": {
+          "name": "notification_new_opinion_notification_id_notification_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_author_id_user_id_fk": {
+          "name": "notification_new_opinion_author_id_user_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_opinion_id_opinion_id_fk": {
+          "name": "notification_new_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_conversation_id_conversation_id_fk": {
+          "name": "notification_new_opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_opinion_vote": {
+      "name": "notification_opinion_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_opinion_vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_votes": {
+          "name": "num_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_opinion_vote_notification_idx": {
+          "name": "notification_opinion_vote_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_opinion_vote_notification_id_notification_id_fk": {
+          "name": "notification_opinion_vote_notification_id_notification_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_opinion_id_opinion_id_fk": {
+          "name": "notification_opinion_vote_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_conversation_id_conversation_id_fk": {
+          "name": "notification_opinion_vote_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_created_id_idx": {
+          "name": "notification_user_created_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_slug_id_unique": {
+          "name": "notification_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_content": {
+      "name": "opinion_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_content_opinion_id_opinion_id_fk": {
+          "name": "opinion_content_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "opinion_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_candidate_assessment": {
+      "name": "opinion_group_candidate_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_candidate_assessment_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "silhouette_score": {
+          "name": "silhouette_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coefficient_of_variation": {
+          "name": "coefficient_of_variation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_score": {
+          "name": "balance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selection_score": {
+          "name": "selection_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "opinion_group_candidate_hidden_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_candidate_assessment_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_candidate_assessment_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_candidate_assessment",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_assessment_candidate_id_unique": {
+          "name": "opinion_group_candidate_assessment_candidate_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_candidate_description_locale_request": {
+      "name": "opinion_group_candidate_description_locale_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_candidate_description_locale_request_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_group_candidate_description_locale_request_updated_idx": {
+          "name": "opinion_group_candidate_description_locale_request_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "og_candidate_desc_locale_request_translation_updated_idx": {
+          "name": "og_candidate_desc_locale_request_translation_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_candidate_description_locale_request\".\"locale\" <> 'en'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_group_candidate_description_locale_request_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_candidate_description_locale_request_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_candidate_description_locale_request",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_description_locale_request_unique": {
+          "name": "opinion_group_candidate_description_locale_request_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "locale"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_candidate_opinion_metrics": {
+      "name": "opinion_group_candidate_opinion_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_candidate_opinion_metrics_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_opinion_id": {
+          "name": "analysis_snapshot_opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_aware_consensus_agree": {
+          "name": "group_aware_consensus_agree",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_aware_consensus_disagree": {
+          "name": "group_aware_consensus_disagree",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "divisiveness": {
+          "name": "divisiveness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "majority_type": {
+          "name": "majority_type",
+          "type": "vote_enum_simple",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "majority_probability_success": {
+          "name": "majority_probability_success",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_rank": {
+          "name": "agreement_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disagreement_rank": {
+          "name": "disagreement_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "divisiveness_rank": {
+          "name": "divisiveness_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_candidate_opinion_metrics_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_candidate_opinion_metrics_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_candidate_opinion_metrics",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_candidate_opinion_metrics_analysis_snapshot_opinion_id_analysis_snapshot_opinion_id_fk": {
+          "name": "opinion_group_candidate_opinion_metrics_analysis_snapshot_opinion_id_analysis_snapshot_opinion_id_fk",
+          "tableFrom": "opinion_group_candidate_opinion_metrics",
+          "tableTo": "analysis_snapshot_opinion",
+          "columnsFrom": [
+            "analysis_snapshot_opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_opinion_metrics_unique": {
+          "name": "opinion_group_candidate_opinion_metrics_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "analysis_snapshot_opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_candidate_opinion_metrics_majority_check": {
+          "name": "opinion_group_candidate_opinion_metrics_majority_check",
+          "value": "(\"opinion_group_candidate_opinion_metrics\".\"majority_type\" IS NULL AND \"opinion_group_candidate_opinion_metrics\".\"majority_probability_success\" IS NULL) OR (\"opinion_group_candidate_opinion_metrics\".\"majority_type\" IS NOT NULL AND \"opinion_group_candidate_opinion_metrics\".\"majority_probability_success\" IS NOT NULL)"
+        },
+        "opinion_group_candidate_opinion_metrics_rank_check": {
+          "name": "opinion_group_candidate_opinion_metrics_rank_check",
+          "value": "(\"opinion_group_candidate_opinion_metrics\".\"agreement_rank\" IS NULL OR \"opinion_group_candidate_opinion_metrics\".\"agreement_rank\" > 0) AND (\"opinion_group_candidate_opinion_metrics\".\"disagreement_rank\" IS NULL OR \"opinion_group_candidate_opinion_metrics\".\"disagreement_rank\" > 0) AND (\"opinion_group_candidate_opinion_metrics\".\"divisiveness_rank\" IS NULL OR \"opinion_group_candidate_opinion_metrics\".\"divisiveness_rank\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_candidate": {
+      "name": "opinion_group_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_candidate_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "snapshot_result_id": {
+          "name": "snapshot_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_variant_id": {
+          "name": "opinion_group_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "analysis_result_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_reason": {
+          "name": "outcome_reason",
+          "type": "analysis_insufficient_data_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_output": {
+          "name": "raw_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_candidate_snapshot_result_id_analysis_snapshot_result_id_fk": {
+          "name": "opinion_group_candidate_snapshot_result_id_analysis_snapshot_result_id_fk",
+          "tableFrom": "opinion_group_candidate",
+          "tableTo": "analysis_snapshot_result",
+          "columnsFrom": [
+            "snapshot_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_candidate_opinion_group_variant_id_opinion_group_variant_id_fk": {
+          "name": "opinion_group_candidate_opinion_group_variant_id_opinion_group_variant_id_fk",
+          "tableFrom": "opinion_group_candidate",
+          "tableTo": "opinion_group_variant",
+          "columnsFrom": [
+            "opinion_group_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_candidate_scope_id_opinion_group_lineage_scope_id_fk": {
+          "name": "opinion_group_candidate_scope_id_opinion_group_lineage_scope_id_fk",
+          "tableFrom": "opinion_group_candidate",
+          "tableTo": "opinion_group_lineage_scope",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_variant_unique": {
+          "name": "opinion_group_candidate_variant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "snapshot_result_id",
+            "opinion_group_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_candidate_reason_check": {
+          "name": "opinion_group_candidate_reason_check",
+          "value": "(\"opinion_group_candidate\".\"outcome\" = 'insufficient_data' AND \"opinion_group_candidate\".\"outcome_reason\" IS NOT NULL) OR (\"opinion_group_candidate\".\"outcome\" = 'success' AND \"opinion_group_candidate\".\"outcome_reason\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_description": {
+      "name": "opinion_group_description",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_description_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_description_translation": {
+      "name": "opinion_group_description_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_description_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description_id": {
+          "name": "description_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_description_translation_description_id_opinion_group_description_id_fk": {
+          "name": "opinion_group_description_translation_description_id_opinion_group_description_id_fk",
+          "tableFrom": "opinion_group_description_translation",
+          "tableTo": "opinion_group_description",
+          "columnsFrom": [
+            "description_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_description_translation_unique": {
+          "name": "opinion_group_description_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description_id",
+            "locale"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_description_translation_work": {
+      "name": "opinion_group_description_translation_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_description_translation_work_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description_id": {
+          "name": "description_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_retryable_ai_description_epoch": {
+          "name": "non_retryable_ai_description_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_group_description_translation_work_lease_expiry_idx": {
+          "name": "opinion_group_description_translation_work_lease_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_description_translation_work\".\"lease_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_group_description_translation_work_claim_idx": {
+          "name": "opinion_group_description_translation_work_claim_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_description_translation_work\".\"lease_token\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_group_description_translation_work_description_id_opinion_group_description_id_fk": {
+          "name": "opinion_group_description_translation_work_description_id_opinion_group_description_id_fk",
+          "tableFrom": "opinion_group_description_translation_work",
+          "tableTo": "opinion_group_description",
+          "columnsFrom": [
+            "description_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_description_translation_work_conversation_id_conversation_id_fk": {
+          "name": "opinion_group_description_translation_work_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion_group_description_translation_work",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_description_translation_work_unique": {
+          "name": "opinion_group_description_translation_work_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description_id",
+            "locale"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_description_translation_work_running_lease_check": {
+          "name": "opinion_group_description_translation_work_running_lease_check",
+          "value": "((\"opinion_group_description_translation_work\".\"lease_owner\" is null AND \"opinion_group_description_translation_work\".\"lease_token\" is null AND \"opinion_group_description_translation_work\".\"lease_expires_at\" is null) OR (\"opinion_group_description_translation_work\".\"lease_owner\" is not null AND \"opinion_group_description_translation_work\".\"lease_token\" is not null AND \"opinion_group_description_translation_work\".\"lease_expires_at\" is not null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_lineage_description_work": {
+      "name": "opinion_group_lineage_description_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_lineage_description_work_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_candidate_id": {
+          "name": "source_candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_retryable_ai_description_epoch": {
+          "name": "non_retryable_ai_description_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_group_lineage_description_work_lease_expiry_idx": {
+          "name": "opinion_group_lineage_description_work_lease_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_lineage_description_work\".\"lease_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_group_lineage_description_work_claim_idx": {
+          "name": "opinion_group_lineage_description_work_claim_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_lineage_description_work\".\"lease_token\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_group_lineage_description_work_lineage_id_opinion_group_lineage_id_fk": {
+          "name": "opinion_group_lineage_description_work_lineage_id_opinion_group_lineage_id_fk",
+          "tableFrom": "opinion_group_lineage_description_work",
+          "tableTo": "opinion_group_lineage",
+          "columnsFrom": [
+            "lineage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_description_work_conversation_id_conversation_id_fk": {
+          "name": "opinion_group_lineage_description_work_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion_group_lineage_description_work",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_description_work_source_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_lineage_description_work_source_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_lineage_description_work",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "source_candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_lineage_description_work_unique": {
+          "name": "opinion_group_lineage_description_work_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_lineage_description_work_running_lease_check": {
+          "name": "opinion_group_lineage_description_work_running_lease_check",
+          "value": "((\"opinion_group_lineage_description_work\".\"lease_owner\" is null AND \"opinion_group_lineage_description_work\".\"lease_token\" is null AND \"opinion_group_lineage_description_work\".\"lease_expires_at\" is null) OR (\"opinion_group_lineage_description_work\".\"lease_owner\" is not null AND \"opinion_group_lineage_description_work\".\"lease_token\" is not null AND \"opinion_group_lineage_description_work\".\"lease_expires_at\" is not null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_lineage_scope": {
+      "name": "opinion_group_lineage_scope",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_lineage_scope_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_variant_id": {
+          "name": "opinion_group_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_lineage_scope_conversation_id_conversation_id_fk": {
+          "name": "opinion_group_lineage_scope_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion_group_lineage_scope",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_scope_opinion_group_variant_id_opinion_group_variant_id_fk": {
+          "name": "opinion_group_lineage_scope_opinion_group_variant_id_opinion_group_variant_id_fk",
+          "tableFrom": "opinion_group_lineage_scope",
+          "tableTo": "opinion_group_variant",
+          "columnsFrom": [
+            "opinion_group_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_lineage_scope_unique": {
+          "name": "opinion_group_lineage_scope_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "opinion_group_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_lineage": {
+      "name": "opinion_group_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_lineage_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_description_id": {
+          "name": "system_description_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_description_id": {
+          "name": "admin_description_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_lineage_scope_id_opinion_group_lineage_scope_id_fk": {
+          "name": "opinion_group_lineage_scope_id_opinion_group_lineage_scope_id_fk",
+          "tableFrom": "opinion_group_lineage",
+          "tableTo": "opinion_group_lineage_scope",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_system_description_id_opinion_group_description_id_fk": {
+          "name": "opinion_group_lineage_system_description_id_opinion_group_description_id_fk",
+          "tableFrom": "opinion_group_lineage",
+          "tableTo": "opinion_group_description",
+          "columnsFrom": [
+            "system_description_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_admin_description_id_opinion_group_description_id_fk": {
+          "name": "opinion_group_lineage_admin_description_id_opinion_group_description_id_fk",
+          "tableFrom": "opinion_group_lineage",
+          "tableTo": "opinion_group_description",
+          "columnsFrom": [
+            "admin_description_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_opinion_stats": {
+      "name": "opinion_group_opinion_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_opinion_stats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_opinion_id": {
+          "name": "analysis_snapshot_opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_passes": {
+          "name": "num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_agreement_type": {
+          "name": "representative_agreement_type",
+          "type": "vote_enum_simple",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_probability_agreement": {
+          "name": "representative_probability_agreement",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_number_agreement": {
+          "name": "representative_number_agreement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_repness": {
+          "name": "raw_repness",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_group_opinion_stats_representative_idx": {
+          "name": "opinion_group_opinion_stats_representative_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "representative_probability_agreement",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_snapshot_opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"opinion_group_opinion_stats\".\"representative_agreement_type\" is not null AND \"opinion_group_opinion_stats\".\"representative_probability_agreement\" is not null)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_group_opinion_stats_group_id_opinion_group_id_fk": {
+          "name": "opinion_group_opinion_stats_group_id_opinion_group_id_fk",
+          "tableFrom": "opinion_group_opinion_stats",
+          "tableTo": "opinion_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_opinion_stats_analysis_snapshot_opinion_id_analysis_snapshot_opinion_id_fk": {
+          "name": "opinion_group_opinion_stats_analysis_snapshot_opinion_id_analysis_snapshot_opinion_id_fk",
+          "tableFrom": "opinion_group_opinion_stats",
+          "tableTo": "analysis_snapshot_opinion",
+          "columnsFrom": [
+            "analysis_snapshot_opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_opinion_stats_unique": {
+          "name": "opinion_group_opinion_stats_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "analysis_snapshot_opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_opinion_stats_counts_check": {
+          "name": "opinion_group_opinion_stats_counts_check",
+          "value": "\"opinion_group_opinion_stats\".\"num_agrees\" >= 0 AND \"opinion_group_opinion_stats\".\"num_disagrees\" >= 0 AND \"opinion_group_opinion_stats\".\"num_passes\" >= 0"
+        },
+        "opinion_group_opinion_stats_representative_check": {
+          "name": "opinion_group_opinion_stats_representative_check",
+          "value": "((\"opinion_group_opinion_stats\".\"representative_agreement_type\" IS NULL AND \"opinion_group_opinion_stats\".\"representative_probability_agreement\" IS NULL AND \"opinion_group_opinion_stats\".\"representative_number_agreement\" IS NULL AND \"opinion_group_opinion_stats\".\"raw_repness\" IS NULL) OR (\"opinion_group_opinion_stats\".\"representative_agreement_type\" IS NOT NULL AND \"opinion_group_opinion_stats\".\"representative_probability_agreement\" IS NOT NULL AND \"opinion_group_opinion_stats\".\"representative_number_agreement\" IS NOT NULL AND \"opinion_group_opinion_stats\".\"raw_repness\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_spec": {
+      "name": "opinion_group_spec",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_spec_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_spec_id": {
+          "name": "analysis_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reducer": {
+          "name": "reducer",
+          "type": "opinion_group_reducer_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clusterer": {
+          "name": "clusterer",
+          "type": "opinion_group_clusterer_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_policy": {
+          "name": "selection_policy",
+          "type": "opinion_group_selection_policy_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_clusterable_participants": {
+          "name": "min_clusterable_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_votes_per_participant": {
+          "name": "min_votes_per_participant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_group_count": {
+          "name": "max_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_spec_analysis_spec_id_analysis_spec_id_fk": {
+          "name": "opinion_group_spec_analysis_spec_id_analysis_spec_id_fk",
+          "tableFrom": "opinion_group_spec",
+          "tableTo": "analysis_spec",
+          "columnsFrom": [
+            "analysis_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_spec_key_version_unique": {
+          "name": "opinion_group_spec_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group": {
+      "name": "opinion_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_users": {
+          "name": "num_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_scope_id_opinion_group_lineage_scope_id_fk": {
+          "name": "opinion_group_scope_id_opinion_group_lineage_scope_id_fk",
+          "tableFrom": "opinion_group",
+          "tableTo": "opinion_group_lineage_scope",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_id_opinion_group_lineage_id_fk": {
+          "name": "opinion_group_lineage_id_opinion_group_lineage_id_fk",
+          "tableFrom": "opinion_group",
+          "tableTo": "opinion_group_lineage",
+          "columnsFrom": [
+            "lineage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_key_unique": {
+          "name": "opinion_group_candidate_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "key"
+          ]
+        },
+        "opinion_group_candidate_lineage_unique": {
+          "name": "opinion_group_candidate_lineage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "lineage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_user": {
+      "name": "opinion_group_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_user_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_user_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_user",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_user_group_id_opinion_group_id_fk": {
+          "name": "opinion_group_user_group_id_opinion_group_id_fk",
+          "tableFrom": "opinion_group_user",
+          "tableTo": "opinion_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_user_user_id_user_id_fk": {
+          "name": "opinion_group_user_user_id_user_id_fk",
+          "tableFrom": "opinion_group_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_user_candidate_unique": {
+          "name": "opinion_group_user_candidate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "user_id"
+          ]
+        },
+        "opinion_group_user_group_unique": {
+          "name": "opinion_group_user_group_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_variant": {
+      "name": "opinion_group_variant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_variant_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_count": {
+          "name": "group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_variant_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "opinion_group_variant_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "opinion_group_variant",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_variant_spec_count_unique": {
+          "name": "opinion_group_variant_spec_count_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "opinion_group_spec_id",
+            "group_count"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_variant_group_count_check": {
+          "name": "opinion_group_variant_group_count_check",
+          "value": "\"opinion_group_variant\".\"group_count\" >= 2"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_moderation": {
+      "name": "opinion_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "opinion_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_moderation_opinion_id_opinion_id_fk": {
+          "name": "opinion_moderation_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_moderation_author_id_user_id_fk": {
+          "name": "opinion_moderation_author_id_user_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_moderation_opinion_id_unique": {
+          "name": "opinion_moderation_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_report": {
+      "name": "opinion_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_id_idx": {
+          "name": "opinion_id_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_report_opinion_id_opinion_id_fk": {
+          "name": "opinion_report_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_report_author_id_user_id_fk": {
+          "name": "opinion_report_author_id_user_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion": {
+      "name": "opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_passes": {
+          "name": "num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_authorId_idx": {
+          "name": "opinion_authorId_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_author_active_created_id_idx": {
+          "name": "opinion_author_active_created_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_conversation_active_idx": {
+          "name": "opinion_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_conversation_active_created_id_idx": {
+          "name": "opinion_conversation_active_created_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_author_id_user_id_fk": {
+          "name": "opinion_author_id_user_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_conversation_id_conversation_id_fk": {
+          "name": "opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_current_content_id_opinion_content_id_fk": {
+          "name": "opinion_current_content_id_opinion_content_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_slug_id_unique": {
+          "name": "opinion_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_membership_all_project_capability": {
+      "name": "organization_membership_all_project_capability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_membership_all_project_capability_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_membership_id": {
+          "name": "organization_membership_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "organization_membership_all_project_capability_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_membership_all_project_capability_organization_membership_id_organization_membership_id_fk": {
+          "name": "organization_membership_all_project_capability_organization_membership_id_organization_membership_id_fk",
+          "tableFrom": "organization_membership_all_project_capability",
+          "tableTo": "organization_membership",
+          "columnsFrom": [
+            "organization_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_membership_all_project_capability_unique": {
+          "name": "organization_membership_all_project_capability_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_membership_id",
+            "capability"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_membership_capability": {
+      "name": "organization_membership_capability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_membership_capability_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_membership_id": {
+          "name": "organization_membership_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "organization_membership_capability_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_membership_capability_organization_membership_id_organization_membership_id_fk": {
+          "name": "organization_membership_capability_organization_membership_id_organization_membership_id_fk",
+          "tableFrom": "organization_membership_capability",
+          "tableTo": "organization_membership",
+          "columnsFrom": [
+            "organization_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_membership_capability_unique": {
+          "name": "organization_membership_capability_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_membership_id",
+            "capability"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_membership": {
+      "name": "organization_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_membership_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_membership_organization_idx": {
+          "name": "organization_membership_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_membership_user_id_user_id_fk": {
+          "name": "organization_membership_user_id_user_id_fk",
+          "tableFrom": "organization_membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_membership_organization_id_organization_id_fk": {
+          "name": "organization_membership_organization_id_organization_id_fk",
+          "tableFrom": "organization_membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_membership_user_organization_unique": {
+          "name": "organization_membership_user_organization_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "directory_visibility": {
+          "name": "directory_visibility",
+          "type": "directory_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_provisioned_for_user_id": {
+          "name": "auto_provisioned_for_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_full_image_path": {
+          "name": "is_full_image_path",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_auto_provisioned_for_user_id_user_id_fk": {
+          "name": "organization_auto_provisioned_for_user_id_user_id_fk",
+          "tableFrom": "organization",
+          "tableTo": "user",
+          "columnsFrom": [
+            "auto_provisioned_for_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_name_unique": {
+          "name": "organization_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_auto_provisioned_for_user_id_unique": {
+          "name": "organization_auto_provisioned_for_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auto_provisioned_for_user_id"
+          ]
+        },
+        "organization_website_url_unique": {
+          "name": "organization_website_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_email_destination_state": {
+      "name": "otp_email_destination_state",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failed_verify_attempts": {
+          "name": "consecutive_failed_verify_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff_until": {
+          "name": "backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otp_email_destination_updated_idx": {
+          "name": "otp_email_destination_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "otp_email_destination_canonical_check": {
+          "name": "otp_email_destination_canonical_check",
+          "value": "\"otp_email_destination_state\".\"email\" = lower(btrim(\"otp_email_destination_state\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.otp_phone_destination_state": {
+      "name": "otp_phone_destination_state",
+      "schema": "",
+      "columns": {
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failed_verify_attempts": {
+          "name": "consecutive_failed_verify_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff_until": {
+          "name": "backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otp_phone_destination_updated_idx": {
+          "name": "otp_phone_destination_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phone": {
+      "name": "phone",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "phone_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phone_hash_active_unique": {
+          "name": "phone_hash_active_unique",
+          "columns": [
+            {
+              "expression": "phone_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"phone\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phone_hash_idx": {
+          "name": "phone_hash_idx",
+          "columns": [
+            {
+              "expression": "phone_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phone_user_id_user_id_fk": {
+          "name": "phone_user_id_user_id_fk",
+          "tableFrom": "phone",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.premium_feature_entitlement": {
+      "name": "premium_feature_entitlement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "premium_feature_entitlement_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feature": {
+          "name": "feature",
+          "type": "premium_feature",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "premium_feature_entitlement_user_idx": {
+          "name": "premium_feature_entitlement_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "premium_feature_entitlement_org_idx": {
+          "name": "premium_feature_entitlement_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premium_feature_entitlement_user_id_user_id_fk": {
+          "name": "premium_feature_entitlement_user_id_user_id_fk",
+          "tableFrom": "premium_feature_entitlement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "premium_feature_entitlement_organization_id_organization_id_fk": {
+          "name": "premium_feature_entitlement_organization_id_organization_id_fk",
+          "tableFrom": "premium_feature_entitlement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "premium_feature_entitlement_created_by_user_id_user_id_fk": {
+          "name": "premium_feature_entitlement_created_by_user_id_user_id_fk",
+          "tableFrom": "premium_feature_entitlement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "premium_feature_entitlement_updated_by_user_id_user_id_fk": {
+          "name": "premium_feature_entitlement_updated_by_user_id_user_id_fk",
+          "tableFrom": "premium_feature_entitlement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "premium_feature_entitlement_single_subject_check": {
+          "name": "premium_feature_entitlement_single_subject_check",
+          "value": "((\"premium_feature_entitlement\".\"user_id\" is not null AND \"premium_feature_entitlement\".\"organization_id\" is null) OR (\"premium_feature_entitlement\".\"user_id\" is null AND \"premium_feature_entitlement\".\"organization_id\" is not null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.project_organization_ownership": {
+      "name": "project_organization_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "project_organization_ownership_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_ownership_organization_idx": {
+          "name": "project_organization_ownership_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_ownership_project_id_project_id_fk": {
+          "name": "project_organization_ownership_project_id_project_id_fk",
+          "tableFrom": "project_organization_ownership",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_organization_ownership_organization_id_organization_id_fk": {
+          "name": "project_organization_ownership_organization_id_organization_id_fk",
+          "tableFrom": "project_organization_ownership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_ownership_project_org_unique": {
+          "name": "project_organization_ownership_project_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "project_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directory_visibility": {
+          "name": "directory_visibility",
+          "type": "directory_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_provisioned_for_organization_id": {
+          "name": "auto_provisioned_for_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_auto_provisioned_for_organization_id_organization_id_fk": {
+          "name": "project_auto_provisioned_for_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "auto_provisioned_for_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_slug_unique": {
+          "name": "project_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "project_auto_provisioned_for_organization_id_unique": {
+          "name": "project_auto_provisioned_for_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auto_provisioned_for_organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_score_entity": {
+      "name": "ranking_score_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ranking_score_entity_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ranking_score_id": {
+          "name": "ranking_score_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug_id": {
+          "name": "entity_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_left": {
+          "name": "uncertainty_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_right": {
+          "name": "uncertainty_right",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ranking_score_entity_slug_idx": {
+          "name": "ranking_score_entity_slug_idx",
+          "columns": [
+            {
+              "expression": "ranking_score_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ranking_score_entity_ranking_score_id_ranking_score_id_fk": {
+          "name": "ranking_score_entity_ranking_score_id_ranking_score_id_fk",
+          "tableFrom": "ranking_score_entity",
+          "tableTo": "ranking_score",
+          "columnsFrom": [
+            "ranking_score_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_score": {
+      "name": "ranking_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ranking_score_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_counts": {
+          "name": "participant_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_sources_snapshot": {
+          "name": "group_sources_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_weights_snapshot": {
+          "name": "user_weights_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_learning": {
+          "name": "preference_learning",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_rights": {
+          "name": "voting_rights",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregation_config": {
+          "name": "aggregation_config",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_score_conversation_id_conversation_id_fk": {
+          "name": "ranking_score_conversation_id_conversation_id_fk",
+          "tableFrom": "ranking_score",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.realtime_event_outbox": {
+      "name": "realtime_event_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "realtime_event_outbox_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "realtime_event_outbox_created_at_idx": {
+          "name": "realtime_event_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "realtime_event_outbox_conversation_replay_idx": {
+          "name": "realtime_event_outbox_conversation_replay_idx",
+          "columns": [
+            {
+              "expression": "(\"payload\"->>'conversationSlugId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"realtime_event_outbox\".\"event_type\" IN ('conversation_analysis_updated', 'conversation_settings_updated')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_aggregate_option": {
+      "name": "survey_aggregate_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_aggregate_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_aggregate_question_id": {
+          "name": "survey_aggregate_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option_slug_id": {
+          "name": "option_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_order": {
+          "name": "option_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_aggregate_option_survey_aggregate_question_id_survey_aggregate_question_id_fk": {
+          "name": "survey_aggregate_option_survey_aggregate_question_id_survey_aggregate_question_id_fk",
+          "tableFrom": "survey_aggregate_option",
+          "tableTo": "survey_aggregate_question",
+          "columnsFrom": [
+            "survey_aggregate_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_option_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_aggregate_option_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_aggregate_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_aggregate_option_question_slug_unique": {
+          "name": "survey_aggregate_option_question_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_aggregate_question_id",
+            "option_slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_aggregate_question": {
+      "name": "survey_aggregate_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_aggregate_question_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_aggregate_snapshot_id": {
+          "name": "survey_aggregate_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_slug_id": {
+          "name": "question_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_order": {
+          "name": "question_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public_aggregate_suppression_enabled": {
+          "name": "is_public_aggregate_suppression_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "question_semantic_version": {
+          "name": "question_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_aggregate_question_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk": {
+          "name": "survey_aggregate_question_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk",
+          "tableFrom": "survey_aggregate_question",
+          "tableTo": "survey_aggregate_snapshot",
+          "columnsFrom": [
+            "survey_aggregate_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_question_survey_question_id_survey_question_id_fk": {
+          "name": "survey_aggregate_question_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_aggregate_question",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_aggregate_question_snapshot_slug_unique": {
+          "name": "survey_aggregate_question_snapshot_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_aggregate_snapshot_id",
+            "question_slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_aggregate_result": {
+      "name": "survey_aggregate_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_aggregate_result_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_aggregate_snapshot_id": {
+          "name": "survey_aggregate_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "survey_aggregate_scope_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_aggregate_question_id": {
+          "name": "survey_aggregate_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_aggregate_option_id": {
+          "name": "survey_aggregate_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_percentage": {
+          "name": "suppressed_percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_count": {
+          "name": "full_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_percentage": {
+          "name": "full_percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suppressed": {
+          "name": "is_suppressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "survey_aggregate_suppression_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_aggregate_result_snapshot_idx": {
+          "name": "survey_aggregate_result_snapshot_idx",
+          "columns": [
+            {
+              "expression": "survey_aggregate_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_aggregate_result_group_idx": {
+          "name": "survey_aggregate_result_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_aggregate_result_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk": {
+          "name": "survey_aggregate_result_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "survey_aggregate_snapshot",
+          "columnsFrom": [
+            "survey_aggregate_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_result_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "survey_aggregate_result_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_result_group_id_opinion_group_id_fk": {
+          "name": "survey_aggregate_result_group_id_opinion_group_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "opinion_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_result_survey_aggregate_question_id_survey_aggregate_question_id_fk": {
+          "name": "survey_aggregate_result_survey_aggregate_question_id_survey_aggregate_question_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "survey_aggregate_question",
+          "columnsFrom": [
+            "survey_aggregate_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_result_survey_aggregate_option_id_survey_aggregate_option_id_fk": {
+          "name": "survey_aggregate_result_survey_aggregate_option_id_survey_aggregate_option_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "survey_aggregate_option",
+          "columnsFrom": [
+            "survey_aggregate_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "survey_aggregate_result_scope_check": {
+          "name": "survey_aggregate_result_scope_check",
+          "value": "((\"survey_aggregate_result\".\"scope\" = 'overall' AND \"survey_aggregate_result\".\"candidate_id\" is null AND \"survey_aggregate_result\".\"group_id\" is null) OR (\"survey_aggregate_result\".\"scope\" = 'opinion_group' AND \"survey_aggregate_result\".\"candidate_id\" is not null AND \"survey_aggregate_result\".\"group_id\" is not null))"
+        },
+        "survey_aggregate_result_suppression_check": {
+          "name": "survey_aggregate_result_suppression_check",
+          "value": "((\"survey_aggregate_result\".\"is_suppressed\" = true AND \"survey_aggregate_result\".\"suppressed_count\" is null AND \"survey_aggregate_result\".\"suppressed_percentage\" is null AND \"survey_aggregate_result\".\"suppression_reason\" is not null) OR (\"survey_aggregate_result\".\"is_suppressed\" = false AND \"survey_aggregate_result\".\"suppressed_count\" is not null AND \"survey_aggregate_result\".\"suppression_reason\" is null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.survey_aggregate_snapshot": {
+      "name": "survey_aggregate_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_aggregate_snapshot_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_id": {
+          "name": "analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_config_id": {
+          "name": "survey_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_config_revision": {
+          "name": "survey_config_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppression_threshold": {
+          "name": "suppression_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_aggregate_snapshot_conversation_idx": {
+          "name": "survey_aggregate_snapshot_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_aggregate_snapshot_conversation_id_conversation_id_fk": {
+          "name": "survey_aggregate_snapshot_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_aggregate_snapshot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_snapshot_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "survey_aggregate_snapshot_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "survey_aggregate_snapshot",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_snapshot_survey_config_id_survey_config_id_fk": {
+          "name": "survey_aggregate_snapshot_survey_config_id_survey_config_id_fk",
+          "tableFrom": "survey_aggregate_snapshot",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_aggregate_snapshot_checkpoint_unique": {
+          "name": "survey_aggregate_snapshot_checkpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_snapshot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answer_option": {
+      "name": "survey_answer_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_answer_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_answer_id": {
+          "name": "survey_answer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_answer_option_answer_option_active_uidx": {
+          "name": "survey_answer_option_answer_option_active_uidx",
+          "columns": [
+            {
+              "expression": "survey_answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "survey_question_option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_answer_option\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_option_survey_answer_id_survey_answer_id_fk": {
+          "name": "survey_answer_option_survey_answer_id_survey_answer_id_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_answer",
+          "columnsFrom": [
+            "survey_answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_answer_option_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_answer_question_fk": {
+          "name": "survey_answer_option_answer_question_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_answer",
+          "columnsFrom": [
+            "survey_answer_id",
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "survey_question_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_option_question_fk": {
+          "name": "survey_answer_option_option_question_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id",
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "survey_question_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answer": {
+      "name": "survey_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_answer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_response_id": {
+          "name": "survey_response_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_question_semantic_version": {
+          "name": "answered_question_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_value_html": {
+          "name": "text_value_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_answer_response_question_active_uidx": {
+          "name": "survey_answer_response_question_active_uidx",
+          "columns": [
+            {
+              "expression": "survey_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "survey_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_answer\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_survey_response_id_survey_response_id_fk": {
+          "name": "survey_answer_survey_response_id_survey_response_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "columnsFrom": [
+            "survey_response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_survey_question_id_survey_question_id_fk": {
+          "name": "survey_answer_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_response_conversation_fk": {
+          "name": "survey_answer_response_conversation_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "columnsFrom": [
+            "survey_response_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_question_conversation_fk": {
+          "name": "survey_answer_question_conversation_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_answer_id_question_unique": {
+          "name": "survey_answer_id_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "survey_question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_config": {
+      "name": "survey_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_config_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision": {
+          "name": "current_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_config_active_conversation_uidx": {
+          "name": "survey_config_active_conversation_uidx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_config\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_config_conversation_id_conversation_id_fk": {
+          "name": "survey_config_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_config",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_config_id_conversation_unique": {
+          "name": "survey_config_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_content": {
+      "name": "survey_question_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constraints": {
+          "name": "constraints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language_code": {
+          "name": "source_language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_language_confidence": {
+          "name": "source_language_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_content_survey_question_id_survey_question_id_fk": {
+          "name": "survey_question_content_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_question_content",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_content_translation": {
+      "name": "survey_question_content_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_content_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_content_id": {
+          "name": "survey_question_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_language_code": {
+          "name": "display_language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_question_text": {
+          "name": "translated_question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_content_translation_survey_question_content_id_survey_question_content_id_fk": {
+          "name": "survey_question_content_translation_survey_question_content_id_survey_question_content_id_fk",
+          "tableFrom": "survey_question_content_translation",
+          "tableTo": "survey_question_content",
+          "columnsFrom": [
+            "survey_question_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_content_translation_unique": {
+          "name": "survey_question_content_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_question_content_id",
+            "display_language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option_content": {
+      "name": "survey_question_option_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language_code": {
+          "name": "source_language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_language_confidence": {
+          "name": "source_language_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_option_content_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_question_option_content_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_question_option_content",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option_content_translation": {
+      "name": "survey_question_option_content_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_content_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_option_content_id": {
+          "name": "survey_question_option_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_language_code": {
+          "name": "display_language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_option_text": {
+          "name": "translated_option_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_option_content_translation_survey_question_option_content_id_survey_question_option_content_id_fk": {
+          "name": "survey_question_option_content_translation_survey_question_option_content_id_survey_question_option_content_id_fk",
+          "tableFrom": "survey_question_option_content_translation",
+          "tableTo": "survey_question_option_content",
+          "columnsFrom": [
+            "survey_question_option_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_option_content_translation_unique": {
+          "name": "survey_question_option_content_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_question_option_content_id",
+            "display_language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option": {
+      "name": "survey_question_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_option_active_question_display_order_uidx": {
+          "name": "survey_question_option_active_question_display_order_uidx",
+          "columns": [
+            {
+              "expression": "survey_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_question_option\".\"current_content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_option_survey_question_id_survey_question_id_fk": {
+          "name": "survey_question_option_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_question_option",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_option_current_content_id_survey_question_option_content_id_fk": {
+          "name": "survey_question_option_current_content_id_survey_question_option_content_id_fk",
+          "tableFrom": "survey_question_option",
+          "tableTo": "survey_question_option_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_option_slug_id_unique": {
+          "name": "survey_question_option_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "survey_question_option_current_content_id_unique": {
+          "name": "survey_question_option_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "survey_question_option_id_question_unique": {
+          "name": "survey_question_option_id_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "survey_question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question": {
+      "name": "survey_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_config_id": {
+          "name": "survey_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "choice_display": {
+          "name": "choice_display",
+          "type": "survey_choice_display",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_semantic_version": {
+          "name": "current_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public_aggregate_suppression_enabled": {
+          "name": "is_public_aggregate_suppression_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_active_config_display_order_uidx": {
+          "name": "survey_question_active_config_display_order_uidx",
+          "columns": [
+            {
+              "expression": "survey_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_question\".\"current_content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_config_idx": {
+          "name": "survey_question_config_idx",
+          "columns": [
+            {
+              "expression": "survey_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_survey_config_id_survey_config_id_fk": {
+          "name": "survey_question_survey_config_id_survey_config_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_conversation_id_conversation_id_fk": {
+          "name": "survey_question_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_current_content_id_survey_question_content_id_fk": {
+          "name": "survey_question_current_content_id_survey_question_content_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_question_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_config_conversation_fk": {
+          "name": "survey_question_config_conversation_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_slug_id_unique": {
+          "name": "survey_question_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "survey_question_current_content_id_unique": {
+          "name": "survey_question_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "survey_question_id_conversation_unique": {
+          "name": "survey_question_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_response": {
+      "name": "survey_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_response_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_response_conversation_created_idx": {
+          "name": "survey_response_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_response_participant_id_user_id_fk": {
+          "name": "survey_response_participant_id_user_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_response_conversation_id_conversation_id_fk": {
+          "name": "survey_response_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_response_conversation_participant_unique": {
+          "name": "survey_response_conversation_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        },
+        "survey_response_id_conversation_unique": {
+          "name": "survey_response_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_weight": {
+          "name": "score_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_code_unique": {
+          "name": "topic_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "topic_name_unique": {
+          "name": "topic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "topic_description_unique": {
+          "name": "topic_description_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_display_language": {
+      "name": "user_display_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_display_language_user_id_user_id_fk": {
+          "name": "user_display_language_user_id_user_id_fk",
+          "tableFrom": "user_display_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_display_language_unique": {
+          "name": "user_display_language_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mute_preference": {
+      "name": "user_mute_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_mute_preference_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_mute_preference_source_user_id_user_id_fk": {
+          "name": "user_mute_preference_source_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_mute_preference_target_user_id_user_id_fk": {
+          "name": "user_mute_preference_target_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_unique_mute": {
+          "name": "user_unique_mute",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_user_id",
+            "target_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_organization_mapping": {
+      "name": "user_organization_mapping",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_organization_mapping_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_organization_mapping_user_id_user_id_fk": {
+          "name": "user_organization_mapping_user_id_user_id_fk",
+          "tableFrom": "user_organization_mapping",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_organization_mapping_organization_id_organization_id_fk": {
+          "name": "user_organization_mapping_organization_id_organization_id_fk",
+          "tableFrom": "user_organization_mapping",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_orgaization_mapping": {
+          "name": "unique_user_orgaization_mapping",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_spoken_languages": {
+      "name": "user_spoken_languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_spoken_languages_user_id_user_id_fk": {
+          "name": "user_spoken_languages_user_id_user_id_fk",
+          "tableFrom": "user_spoken_languages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_spoken_languages_unique": {
+          "name": "user_spoken_languages_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "polis_participant_id": {
+          "name": "polis_participant_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_site_moderator": {
+          "name": "is_site_moderator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_site_org_admin": {
+          "name": "is_site_org_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_imported": {
+          "name": "is_imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_conversation_count": {
+          "name": "active_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_conversation_count": {
+          "name": "total_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_content": {
+      "name": "vote_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_content_id": {
+          "name": "opinion_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "vote_enum_all",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vote_content_vote_id_vote_id_fk": {
+          "name": "vote_content_vote_id_vote_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "vote",
+          "columnsFrom": [
+            "vote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_content_opinion_content_id_opinion_content_id_fk": {
+          "name": "vote_content_opinion_content_id_opinion_content_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "opinion_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polis_vote_id": {
+          "name": "polis_vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vote_authorId_idx": {
+          "name": "vote_authorId_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_author_active_updated_id_idx": {
+          "name": "vote_author_active_updated_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"vote\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_opinion_active_idx": {
+          "name": "vote_opinion_active_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_author_id_user_id_fk": {
+          "name": "vote_author_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_opinion_id_opinion_id_fk": {
+          "name": "vote_opinion_id_opinion_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_current_content_id_vote_content_id_fk": {
+          "name": "vote_current_content_id_vote_content_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "vote_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vote_author_id_opinion_id_unique": {
+          "name": "vote_author_id_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_id",
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zk_passport": {
+      "name": "zk_passport",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "zk_passport_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citizenship": {
+          "name": "citizenship",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sex": {
+          "name": "sex",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zk_passport_nullifier_active_unique": {
+          "name": "zk_passport_nullifier_active_unique",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zk_passport\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zk_passport_nullifier_idx": {
+          "name": "zk_passport_nullifier_idx",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zk_passport_user_id_user_id_fk": {
+          "name": "zk_passport_user_id_user_id_fk",
+          "tableFrom": "zk_passport",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.analysis_compression_enum": {
+      "name": "analysis_compression_enum",
+      "schema": "public",
+      "values": [
+        "zstd"
+      ]
+    },
+    "public.analysis_family_enum": {
+      "name": "analysis_family_enum",
+      "schema": "public",
+      "values": [
+        "opinion_groups"
+      ]
+    },
+    "public.analysis_insufficient_data_reason_enum": {
+      "name": "analysis_insufficient_data_reason_enum",
+      "schema": "public",
+      "values": [
+        "empty_vote_matrix",
+        "not_enough_clusterable_participants",
+        "not_enough_unique_points",
+        "not_enough_samples_for_group_count",
+        "other"
+      ]
+    },
+    "public.analysis_result_outcome_enum": {
+      "name": "analysis_result_outcome_enum",
+      "schema": "public",
+      "values": [
+        "success",
+        "insufficient_data"
+      ]
+    },
+    "public.analysis_work_error_kind_enum": {
+      "name": "analysis_work_error_kind_enum",
+      "schema": "public",
+      "values": [
+        "red_dwarf_exception",
+        "red_dwarf_contract_violation",
+        "database_error",
+        "valkey_error",
+        "transaction_error",
+        "unknown_error"
+      ]
+    },
+    "public.auth_type": {
+      "name": "auth_type",
+      "schema": "public",
+      "values": [
+        "register",
+        "login_known_device",
+        "login_new_device",
+        "merge",
+        "restore_deleted",
+        "restore_and_merge"
+      ]
+    },
+    "public.conversation_moderation_action": {
+      "name": "conversation_moderation_action",
+      "schema": "public",
+      "values": [
+        "lock"
+      ]
+    },
+    "public.conversation_type": {
+      "name": "conversation_type",
+      "schema": "public",
+      "values": [
+        "polis",
+        "maxdiff"
+      ]
+    },
+    "public.conversation_view_snapshot_checkpoint_reason_enum": {
+      "name": "conversation_view_snapshot_checkpoint_reason_enum",
+      "schema": "public",
+      "values": [
+        "first_displayable_analysis",
+        "first_group_count_available",
+        "default_group_count_changed",
+        "major_participation_milestone",
+        "major_vote_milestone",
+        "conversation_closed"
+      ]
+    },
+    "public.conversation_view_snapshot_reason_enum": {
+      "name": "conversation_view_snapshot_reason_enum",
+      "schema": "public",
+      "values": [
+        "analysis_completed",
+        "survey_refreshed",
+        "conversation_content_updated",
+        "conversation_lifecycle_updated"
+      ]
+    },
+    "public.directory_visibility": {
+      "name": "directory_visibility",
+      "schema": "public",
+      "values": [
+        "listed",
+        "unlisted"
+      ]
+    },
+    "public.email_reachability": {
+      "name": "email_reachability",
+      "schema": "public",
+      "values": [
+        "safe",
+        "risky",
+        "invalid",
+        "unknown"
+      ]
+    },
+    "public.email_type": {
+      "name": "email_type",
+      "schema": "public",
+      "values": [
+        "primary",
+        "backup",
+        "secondary",
+        "other"
+      ]
+    },
+    "public.event_slug": {
+      "name": "event_slug",
+      "schema": "public",
+      "values": [
+        "devconnect-2025"
+      ]
+    },
+    "public.export_artifact_status_enum": {
+      "name": "export_artifact_status_enum",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.export_cancellation_reason_enum": {
+      "name": "export_cancellation_reason_enum",
+      "schema": "public",
+      "values": [
+        "duplicate_in_batch",
+        "cooldown_active"
+      ]
+    },
+    "public.export_failure_reason_enum": {
+      "name": "export_failure_reason_enum",
+      "schema": "public",
+      "values": [
+        "processing_error",
+        "timeout",
+        "server_restart"
+      ]
+    },
+    "public.export_file_audience_enum": {
+      "name": "export_file_audience_enum",
+      "schema": "public",
+      "values": [
+        "redacted",
+        "owner",
+        "requester"
+      ]
+    },
+    "public.export_file_type_enum": {
+      "name": "export_file_type_enum",
+      "schema": "public",
+      "values": [
+        "bundle",
+        "comments",
+        "votes",
+        "participants",
+        "summary",
+        "stats",
+        "survey_questions",
+        "survey_question_options",
+        "survey_participant_responses",
+        "survey_public_aggregates",
+        "survey_full_aggregates"
+      ]
+    },
+    "public.export_generation_status_enum": {
+      "name": "export_generation_status_enum",
+      "schema": "public",
+      "values": [
+        "collecting",
+        "queued",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.export_status_enum": {
+      "name": "export_status_enum",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.external_source_type": {
+      "name": "external_source_type",
+      "schema": "public",
+      "values": [
+        "github_issue"
+      ]
+    },
+    "public.import_failure_reason_enum": {
+      "name": "import_failure_reason_enum",
+      "schema": "public",
+      "values": [
+        "processing_error",
+        "timeout",
+        "server_restart",
+        "invalid_data_format"
+      ]
+    },
+    "public.import_method": {
+      "name": "import_method",
+      "schema": "public",
+      "values": [
+        "url",
+        "csv"
+      ]
+    },
+    "public.import_status_enum": {
+      "name": "import_status_enum",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.maxdiff_lifecycle_status": {
+      "name": "maxdiff_lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "in_progress",
+        "canceled"
+      ]
+    },
+    "public.moderation_reason_enum": {
+      "name": "moderation_reason_enum",
+      "schema": "public",
+      "values": [
+        "misleading",
+        "antisocial",
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "opinion_vote",
+        "new_opinion",
+        "export_started",
+        "export_completed",
+        "export_failed",
+        "export_cancelled",
+        "import_started",
+        "import_completed",
+        "import_failed"
+      ]
+    },
+    "public.opinion_group_candidate_hidden_reason_enum": {
+      "name": "opinion_group_candidate_hidden_reason_enum",
+      "schema": "public",
+      "values": [
+        "singleton_group",
+        "duplicate_representative_opinions",
+        "missing_representative_opinions",
+        "invalid_candidate_output"
+      ]
+    },
+    "public.opinion_group_clusterer_enum": {
+      "name": "opinion_group_clusterer_enum",
+      "schema": "public",
+      "values": [
+        "kmeans"
+      ]
+    },
+    "public.opinion_group_reducer_enum": {
+      "name": "opinion_group_reducer_enum",
+      "schema": "public",
+      "values": [
+        "pca"
+      ]
+    },
+    "public.opinion_group_selection_policy_enum": {
+      "name": "opinion_group_selection_policy_enum",
+      "schema": "public",
+      "values": [
+        "silhouette_size_balance"
+      ]
+    },
+    "public.opinion_moderation_action": {
+      "name": "opinion_moderation_action",
+      "schema": "public",
+      "values": [
+        "move",
+        "hide"
+      ]
+    },
+    "public.organization_membership_all_project_capability_enum": {
+      "name": "organization_membership_all_project_capability_enum",
+      "schema": "public",
+      "values": [
+        "project_update",
+        "project_delete",
+        "project_manage_owner_organizations",
+        "conversation_create",
+        "conversation_update",
+        "conversation_delete",
+        "conversation_view_private_results",
+        "conversation_export_owner_data",
+        "conversation_moderate",
+        "conversation_manage_integrations"
+      ]
+    },
+    "public.organization_membership_capability_enum": {
+      "name": "organization_membership_capability_enum",
+      "schema": "public",
+      "values": [
+        "organization_manage_members",
+        "organization_manage_profile",
+        "project_create"
+      ]
+    },
+    "public.participation_mode": {
+      "name": "participation_mode",
+      "schema": "public",
+      "values": [
+        "account_required",
+        "strong_verification",
+        "email_verification",
+        "guest"
+      ]
+    },
+    "public.phone_country_code": {
+      "name": "phone_country_code",
+      "schema": "public",
+      "values": [
+        "AC",
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AO",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NU",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TA",
+        "TC",
+        "TD",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "XK",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW"
+      ]
+    },
+    "public.premium_feature": {
+      "name": "premium_feature",
+      "schema": "public",
+      "values": [
+        "survey",
+        "event_ticket",
+        "analysis_variants"
+      ]
+    },
+    "public.report_reason_enum": {
+      "name": "report_reason_enum",
+      "schema": "public",
+      "values": [
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam",
+        "misleading",
+        "antisocial"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "F",
+        "M",
+        "X"
+      ]
+    },
+    "public.survey_aggregate_scope_enum": {
+      "name": "survey_aggregate_scope_enum",
+      "schema": "public",
+      "values": [
+        "overall",
+        "opinion_group"
+      ]
+    },
+    "public.survey_aggregate_suppression_reason_enum": {
+      "name": "survey_aggregate_suppression_reason_enum",
+      "schema": "public",
+      "values": [
+        "count_below_threshold",
+        "cluster_deductive_disclosure"
+      ]
+    },
+    "public.survey_choice_display": {
+      "name": "survey_choice_display",
+      "schema": "public",
+      "values": [
+        "auto",
+        "list",
+        "dropdown"
+      ]
+    },
+    "public.survey_question_type": {
+      "name": "survey_question_type",
+      "schema": "public",
+      "values": [
+        "choice",
+        "free_text"
+      ]
+    },
+    "public.ticket_provider": {
+      "name": "ticket_provider",
+      "schema": "public",
+      "values": [
+        "zupass"
+      ]
+    },
+    "public.vote_enum_all": {
+      "name": "vote_enum_all",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree",
+        "pass"
+      ]
+    },
+    "public.vote_enum_simple": {
+      "name": "vote_enum_simple",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/drizzle/meta/0071_snapshot.json
+++ b/services/api/drizzle/meta/0071_snapshot.json
@@ -1,0 +1,12252 @@
+{
+  "id": "469fecb4-f9fd-4ffb-b9d0-6825944f58d2",
+  "prevId": "b4151289-cd82-4269-b057-4905bca6bdf5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.analysis_input_snapshot": {
+      "name": "analysis_input_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_input_snapshot_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_generation": {
+          "name": "data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_hash": {
+          "name": "input_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_count": {
+          "name": "opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "compression": {
+          "name": "compression",
+          "type": "analysis_compression_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_input_snapshot_conversation_idx": {
+          "name": "analysis_input_snapshot_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_input_snapshot_conversation_id_conversation_id_fk": {
+          "name": "analysis_input_snapshot_conversation_id_conversation_id_fk",
+          "tableFrom": "analysis_input_snapshot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_input_snapshot_hash_unique": {
+          "name": "analysis_input_snapshot_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "data_generation",
+            "input_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "analysis_input_snapshot_counts_check": {
+          "name": "analysis_input_snapshot_counts_check",
+          "value": "\"analysis_input_snapshot\".\"opinion_count\" >= 0 AND \"analysis_input_snapshot\".\"participant_count\" >= 0 AND \"analysis_input_snapshot\".\"vote_count\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_snapshot_opinion": {
+      "name": "analysis_snapshot_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_snapshot_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_snapshot_id": {
+          "name": "analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_content_id": {
+          "name": "opinion_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_opinion_index": {
+          "name": "local_opinion_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_passes": {
+          "name": "num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "routing_priority": {
+          "name": "routing_priority",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "analysis_snapshot_opinion_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "analysis_snapshot_opinion_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "analysis_snapshot_opinion",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_opinion_opinion_id_opinion_id_fk": {
+          "name": "analysis_snapshot_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "analysis_snapshot_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_opinion_opinion_content_id_opinion_content_id_fk": {
+          "name": "analysis_snapshot_opinion_opinion_content_id_opinion_content_id_fk",
+          "tableFrom": "analysis_snapshot_opinion",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "opinion_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_snapshot_opinion_unique": {
+          "name": "analysis_snapshot_opinion_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_snapshot_id",
+            "opinion_id"
+          ]
+        },
+        "analysis_snapshot_opinion_local_idx_unique": {
+          "name": "analysis_snapshot_opinion_local_idx_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_snapshot_id",
+            "local_opinion_index"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_snapshot_result": {
+      "name": "analysis_snapshot_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_snapshot_result_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_id": {
+          "name": "analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "analysis_result_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_reason": {
+          "name": "outcome_reason",
+          "type": "analysis_insufficient_data_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "variants_enabled": {
+          "name": "variants_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "analysis_snapshot_result_conversation_id_conversation_id_fk": {
+          "name": "analysis_snapshot_result_conversation_id_conversation_id_fk",
+          "tableFrom": "analysis_snapshot_result",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_result_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "analysis_snapshot_result_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "analysis_snapshot_result",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_result_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "analysis_snapshot_result_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "analysis_snapshot_result",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_snapshot_result_spec_unique": {
+          "name": "analysis_snapshot_result_spec_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_snapshot_id",
+            "opinion_group_spec_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "analysis_snapshot_result_reason_check": {
+          "name": "analysis_snapshot_result_reason_check",
+          "value": "(\"analysis_snapshot_result\".\"outcome\" = 'insufficient_data' AND \"analysis_snapshot_result\".\"outcome_reason\" IS NOT NULL) OR (\"analysis_snapshot_result\".\"outcome\" = 'success' AND \"analysis_snapshot_result\".\"outcome_reason\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.analysis_snapshot": {
+      "name": "analysis_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_snapshot_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_snapshot_id": {
+          "name": "input_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_generation": {
+          "name": "data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_snapshot_latest_idx": {
+          "name": "analysis_snapshot_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "data_generation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_snapshot_conversation_id_conversation_id_fk": {
+          "name": "analysis_snapshot_conversation_id_conversation_id_fk",
+          "tableFrom": "analysis_snapshot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_conversation_content_id_conversation_content_id_fk": {
+          "name": "analysis_snapshot_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "analysis_snapshot",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "analysis_snapshot_input_snapshot_id_analysis_input_snapshot_id_fk": {
+          "name": "analysis_snapshot_input_snapshot_id_analysis_input_snapshot_id_fk",
+          "tableFrom": "analysis_snapshot",
+          "tableTo": "analysis_input_snapshot",
+          "columnsFrom": [
+            "input_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_spec": {
+      "name": "analysis_spec",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_spec_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_family": {
+          "name": "analysis_family",
+          "type": "analysis_family_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.analysis_work_state": {
+      "name": "analysis_work_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "analysis_work_state_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_completed_data_generation": {
+          "name": "last_completed_data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "running_data_generation": {
+          "name": "running_data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persisted_analysis_snapshot_id": {
+          "name": "persisted_analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dirty_since": {
+          "name": "dirty_since",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_generation": {
+          "name": "attempt_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "non_retryable_generation": {
+          "name": "non_retryable_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_retryable_analysis_engine_epoch": {
+          "name": "non_retryable_analysis_engine_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_kind": {
+          "name": "last_error_kind",
+          "type": "analysis_work_error_kind_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_stack_hash": {
+          "name": "last_error_stack_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "analysis_work_state_lease_expiry_idx": {
+          "name": "analysis_work_state_lease_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"analysis_work_state\".\"running_data_generation\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "analysis_work_state_running_conversation_unique": {
+          "name": "analysis_work_state_running_conversation_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"analysis_work_state\".\"running_data_generation\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "analysis_work_state_conversation_id_conversation_id_fk": {
+          "name": "analysis_work_state_conversation_id_conversation_id_fk",
+          "tableFrom": "analysis_work_state",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_work_state_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "analysis_work_state_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "analysis_work_state",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "analysis_work_state_persisted_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "analysis_work_state_persisted_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "analysis_work_state",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "persisted_analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "analysis_work_state_conversation_spec_unique": {
+          "name": "analysis_work_state_conversation_spec_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "opinion_group_spec_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "analysis_work_state_running_lease_check": {
+          "name": "analysis_work_state_running_lease_check",
+          "value": "((\"analysis_work_state\".\"running_data_generation\" is null AND \"analysis_work_state\".\"lease_owner\" is null AND \"analysis_work_state\".\"lease_token\" is null AND \"analysis_work_state\".\"lease_expires_at\" is null) OR (\"analysis_work_state\".\"running_data_generation\" is not null AND \"analysis_work_state\".\"lease_owner\" is not null AND \"analysis_work_state\".\"lease_token\" is not null AND \"analysis_work_state\".\"lease_expires_at\" is not null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_attempt_email": {
+      "name": "auth_attempt_email",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_reachability": {
+          "name": "email_reachability",
+          "type": "email_reachability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_attempt_email_canonical_check": {
+          "name": "auth_attempt_email_canonical_check",
+          "value": "\"auth_attempt_email\".\"email\" = lower(btrim(\"auth_attempt_email\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_attempt_phone": {
+      "name": "auth_attempt_phone",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_expiry": {
+          "name": "code_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guess_attempt_amount": {
+          "name": "guess_attempt_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"auth_attempt_phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_content": {
+      "name": "conversation_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(140)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_content_conversation_id_conversation_id_fk": {
+          "name": "conversation_content_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_content",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_artifact": {
+      "name": "conversation_export_artifact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_artifact_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "export_file_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "export_file_audience_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "export_artifact_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "record_count": {
+          "name": "record_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_artifact_generation_idx": {
+          "name": "conversation_export_artifact_generation_idx",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_artifact_shared_unique": {
+          "name": "conversation_export_artifact_shared_unique",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_artifact\".\"subject_user_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_artifact_requester_unique": {
+          "name": "conversation_export_artifact_requester_unique",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_artifact\".\"subject_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_artifact_generation_id_conversation_export_generation_id_fk": {
+          "name": "conversation_export_artifact_generation_id_conversation_export_generation_id_fk",
+          "tableFrom": "conversation_export_artifact",
+          "tableTo": "conversation_export_generation",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_artifact_subject_user_id_user_id_fk": {
+          "name": "conversation_export_artifact_subject_user_id_user_id_fk",
+          "tableFrom": "conversation_export_artifact",
+          "tableTo": "user",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_generation": {
+      "name": "conversation_export_generation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_generation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_generation_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'collecting'"
+        },
+        "collecting_ends_at": {
+          "name": "collecting_ends_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_generation_conversation_idx": {
+          "name": "conversation_export_generation_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_collecting_due_idx": {
+          "name": "conversation_export_generation_collecting_due_idx",
+          "columns": [
+            {
+              "expression": "collecting_ends_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_generation\".\"status\" = 'collecting'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_queued_due_idx": {
+          "name": "conversation_export_generation_queued_due_idx",
+          "columns": [
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_generation\".\"status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_collecting_unique": {
+          "name": "conversation_export_generation_collecting_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_generation\".\"status\" = 'collecting'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_generation_processing_unique": {
+          "name": "conversation_export_generation_processing_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_generation\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_generation_conversation_id_conversation_id_fk": {
+          "name": "conversation_export_generation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_export_generation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_export_generation_slug_id_unique": {
+          "name": "conversation_export_generation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_request_file": {
+      "name": "conversation_export_request_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_request_file_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_id": {
+          "name": "artifact_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "export_file_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "export_file_audience_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_request_file_artifact_idx": {
+          "name": "conversation_export_request_file_artifact_idx",
+          "columns": [
+            {
+              "expression": "artifact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_file_unique": {
+          "name": "conversation_export_request_file_unique",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "file_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_request_file_request_id_conversation_export_request_id_fk": {
+          "name": "conversation_export_request_file_request_id_conversation_export_request_id_fk",
+          "tableFrom": "conversation_export_request_file",
+          "tableTo": "conversation_export_request",
+          "columnsFrom": [
+            "request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_file_artifact_id_conversation_export_artifact_id_fk": {
+          "name": "conversation_export_request_file_artifact_id_conversation_export_artifact_id_fk",
+          "tableFrom": "conversation_export_request_file",
+          "tableTo": "conversation_export_artifact",
+          "columnsFrom": [
+            "artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_export_request": {
+      "name": "conversation_export_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_export_request_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "export_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "export_cancellation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_notified_at": {
+          "name": "started_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_notified_at": {
+          "name": "completed_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failed_notified_at": {
+          "name": "failed_notified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_export_request_conversation_idx": {
+          "name": "conversation_export_request_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_generation_idx": {
+          "name": "conversation_export_request_generation_idx",
+          "columns": [
+            {
+              "expression": "generation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_active_history_idx": {
+          "name": "conversation_export_request_active_history_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_expiry_idx": {
+          "name": "conversation_export_request_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_export_request_active_unique": {
+          "name": "conversation_export_request_active_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_export_request\".\"status\" = 'processing' AND \"conversation_export_request\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_export_request_conversation_id_conversation_id_fk": {
+          "name": "conversation_export_request_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_generation_id_conversation_export_generation_id_fk": {
+          "name": "conversation_export_request_generation_id_conversation_export_generation_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "conversation_export_generation",
+          "columnsFrom": [
+            "generation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_export_request_user_id_user_id_fk": {
+          "name": "conversation_export_request_user_id_user_id_fk",
+          "tableFrom": "conversation_export_request",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_export_request_slug_id_unique": {
+          "name": "conversation_export_request_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_import": {
+      "name": "conversation_import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_import_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "import_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "import_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "csv_file_metadata": {
+          "name": "csv_file_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_import_status_idx": {
+          "name": "conversation_import_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_created_idx": {
+          "name": "conversation_import_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_user_idx": {
+          "name": "conversation_import_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_import_active_user_unique": {
+          "name": "conversation_import_active_user_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_import\".\"status\" = 'processing'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_import_conversation_id_conversation_id_fk": {
+          "name": "conversation_import_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_import",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_import_user_id_user_id_fk": {
+          "name": "conversation_import_user_id_user_id_fk",
+          "tableFrom": "conversation_import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_import_slug_id_unique": {
+          "name": "conversation_import_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_import_conversation_id_unique": {
+          "name": "conversation_import_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_moderation": {
+      "name": "conversation_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "conversation_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_moderation_conversation_id_conversation_id_fk": {
+          "name": "conversation_moderation_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_moderation_author_id_user_id_fk": {
+          "name": "conversation_moderation_author_id_user_id_fk",
+          "tableFrom": "conversation_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_moderation_conversation_id_unique": {
+          "name": "conversation_moderation_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_report": {
+      "name": "conversation_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_id_idx": {
+          "name": "conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_report_conversation_id_conversation_id_fk": {
+          "name": "conversation_report_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_report_author_id_user_id_fk": {
+          "name": "conversation_report_author_id_user_id_fk",
+          "tableFrom": "conversation_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation": {
+      "name": "conversation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_ranking_score_id": {
+          "name": "current_ranking_score_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_indexed": {
+          "name": "is_indexed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "participation_mode": {
+          "name": "participation_mode",
+          "type": "participation_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'account_required'"
+        },
+        "conversation_type": {
+          "name": "conversation_type",
+          "type": "conversation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'polis'"
+        },
+        "is_importing": {
+          "name": "is_importing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_edited": {
+          "name": "is_edited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requires_event_ticket": {
+          "name": "requires_event_ticket",
+          "type": "event_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_labeling_enabled": {
+          "name": "ai_labeling_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "analysis_data_generation": {
+          "name": "analysis_data_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "preferred_opinion_group_count": {
+          "name": "preferred_opinion_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_url": {
+          "name": "import_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_conversation_url": {
+          "name": "import_conversation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_export_url": {
+          "name": "import_export_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_created_at": {
+          "name": "import_created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_author": {
+          "name": "import_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "import_method": {
+          "name": "import_method",
+          "type": "import_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_source_config": {
+          "name": "external_source_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_feed_idx": {
+          "name": "conversation_feed_idx",
+          "columns": [
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation\".\"is_indexed\" = true AND \"conversation\".\"is_importing\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_type_importing_idx": {
+          "name": "conversation_type_importing_idx",
+          "columns": [
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_project_id_idx": {
+          "name": "conversation_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_project_timeline_idx": {
+          "name": "conversation_project_timeline_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_importing",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_project_id_project_id_fk": {
+          "name": "conversation_project_id_project_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_content_id_conversation_content_id_fk": {
+          "name": "conversation_current_content_id_conversation_content_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_current_ranking_score_id_ranking_score_id_fk": {
+          "name": "conversation_current_ranking_score_id_ranking_score_id_fk",
+          "tableFrom": "conversation",
+          "tableTo": "ranking_score",
+          "columnsFrom": [
+            "current_ranking_score_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_slug_id_unique": {
+          "name": "conversation_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "conversation_current_content_id_unique": {
+          "name": "conversation_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "conversation_current_ranking_score_id_unique": {
+          "name": "conversation_current_ranking_score_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_ranking_score_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "conversation_preferred_opinion_group_count_check": {
+          "name": "conversation_preferred_opinion_group_count_check",
+          "value": "\"conversation\".\"preferred_opinion_group_count\" IS NULL OR \"conversation\".\"preferred_opinion_group_count\" >= 2"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_topic": {
+      "name": "conversation_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversation_topic_conversation_id_conversation_id_fk": {
+          "name": "conversation_topic_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_topic_topic_id_topic_id_fk": {
+          "name": "conversation_topic_topic_id_topic_id_fk",
+          "tableFrom": "conversation_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversation_topic_unique": {
+          "name": "conversation_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversation_view_snapshot_checkpoint_reason": {
+      "name": "conversation_view_snapshot_checkpoint_reason",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_view_snapshot_checkpoint_reason_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_view_snapshot_id": {
+          "name": "conversation_view_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "conversation_view_snapshot_checkpoint_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_count": {
+          "name": "group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_group_count": {
+          "name": "previous_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant_milestone": {
+          "name": "participant_milestone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vote_milestone": {
+          "name": "vote_milestone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_view_snapshot_checkpoint_reason_snapshot_idx": {
+          "name": "conversation_view_snapshot_checkpoint_reason_snapshot_idx",
+          "columns": [
+            {
+              "expression": "conversation_view_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_first_displayable_unique": {
+          "name": "conversation_view_snapshot_checkpoint_first_displayable_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'first_displayable_analysis'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_group_count_unique": {
+          "name": "conversation_view_snapshot_checkpoint_group_count_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "group_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'first_group_count_available'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_default_change_unique": {
+          "name": "conversation_view_snapshot_checkpoint_default_change_unique",
+          "columns": [
+            {
+              "expression": "conversation_view_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'default_group_count_changed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_participant_unique": {
+          "name": "conversation_view_snapshot_checkpoint_participant_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "participant_milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'major_participation_milestone'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_vote_unique": {
+          "name": "conversation_view_snapshot_checkpoint_vote_unique",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "vote_milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'major_vote_milestone'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_checkpoint_closed_unique": {
+          "name": "conversation_view_snapshot_checkpoint_closed_unique",
+          "columns": [
+            {
+              "expression": "conversation_view_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'conversation_closed'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_view_snapshot_checkpoint_reason_conversation_view_snapshot_id_conversation_view_snapshot_id_fk": {
+          "name": "conversation_view_snapshot_checkpoint_reason_conversation_view_snapshot_id_conversation_view_snapshot_id_fk",
+          "tableFrom": "conversation_view_snapshot_checkpoint_reason",
+          "tableTo": "conversation_view_snapshot",
+          "columnsFrom": [
+            "conversation_view_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_checkpoint_reason_conversation_id_conversation_id_fk": {
+          "name": "conversation_view_snapshot_checkpoint_reason_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_view_snapshot_checkpoint_reason",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_checkpoint_reason_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "conversation_view_snapshot_checkpoint_reason_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "conversation_view_snapshot_checkpoint_reason",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_view_snapshot_checkpoint_reason_group_count_check": {
+          "name": "conversation_view_snapshot_checkpoint_reason_group_count_check",
+          "value": "((\"conversation_view_snapshot_checkpoint_reason\".\"reason\" IN ('first_group_count_available', 'default_group_count_changed') AND \"conversation_view_snapshot_checkpoint_reason\".\"group_count\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"group_count\" >= 2 AND (\"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL OR \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" >= 2)) OR (\"conversation_view_snapshot_checkpoint_reason\".\"reason\" NOT IN ('first_group_count_available', 'default_group_count_changed') AND \"conversation_view_snapshot_checkpoint_reason\".\"group_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL))"
+        },
+        "conversation_view_snapshot_checkpoint_reason_milestone_check": {
+          "name": "conversation_view_snapshot_checkpoint_reason_milestone_check",
+          "value": "((\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'major_participation_milestone' AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" >= \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" > 0) OR (\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'major_vote_milestone' AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" >= \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" > 0) OR (\"conversation_view_snapshot_checkpoint_reason\".\"reason\" NOT IN ('major_participation_milestone', 'major_vote_milestone') AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" IS NULL))"
+        },
+        "conversation_view_snapshot_checkpoint_reason_previous_check": {
+          "name": "conversation_view_snapshot_checkpoint_reason_previous_check",
+          "value": "((\"conversation_view_snapshot_checkpoint_reason\".\"reason\" = 'default_group_count_changed' AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NOT NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" <> \"conversation_view_snapshot_checkpoint_reason\".\"group_count\" AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"participant_milestone\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_count\" IS NULL AND \"conversation_view_snapshot_checkpoint_reason\".\"vote_milestone\" IS NULL) OR (\"conversation_view_snapshot_checkpoint_reason\".\"reason\" <> 'default_group_count_changed' AND \"conversation_view_snapshot_checkpoint_reason\".\"previous_group_count\" IS NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.conversation_view_snapshot": {
+      "name": "conversation_view_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "conversation_view_snapshot_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_id": {
+          "name": "analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "survey_aggregate_snapshot_id": {
+          "name": "survey_aggregate_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "view_reason": {
+          "name": "view_reason",
+          "type": "conversation_view_snapshot_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferred_opinion_group_count": {
+          "name": "preferred_opinion_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_closed": {
+          "name": "is_closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_count": {
+          "name": "opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_vote_count": {
+          "name": "total_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_participant_count": {
+          "name": "total_participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderated_opinion_count": {
+          "name": "moderated_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hidden_opinion_count": {
+          "name": "hidden_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_view_snapshot_latest_idx": {
+          "name": "conversation_view_snapshot_latest_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_latest_active_idx": {
+          "name": "conversation_view_snapshot_latest_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_view_snapshot\".\"activated_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_latest_spec_active_idx": {
+          "name": "conversation_view_snapshot_latest_spec_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "opinion_group_spec_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_view_snapshot\".\"activated_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversation_view_snapshot_analysis_snapshot_idx": {
+          "name": "conversation_view_snapshot_analysis_snapshot_idx",
+          "columns": [
+            {
+              "expression": "analysis_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"conversation_view_snapshot\".\"analysis_snapshot_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversation_view_snapshot_conversation_id_conversation_id_fk": {
+          "name": "conversation_view_snapshot_conversation_id_conversation_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "conversation_view_snapshot_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "conversation_view_snapshot_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk": {
+          "name": "conversation_view_snapshot_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "survey_aggregate_snapshot",
+          "columnsFrom": [
+            "survey_aggregate_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversation_view_snapshot_conversation_content_id_conversation_content_id_fk": {
+          "name": "conversation_view_snapshot_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "conversation_view_snapshot",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "conversation_view_snapshot_counts_check": {
+          "name": "conversation_view_snapshot_counts_check",
+          "value": "\"conversation_view_snapshot\".\"opinion_count\" >= 0 AND \"conversation_view_snapshot\".\"vote_count\" >= 0 AND \"conversation_view_snapshot\".\"participant_count\" >= 0 AND \"conversation_view_snapshot\".\"total_opinion_count\" >= 0 AND \"conversation_view_snapshot\".\"total_vote_count\" >= 0 AND \"conversation_view_snapshot\".\"total_participant_count\" >= 0 AND \"conversation_view_snapshot\".\"moderated_opinion_count\" >= 0 AND \"conversation_view_snapshot\".\"hidden_opinion_count\" >= 0"
+        },
+        "conversation_view_snapshot_preferred_opinion_group_count_check": {
+          "name": "conversation_view_snapshot_preferred_opinion_group_count_check",
+          "value": "\"conversation_view_snapshot\".\"preferred_opinion_group_count\" IS NULL OR (\"conversation_view_snapshot\".\"preferred_opinion_group_count\" >= 2 AND \"conversation_view_snapshot\".\"preferred_opinion_group_count\" <= 6)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.device": {
+      "name": "device",
+      "schema": "",
+      "columns": {
+        "did_write": {
+          "name": "did_write",
+          "type": "varchar(1000)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_expiry": {
+          "name": "session_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_user_id_user_id_fk": {
+          "name": "device_user_id_user_id_fk",
+          "tableFrom": "device",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email": {
+      "name": "email",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "email_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "email_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email_reachability": {
+          "name": "email_reachability",
+          "type": "email_reachability",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_active_unique": {
+          "name": "email_active_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_user_id_user_id_fk": {
+          "name": "email_user_id_user_id_fk",
+          "tableFrom": "email",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_canonical_check": {
+          "name": "email_canonical_check",
+          "value": "\"email\".\"email\" = lower(btrim(\"email\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.event_ticket": {
+      "name": "event_ticket",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "event_ticket_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "ticket_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_slug": {
+          "name": "event_slug",
+          "type": "event_slug",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pcd_type": {
+          "name": "pcd_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_metadata": {
+          "name": "provider_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_event_idx": {
+          "name": "user_event_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_ticket_nullifier_event_active_unique": {
+          "name": "event_ticket_nullifier_event_active_unique",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"event_ticket\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "nullifier_idx": {
+          "name": "nullifier_idx",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_ticket_user_id_user_id_fk": {
+          "name": "event_ticket_user_id_user_id_fk",
+          "tableFrom": "event_ticket",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.followed_topic": {
+      "name": "followed_topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "followed_topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "followed_topic_user_id_user_id_fk": {
+          "name": "followed_topic_user_id_user_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "followed_topic_topic_id_topic_id_fk": {
+          "name": "followed_topic_topic_id_topic_id_fk",
+          "tableFrom": "followed_topic",
+          "tableTo": "topic",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "followed_topic_unique": {
+          "name": "followed_topic_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "topic_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_comparison": {
+      "name": "maxdiff_comparison",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_comparison_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_result_id": {
+          "name": "maxdiff_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "best_slug_id": {
+          "name": "best_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "worst_slug_id": {
+          "name": "worst_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_set": {
+          "name": "candidate_set",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "maxdiff_comparison_result_idx": {
+          "name": "maxdiff_comparison_result_idx",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_comparison_active_result_position_unique": {
+          "name": "maxdiff_comparison_active_result_position_unique",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"maxdiff_comparison\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_comparison_maxdiff_result_id_maxdiff_result_id_fk": {
+          "name": "maxdiff_comparison_maxdiff_result_id_maxdiff_result_id_fk",
+          "tableFrom": "maxdiff_comparison",
+          "tableTo": "maxdiff_result",
+          "columnsFrom": [
+            "maxdiff_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item_content": {
+      "name": "maxdiff_item_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_item_id": {
+          "name": "maxdiff_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "maxdiff_item_content_maxdiff_item_id_maxdiff_item_id_fk": {
+          "name": "maxdiff_item_content_maxdiff_item_id_maxdiff_item_id_fk",
+          "tableFrom": "maxdiff_item_content",
+          "tableTo": "maxdiff_item",
+          "columnsFrom": [
+            "maxdiff_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "maxdiff_item_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "maxdiff_item_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item_external_source": {
+      "name": "maxdiff_item_external_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_external_source_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_item_id": {
+          "name": "maxdiff_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "external_source_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_metadata": {
+          "name": "external_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_external_source_dedup_idx": {
+          "name": "maxdiff_external_source_dedup_idx",
+          "columns": [
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_item_external_source_maxdiff_item_id_maxdiff_item_id_fk": {
+          "name": "maxdiff_item_external_source_maxdiff_item_id_maxdiff_item_id_fk",
+          "tableFrom": "maxdiff_item_external_source",
+          "tableTo": "maxdiff_item",
+          "columnsFrom": [
+            "maxdiff_item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_external_source_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_item_external_source_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_item_external_source",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_item_external_source_maxdiff_item_id_unique": {
+          "name": "maxdiff_item_external_source_maxdiff_item_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "maxdiff_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_item": {
+      "name": "maxdiff_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_item_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "maxdiff_lifecycle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "snapshot_score": {
+          "name": "snapshot_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_rank": {
+          "name": "snapshot_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_participant_count": {
+          "name": "snapshot_participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_item_conversation_active_idx": {
+          "name": "maxdiff_item_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_item_lifecycle_idx": {
+          "name": "maxdiff_item_lifecycle_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_item_author_id_user_id_fk": {
+          "name": "maxdiff_item_author_id_user_id_fk",
+          "tableFrom": "maxdiff_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_item_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_item_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_item",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_item_slug_id_unique": {
+          "name": "maxdiff_item_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_result": {
+      "name": "maxdiff_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_result_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ranking": {
+          "name": "ranking",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comparisons": {
+          "name": "comparisons",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_complete": {
+          "name": "is_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "maxdiff_result_complete_idx": {
+          "name": "maxdiff_result_complete_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_complete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "maxdiff_result_conversation_idx": {
+          "name": "maxdiff_result_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_result_participant_id_user_id_fk": {
+          "name": "maxdiff_result_participant_id_user_id_fk",
+          "tableFrom": "maxdiff_result",
+          "tableTo": "user",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "maxdiff_result_conversation_id_conversation_id_fk": {
+          "name": "maxdiff_result_conversation_id_conversation_id_fk",
+          "tableFrom": "maxdiff_result",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_result_participant_id_conversation_id_unique": {
+          "name": "maxdiff_result_participant_id_conversation_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant_id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.maxdiff_user_entity_score": {
+      "name": "maxdiff_user_entity_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "maxdiff_user_entity_score_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "maxdiff_result_id": {
+          "name": "maxdiff_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug_id": {
+          "name": "entity_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_left": {
+          "name": "uncertainty_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_right": {
+          "name": "uncertainty_right",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "maxdiff_user_entity_score_result_score_idx": {
+          "name": "maxdiff_user_entity_score_result_score_idx",
+          "columns": [
+            {
+              "expression": "maxdiff_result_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"score\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "maxdiff_user_entity_score_maxdiff_result_id_maxdiff_result_id_fk": {
+          "name": "maxdiff_user_entity_score_maxdiff_result_id_maxdiff_result_id_fk",
+          "tableFrom": "maxdiff_user_entity_score",
+          "tableTo": "maxdiff_result",
+          "columnsFrom": [
+            "maxdiff_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "maxdiff_user_entity_score_maxdiff_result_id_entity_slug_id_unique": {
+          "name": "maxdiff_user_entity_score_maxdiff_result_id_entity_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "maxdiff_result_id",
+            "entity_slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_export": {
+      "name": "notification_export",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_export_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_request_id": {
+          "name": "export_request_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "export_slug_id": {
+          "name": "export_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "export_failure_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "export_cancellation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_export_notification_idx": {
+          "name": "notification_export_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_export_notification_id_notification_id_fk": {
+          "name": "notification_export_notification_id_notification_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_export_export_request_id_conversation_export_request_id_fk": {
+          "name": "notification_export_export_request_id_conversation_export_request_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "conversation_export_request",
+          "columnsFrom": [
+            "export_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_export_conversation_id_conversation_id_fk": {
+          "name": "notification_export_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_export",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_import": {
+      "name": "notification_import",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_import_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_id": {
+          "name": "import_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_import_notification_idx": {
+          "name": "notification_import_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_import_notification_id_notification_id_fk": {
+          "name": "notification_import_notification_id_notification_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_import_import_id_conversation_import_id_fk": {
+          "name": "notification_import_import_id_conversation_import_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "conversation_import",
+          "columnsFrom": [
+            "import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_import_conversation_id_conversation_id_fk": {
+          "name": "notification_import_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_import",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_new_opinion": {
+      "name": "notification_new_opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_new_opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_new_opinion_notification_idx": {
+          "name": "notification_new_opinion_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_new_opinion_notification_id_notification_id_fk": {
+          "name": "notification_new_opinion_notification_id_notification_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_author_id_user_id_fk": {
+          "name": "notification_new_opinion_author_id_user_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_opinion_id_opinion_id_fk": {
+          "name": "notification_new_opinion_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_new_opinion_conversation_id_conversation_id_fk": {
+          "name": "notification_new_opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_new_opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_opinion_vote": {
+      "name": "notification_opinion_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_opinion_vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_votes": {
+          "name": "num_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_opinion_vote_notification_idx": {
+          "name": "notification_opinion_vote_notification_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_opinion_vote_notification_id_notification_id_fk": {
+          "name": "notification_opinion_vote_notification_id_notification_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_opinion_id_opinion_id_fk": {
+          "name": "notification_opinion_vote_opinion_id_opinion_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notification_opinion_vote_conversation_id_conversation_id_fk": {
+          "name": "notification_opinion_vote_conversation_id_conversation_id_fk",
+          "tableFrom": "notification_opinion_vote",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "notification_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_user_created_id_idx": {
+          "name": "notification_user_created_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_user_id_user_id_fk": {
+          "name": "notification_user_id_user_id_fk",
+          "tableFrom": "notification",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_slug_id_unique": {
+          "name": "notification_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_content": {
+      "name": "opinion_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_content_id": {
+          "name": "conversation_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(3000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_content_opinion_id_opinion_id_fk": {
+          "name": "opinion_content_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_content_conversation_content_id_conversation_content_id_fk": {
+          "name": "opinion_content_conversation_content_id_conversation_content_id_fk",
+          "tableFrom": "opinion_content",
+          "tableTo": "conversation_content",
+          "columnsFrom": [
+            "conversation_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_candidate_assessment": {
+      "name": "opinion_group_candidate_assessment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_candidate_assessment_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "silhouette_score": {
+          "name": "silhouette_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coefficient_of_variation": {
+          "name": "coefficient_of_variation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "balance_score": {
+          "name": "balance_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selection_score": {
+          "name": "selection_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden_reason": {
+          "name": "hidden_reason",
+          "type": "opinion_group_candidate_hidden_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_candidate_assessment_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_candidate_assessment_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_candidate_assessment",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_assessment_candidate_id_unique": {
+          "name": "opinion_group_candidate_assessment_candidate_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_candidate_description_locale_request": {
+      "name": "opinion_group_candidate_description_locale_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_candidate_description_locale_request_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_group_candidate_description_locale_request_updated_idx": {
+          "name": "opinion_group_candidate_description_locale_request_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "og_candidate_desc_locale_request_translation_updated_idx": {
+          "name": "og_candidate_desc_locale_request_translation_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_candidate_description_locale_request\".\"locale\" <> 'en'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_group_candidate_description_locale_request_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_candidate_description_locale_request_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_candidate_description_locale_request",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_description_locale_request_unique": {
+          "name": "opinion_group_candidate_description_locale_request_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "locale"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_candidate_opinion_metrics": {
+      "name": "opinion_group_candidate_opinion_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_candidate_opinion_metrics_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_opinion_id": {
+          "name": "analysis_snapshot_opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_aware_consensus_agree": {
+          "name": "group_aware_consensus_agree",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_aware_consensus_disagree": {
+          "name": "group_aware_consensus_disagree",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "divisiveness": {
+          "name": "divisiveness",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "majority_type": {
+          "name": "majority_type",
+          "type": "vote_enum_simple",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "majority_probability_success": {
+          "name": "majority_probability_success",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agreement_rank": {
+          "name": "agreement_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disagreement_rank": {
+          "name": "disagreement_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "divisiveness_rank": {
+          "name": "divisiveness_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_candidate_opinion_metrics_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_candidate_opinion_metrics_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_candidate_opinion_metrics",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_candidate_opinion_metrics_analysis_snapshot_opinion_id_analysis_snapshot_opinion_id_fk": {
+          "name": "opinion_group_candidate_opinion_metrics_analysis_snapshot_opinion_id_analysis_snapshot_opinion_id_fk",
+          "tableFrom": "opinion_group_candidate_opinion_metrics",
+          "tableTo": "analysis_snapshot_opinion",
+          "columnsFrom": [
+            "analysis_snapshot_opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_opinion_metrics_unique": {
+          "name": "opinion_group_candidate_opinion_metrics_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "analysis_snapshot_opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_candidate_opinion_metrics_majority_check": {
+          "name": "opinion_group_candidate_opinion_metrics_majority_check",
+          "value": "(\"opinion_group_candidate_opinion_metrics\".\"majority_type\" IS NULL AND \"opinion_group_candidate_opinion_metrics\".\"majority_probability_success\" IS NULL) OR (\"opinion_group_candidate_opinion_metrics\".\"majority_type\" IS NOT NULL AND \"opinion_group_candidate_opinion_metrics\".\"majority_probability_success\" IS NOT NULL)"
+        },
+        "opinion_group_candidate_opinion_metrics_rank_check": {
+          "name": "opinion_group_candidate_opinion_metrics_rank_check",
+          "value": "(\"opinion_group_candidate_opinion_metrics\".\"agreement_rank\" IS NULL OR \"opinion_group_candidate_opinion_metrics\".\"agreement_rank\" > 0) AND (\"opinion_group_candidate_opinion_metrics\".\"disagreement_rank\" IS NULL OR \"opinion_group_candidate_opinion_metrics\".\"disagreement_rank\" > 0) AND (\"opinion_group_candidate_opinion_metrics\".\"divisiveness_rank\" IS NULL OR \"opinion_group_candidate_opinion_metrics\".\"divisiveness_rank\" > 0)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_candidate": {
+      "name": "opinion_group_candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_candidate_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "snapshot_result_id": {
+          "name": "snapshot_result_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_variant_id": {
+          "name": "opinion_group_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "analysis_result_outcome_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome_reason": {
+          "name": "outcome_reason",
+          "type": "analysis_insufficient_data_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_output": {
+          "name": "raw_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_candidate_snapshot_result_id_analysis_snapshot_result_id_fk": {
+          "name": "opinion_group_candidate_snapshot_result_id_analysis_snapshot_result_id_fk",
+          "tableFrom": "opinion_group_candidate",
+          "tableTo": "analysis_snapshot_result",
+          "columnsFrom": [
+            "snapshot_result_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_candidate_opinion_group_variant_id_opinion_group_variant_id_fk": {
+          "name": "opinion_group_candidate_opinion_group_variant_id_opinion_group_variant_id_fk",
+          "tableFrom": "opinion_group_candidate",
+          "tableTo": "opinion_group_variant",
+          "columnsFrom": [
+            "opinion_group_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_candidate_scope_id_opinion_group_lineage_scope_id_fk": {
+          "name": "opinion_group_candidate_scope_id_opinion_group_lineage_scope_id_fk",
+          "tableFrom": "opinion_group_candidate",
+          "tableTo": "opinion_group_lineage_scope",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_variant_unique": {
+          "name": "opinion_group_candidate_variant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "snapshot_result_id",
+            "opinion_group_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_candidate_reason_check": {
+          "name": "opinion_group_candidate_reason_check",
+          "value": "(\"opinion_group_candidate\".\"outcome\" = 'insufficient_data' AND \"opinion_group_candidate\".\"outcome_reason\" IS NOT NULL) OR (\"opinion_group_candidate\".\"outcome\" = 'success' AND \"opinion_group_candidate\".\"outcome_reason\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_description": {
+      "name": "opinion_group_description",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_description_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_description_translation": {
+      "name": "opinion_group_description_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_description_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description_id": {
+          "name": "description_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_description_translation_description_id_opinion_group_description_id_fk": {
+          "name": "opinion_group_description_translation_description_id_opinion_group_description_id_fk",
+          "tableFrom": "opinion_group_description_translation",
+          "tableTo": "opinion_group_description",
+          "columnsFrom": [
+            "description_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_description_translation_unique": {
+          "name": "opinion_group_description_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description_id",
+            "locale"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_description_translation_work": {
+      "name": "opinion_group_description_translation_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_description_translation_work_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "description_id": {
+          "name": "description_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_retryable_ai_description_epoch": {
+          "name": "non_retryable_ai_description_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_group_description_translation_work_lease_expiry_idx": {
+          "name": "opinion_group_description_translation_work_lease_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_description_translation_work\".\"lease_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_group_description_translation_work_claim_idx": {
+          "name": "opinion_group_description_translation_work_claim_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_description_translation_work\".\"lease_token\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_group_description_translation_work_description_id_opinion_group_description_id_fk": {
+          "name": "opinion_group_description_translation_work_description_id_opinion_group_description_id_fk",
+          "tableFrom": "opinion_group_description_translation_work",
+          "tableTo": "opinion_group_description",
+          "columnsFrom": [
+            "description_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_description_translation_work_conversation_id_conversation_id_fk": {
+          "name": "opinion_group_description_translation_work_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion_group_description_translation_work",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_description_translation_work_unique": {
+          "name": "opinion_group_description_translation_work_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description_id",
+            "locale"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_description_translation_work_running_lease_check": {
+          "name": "opinion_group_description_translation_work_running_lease_check",
+          "value": "((\"opinion_group_description_translation_work\".\"lease_owner\" is null AND \"opinion_group_description_translation_work\".\"lease_token\" is null AND \"opinion_group_description_translation_work\".\"lease_expires_at\" is null) OR (\"opinion_group_description_translation_work\".\"lease_owner\" is not null AND \"opinion_group_description_translation_work\".\"lease_token\" is not null AND \"opinion_group_description_translation_work\".\"lease_expires_at\" is not null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_lineage_description_work": {
+      "name": "opinion_group_lineage_description_work",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_lineage_description_work_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_candidate_id": {
+          "name": "source_candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_retryable_ai_description_epoch": {
+          "name": "non_retryable_ai_description_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_message": {
+          "name": "last_error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_group_lineage_description_work_lease_expiry_idx": {
+          "name": "opinion_group_lineage_description_work_lease_expiry_idx",
+          "columns": [
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_lineage_description_work\".\"lease_token\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_group_lineage_description_work_claim_idx": {
+          "name": "opinion_group_lineage_description_work_claim_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion_group_lineage_description_work\".\"lease_token\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_group_lineage_description_work_lineage_id_opinion_group_lineage_id_fk": {
+          "name": "opinion_group_lineage_description_work_lineage_id_opinion_group_lineage_id_fk",
+          "tableFrom": "opinion_group_lineage_description_work",
+          "tableTo": "opinion_group_lineage",
+          "columnsFrom": [
+            "lineage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_description_work_conversation_id_conversation_id_fk": {
+          "name": "opinion_group_lineage_description_work_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion_group_lineage_description_work",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_description_work_source_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_lineage_description_work_source_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_lineage_description_work",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "source_candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_lineage_description_work_unique": {
+          "name": "opinion_group_lineage_description_work_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_lineage_description_work_running_lease_check": {
+          "name": "opinion_group_lineage_description_work_running_lease_check",
+          "value": "((\"opinion_group_lineage_description_work\".\"lease_owner\" is null AND \"opinion_group_lineage_description_work\".\"lease_token\" is null AND \"opinion_group_lineage_description_work\".\"lease_expires_at\" is null) OR (\"opinion_group_lineage_description_work\".\"lease_owner\" is not null AND \"opinion_group_lineage_description_work\".\"lease_token\" is not null AND \"opinion_group_lineage_description_work\".\"lease_expires_at\" is not null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_lineage_scope": {
+      "name": "opinion_group_lineage_scope",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_lineage_scope_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_group_variant_id": {
+          "name": "opinion_group_variant_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_lineage_scope_conversation_id_conversation_id_fk": {
+          "name": "opinion_group_lineage_scope_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion_group_lineage_scope",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_scope_opinion_group_variant_id_opinion_group_variant_id_fk": {
+          "name": "opinion_group_lineage_scope_opinion_group_variant_id_opinion_group_variant_id_fk",
+          "tableFrom": "opinion_group_lineage_scope",
+          "tableTo": "opinion_group_variant",
+          "columnsFrom": [
+            "opinion_group_variant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_lineage_scope_unique": {
+          "name": "opinion_group_lineage_scope_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "opinion_group_variant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_lineage": {
+      "name": "opinion_group_lineage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_lineage_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_description_id": {
+          "name": "system_description_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_description_id": {
+          "name": "admin_description_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_lineage_scope_id_opinion_group_lineage_scope_id_fk": {
+          "name": "opinion_group_lineage_scope_id_opinion_group_lineage_scope_id_fk",
+          "tableFrom": "opinion_group_lineage",
+          "tableTo": "opinion_group_lineage_scope",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_system_description_id_opinion_group_description_id_fk": {
+          "name": "opinion_group_lineage_system_description_id_opinion_group_description_id_fk",
+          "tableFrom": "opinion_group_lineage",
+          "tableTo": "opinion_group_description",
+          "columnsFrom": [
+            "system_description_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_admin_description_id_opinion_group_description_id_fk": {
+          "name": "opinion_group_lineage_admin_description_id_opinion_group_description_id_fk",
+          "tableFrom": "opinion_group_lineage",
+          "tableTo": "opinion_group_description",
+          "columnsFrom": [
+            "admin_description_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_opinion_stats": {
+      "name": "opinion_group_opinion_stats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_opinion_stats_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_opinion_id": {
+          "name": "analysis_snapshot_opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_passes": {
+          "name": "num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "representative_agreement_type": {
+          "name": "representative_agreement_type",
+          "type": "vote_enum_simple",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_probability_agreement": {
+          "name": "representative_probability_agreement",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_number_agreement": {
+          "name": "representative_number_agreement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_repness": {
+          "name": "raw_repness",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_group_opinion_stats_representative_idx": {
+          "name": "opinion_group_opinion_stats_representative_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "representative_probability_agreement",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "analysis_snapshot_opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"opinion_group_opinion_stats\".\"representative_agreement_type\" is not null AND \"opinion_group_opinion_stats\".\"representative_probability_agreement\" is not null)",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_group_opinion_stats_group_id_opinion_group_id_fk": {
+          "name": "opinion_group_opinion_stats_group_id_opinion_group_id_fk",
+          "tableFrom": "opinion_group_opinion_stats",
+          "tableTo": "opinion_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_opinion_stats_analysis_snapshot_opinion_id_analysis_snapshot_opinion_id_fk": {
+          "name": "opinion_group_opinion_stats_analysis_snapshot_opinion_id_analysis_snapshot_opinion_id_fk",
+          "tableFrom": "opinion_group_opinion_stats",
+          "tableTo": "analysis_snapshot_opinion",
+          "columnsFrom": [
+            "analysis_snapshot_opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_opinion_stats_unique": {
+          "name": "opinion_group_opinion_stats_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "analysis_snapshot_opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_opinion_stats_counts_check": {
+          "name": "opinion_group_opinion_stats_counts_check",
+          "value": "\"opinion_group_opinion_stats\".\"num_agrees\" >= 0 AND \"opinion_group_opinion_stats\".\"num_disagrees\" >= 0 AND \"opinion_group_opinion_stats\".\"num_passes\" >= 0"
+        },
+        "opinion_group_opinion_stats_representative_check": {
+          "name": "opinion_group_opinion_stats_representative_check",
+          "value": "((\"opinion_group_opinion_stats\".\"representative_agreement_type\" IS NULL AND \"opinion_group_opinion_stats\".\"representative_probability_agreement\" IS NULL AND \"opinion_group_opinion_stats\".\"representative_number_agreement\" IS NULL AND \"opinion_group_opinion_stats\".\"raw_repness\" IS NULL) OR (\"opinion_group_opinion_stats\".\"representative_agreement_type\" IS NOT NULL AND \"opinion_group_opinion_stats\".\"representative_probability_agreement\" IS NOT NULL AND \"opinion_group_opinion_stats\".\"representative_number_agreement\" IS NOT NULL AND \"opinion_group_opinion_stats\".\"raw_repness\" IS NOT NULL))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_spec": {
+      "name": "opinion_group_spec",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_spec_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "analysis_spec_id": {
+          "name": "analysis_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reducer": {
+          "name": "reducer",
+          "type": "opinion_group_reducer_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clusterer": {
+          "name": "clusterer",
+          "type": "opinion_group_clusterer_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selection_policy": {
+          "name": "selection_policy",
+          "type": "opinion_group_selection_policy_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_clusterable_participants": {
+          "name": "min_clusterable_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_votes_per_participant": {
+          "name": "min_votes_per_participant",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_group_count": {
+          "name": "max_group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_spec_analysis_spec_id_analysis_spec_id_fk": {
+          "name": "opinion_group_spec_analysis_spec_id_analysis_spec_id_fk",
+          "tableFrom": "opinion_group_spec",
+          "tableTo": "analysis_spec",
+          "columnsFrom": [
+            "analysis_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_spec_key_version_unique": {
+          "name": "opinion_group_spec_key_version_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key",
+            "version"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group": {
+      "name": "opinion_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lineage_id": {
+          "name": "lineage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "num_users": {
+          "name": "num_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_scope_id_opinion_group_lineage_scope_id_fk": {
+          "name": "opinion_group_scope_id_opinion_group_lineage_scope_id_fk",
+          "tableFrom": "opinion_group",
+          "tableTo": "opinion_group_lineage_scope",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_lineage_id_opinion_group_lineage_id_fk": {
+          "name": "opinion_group_lineage_id_opinion_group_lineage_id_fk",
+          "tableFrom": "opinion_group",
+          "tableTo": "opinion_group_lineage",
+          "columnsFrom": [
+            "lineage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_candidate_key_unique": {
+          "name": "opinion_group_candidate_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "key"
+          ]
+        },
+        "opinion_group_candidate_lineage_unique": {
+          "name": "opinion_group_candidate_lineage_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "lineage_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_user": {
+      "name": "opinion_group_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_user_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_user_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "opinion_group_user_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "opinion_group_user",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_user_group_id_opinion_group_id_fk": {
+          "name": "opinion_group_user_group_id_opinion_group_id_fk",
+          "tableFrom": "opinion_group_user",
+          "tableTo": "opinion_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_group_user_user_id_user_id_fk": {
+          "name": "opinion_group_user_user_id_user_id_fk",
+          "tableFrom": "opinion_group_user",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_user_candidate_unique": {
+          "name": "opinion_group_user_candidate_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "candidate_id",
+            "user_id"
+          ]
+        },
+        "opinion_group_user_group_unique": {
+          "name": "opinion_group_user_group_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_group_variant": {
+      "name": "opinion_group_variant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_group_variant_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_group_spec_id": {
+          "name": "opinion_group_spec_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_count": {
+          "name": "group_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_group_variant_opinion_group_spec_id_opinion_group_spec_id_fk": {
+          "name": "opinion_group_variant_opinion_group_spec_id_opinion_group_spec_id_fk",
+          "tableFrom": "opinion_group_variant",
+          "tableTo": "opinion_group_spec",
+          "columnsFrom": [
+            "opinion_group_spec_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_group_variant_spec_count_unique": {
+          "name": "opinion_group_variant_spec_count_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "opinion_group_spec_id",
+            "group_count"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "opinion_group_variant_group_count_check": {
+          "name": "opinion_group_variant_group_count_check",
+          "value": "\"opinion_group_variant\".\"group_count\" >= 2"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.opinion_moderation": {
+      "name": "opinion_moderation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_moderation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "moderation_action": {
+          "name": "moderation_action",
+          "type": "opinion_moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_reason": {
+          "name": "moderation_reason",
+          "type": "moderation_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "moderation_explanation": {
+          "name": "moderation_explanation",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "opinion_moderation_opinion_id_opinion_id_fk": {
+          "name": "opinion_moderation_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_moderation_author_id_user_id_fk": {
+          "name": "opinion_moderation_author_id_user_id_fk",
+          "tableFrom": "opinion_moderation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_moderation_opinion_id_unique": {
+          "name": "opinion_moderation_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion_report": {
+      "name": "opinion_report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_report_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_reason": {
+          "name": "report_reason",
+          "type": "report_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "report_explanation": {
+          "name": "report_explanation",
+          "type": "varchar(260)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_id_idx": {
+          "name": "opinion_id_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_report_opinion_id_opinion_id_fk": {
+          "name": "opinion_report_opinion_id_opinion_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_report_author_id_user_id_fk": {
+          "name": "opinion_report_author_id_user_id_fk",
+          "tableFrom": "opinion_report",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.opinion": {
+      "name": "opinion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "opinion_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_seed": {
+          "name": "is_seed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "num_agrees": {
+          "name": "num_agrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_disagrees": {
+          "name": "num_disagrees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_passes": {
+          "name": "num_passes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_reacted_at": {
+          "name": "last_reacted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "opinion_authorId_idx": {
+          "name": "opinion_authorId_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_author_active_created_id_idx": {
+          "name": "opinion_author_active_created_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_conversation_active_idx": {
+          "name": "opinion_conversation_active_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "opinion_conversation_active_created_id_idx": {
+          "name": "opinion_conversation_active_created_id_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"opinion\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "opinion_author_id_user_id_fk": {
+          "name": "opinion_author_id_user_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_conversation_id_conversation_id_fk": {
+          "name": "opinion_conversation_id_conversation_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "opinion_current_content_id_opinion_content_id_fk": {
+          "name": "opinion_current_content_id_opinion_content_id_fk",
+          "tableFrom": "opinion",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "opinion_slug_id_unique": {
+          "name": "opinion_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_membership_all_project_capability": {
+      "name": "organization_membership_all_project_capability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_membership_all_project_capability_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_membership_id": {
+          "name": "organization_membership_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "organization_membership_all_project_capability_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_membership_all_project_capability_organization_membership_id_organization_membership_id_fk": {
+          "name": "organization_membership_all_project_capability_organization_membership_id_organization_membership_id_fk",
+          "tableFrom": "organization_membership_all_project_capability",
+          "tableTo": "organization_membership",
+          "columnsFrom": [
+            "organization_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_membership_all_project_capability_unique": {
+          "name": "organization_membership_all_project_capability_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_membership_id",
+            "capability"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_membership_capability": {
+      "name": "organization_membership_capability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_membership_capability_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_membership_id": {
+          "name": "organization_membership_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability": {
+          "name": "capability",
+          "type": "organization_membership_capability_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_membership_capability_organization_membership_id_organization_membership_id_fk": {
+          "name": "organization_membership_capability_organization_membership_id_organization_membership_id_fk",
+          "tableFrom": "organization_membership_capability",
+          "tableTo": "organization_membership",
+          "columnsFrom": [
+            "organization_membership_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_membership_capability_unique": {
+          "name": "organization_membership_capability_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "organization_membership_id",
+            "capability"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_membership": {
+      "name": "organization_membership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_membership_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organization_membership_organization_idx": {
+          "name": "organization_membership_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "organization_membership_user_id_user_id_fk": {
+          "name": "organization_membership_user_id_user_id_fk",
+          "tableFrom": "organization_membership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_membership_organization_id_organization_id_fk": {
+          "name": "organization_membership_organization_id_organization_id_fk",
+          "tableFrom": "organization_membership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_membership_user_organization_unique": {
+          "name": "organization_membership_user_organization_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "organization_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directory_visibility": {
+          "name": "directory_visibility",
+          "type": "directory_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_provisioned_for_user_id": {
+          "name": "auto_provisioned_for_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_full_image_path": {
+          "name": "is_full_image_path",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(280)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_auto_provisioned_for_user_id_user_id_fk": {
+          "name": "organization_auto_provisioned_for_user_id_user_id_fk",
+          "tableFrom": "organization",
+          "tableTo": "user",
+          "columnsFrom": [
+            "auto_provisioned_for_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "organization_auto_provisioned_for_user_id_unique": {
+          "name": "organization_auto_provisioned_for_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auto_provisioned_for_user_id"
+          ]
+        },
+        "organization_website_url_unique": {
+          "name": "organization_website_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "website_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.otp_email_destination_state": {
+      "name": "otp_email_destination_state",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failed_verify_attempts": {
+          "name": "consecutive_failed_verify_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff_until": {
+          "name": "backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otp_email_destination_updated_idx": {
+          "name": "otp_email_destination_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "otp_email_destination_canonical_check": {
+          "name": "otp_email_destination_canonical_check",
+          "value": "\"otp_email_destination_state\".\"email\" = lower(btrim(\"otp_email_destination_state\".\"email\"))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.otp_phone_destination_state": {
+      "name": "otp_phone_destination_state",
+      "schema": "",
+      "columns": {
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_otp_sent_at": {
+          "name": "last_otp_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consecutive_failed_verify_attempts": {
+          "name": "consecutive_failed_verify_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "backoff_until": {
+          "name": "backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "otp_phone_destination_updated_idx": {
+          "name": "otp_phone_destination_updated_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.phone": {
+      "name": "phone",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "phone_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_two_digits": {
+          "name": "last_two_digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "countryCallingCode": {
+          "name": "countryCallingCode",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_country_code": {
+          "name": "phone_country_code",
+          "type": "phone_country_code",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pepper_version": {
+          "name": "pepper_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "phone_hash_active_unique": {
+          "name": "phone_hash_active_unique",
+          "columns": [
+            {
+              "expression": "phone_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"phone\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "phone_hash_idx": {
+          "name": "phone_hash_idx",
+          "columns": [
+            {
+              "expression": "phone_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "phone_user_id_user_id_fk": {
+          "name": "phone_user_id_user_id_fk",
+          "tableFrom": "phone",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "check_two_digits": {
+          "name": "check_two_digits",
+          "value": "\"phone\".\"last_two_digits\" BETWEEN 0 and 99"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.premium_feature_entitlement": {
+      "name": "premium_feature_entitlement",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "premium_feature_entitlement_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "premium_feature",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "premium_feature_entitlement_org_idx": {
+          "name": "premium_feature_entitlement_org_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "premium_feature_entitlement_organization_id_organization_id_fk": {
+          "name": "premium_feature_entitlement_organization_id_organization_id_fk",
+          "tableFrom": "premium_feature_entitlement",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "premium_feature_entitlement_created_by_user_id_user_id_fk": {
+          "name": "premium_feature_entitlement_created_by_user_id_user_id_fk",
+          "tableFrom": "premium_feature_entitlement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "premium_feature_entitlement_updated_by_user_id_user_id_fk": {
+          "name": "premium_feature_entitlement_updated_by_user_id_user_id_fk",
+          "tableFrom": "premium_feature_entitlement",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_organization_ownership": {
+      "name": "project_organization_ownership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "project_organization_ownership_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_organization_ownership_organization_idx": {
+          "name": "project_organization_ownership_organization_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_organization_ownership_project_id_project_id_fk": {
+          "name": "project_organization_ownership_project_id_project_id_fk",
+          "tableFrom": "project_organization_ownership",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "project_organization_ownership_organization_id_organization_id_fk": {
+          "name": "project_organization_ownership_organization_id_organization_id_fk",
+          "tableFrom": "project_organization_ownership",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_organization_ownership_project_org_unique": {
+          "name": "project_organization_ownership_project_org_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "project_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "directory_visibility": {
+          "name": "directory_visibility",
+          "type": "directory_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_provisioned_for_organization_id": {
+          "name": "auto_provisioned_for_organization_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_auto_provisioned_for_organization_id_organization_id_fk": {
+          "name": "project_auto_provisioned_for_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "auto_provisioned_for_organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_slug_unique": {
+          "name": "project_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "project_auto_provisioned_for_organization_id_unique": {
+          "name": "project_auto_provisioned_for_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auto_provisioned_for_organization_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_score_entity": {
+      "name": "ranking_score_entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ranking_score_entity_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "ranking_score_id": {
+          "name": "ranking_score_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_slug_id": {
+          "name": "entity_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_left": {
+          "name": "uncertainty_left",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertainty_right": {
+          "name": "uncertainty_right",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_count": {
+          "name": "participant_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ranking_score_entity_slug_idx": {
+          "name": "ranking_score_entity_slug_idx",
+          "columns": [
+            {
+              "expression": "ranking_score_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_slug_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ranking_score_entity_ranking_score_id_ranking_score_id_fk": {
+          "name": "ranking_score_entity_ranking_score_id_ranking_score_id_fk",
+          "tableFrom": "ranking_score_entity",
+          "tableTo": "ranking_score",
+          "columnsFrom": [
+            "ranking_score_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ranking_score": {
+      "name": "ranking_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "ranking_score_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scores": {
+          "name": "scores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_counts": {
+          "name": "participant_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_sources_snapshot": {
+          "name": "group_sources_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_weights_snapshot": {
+          "name": "user_weights_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pipeline_config": {
+          "name": "pipeline_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_learning": {
+          "name": "preference_learning",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "voting_rights": {
+          "name": "voting_rights",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregation_config": {
+          "name": "aggregation_config",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ranking_score_conversation_id_conversation_id_fk": {
+          "name": "ranking_score_conversation_id_conversation_id_fk",
+          "tableFrom": "ranking_score",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.realtime_event_outbox": {
+      "name": "realtime_event_outbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "realtime_event_outbox_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "realtime_event_outbox_created_at_idx": {
+          "name": "realtime_event_outbox_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "realtime_event_outbox_conversation_replay_idx": {
+          "name": "realtime_event_outbox_conversation_replay_idx",
+          "columns": [
+            {
+              "expression": "(\"payload\"->>'conversationSlugId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"realtime_event_outbox\".\"event_type\" IN ('conversation_analysis_updated', 'conversation_settings_updated')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_aggregate_option": {
+      "name": "survey_aggregate_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_aggregate_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_aggregate_question_id": {
+          "name": "survey_aggregate_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "option_slug_id": {
+          "name": "option_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_order": {
+          "name": "option_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_aggregate_option_survey_aggregate_question_id_survey_aggregate_question_id_fk": {
+          "name": "survey_aggregate_option_survey_aggregate_question_id_survey_aggregate_question_id_fk",
+          "tableFrom": "survey_aggregate_option",
+          "tableTo": "survey_aggregate_question",
+          "columnsFrom": [
+            "survey_aggregate_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_option_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_aggregate_option_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_aggregate_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_aggregate_option_question_slug_unique": {
+          "name": "survey_aggregate_option_question_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_aggregate_question_id",
+            "option_slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_aggregate_question": {
+      "name": "survey_aggregate_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_aggregate_question_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_aggregate_snapshot_id": {
+          "name": "survey_aggregate_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_slug_id": {
+          "name": "question_slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_order": {
+          "name": "question_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_public_aggregate_suppression_enabled": {
+          "name": "is_public_aggregate_suppression_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "question_semantic_version": {
+          "name": "question_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_aggregate_question_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk": {
+          "name": "survey_aggregate_question_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk",
+          "tableFrom": "survey_aggregate_question",
+          "tableTo": "survey_aggregate_snapshot",
+          "columnsFrom": [
+            "survey_aggregate_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_question_survey_question_id_survey_question_id_fk": {
+          "name": "survey_aggregate_question_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_aggregate_question",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_aggregate_question_snapshot_slug_unique": {
+          "name": "survey_aggregate_question_snapshot_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_aggregate_snapshot_id",
+            "question_slug_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_aggregate_result": {
+      "name": "survey_aggregate_result",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_aggregate_result_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_aggregate_snapshot_id": {
+          "name": "survey_aggregate_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "candidate_id": {
+          "name": "candidate_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "survey_aggregate_scope_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_aggregate_question_id": {
+          "name": "survey_aggregate_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_aggregate_option_id": {
+          "name": "survey_aggregate_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_count": {
+          "name": "suppressed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed_percentage": {
+          "name": "suppressed_percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_count": {
+          "name": "full_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_percentage": {
+          "name": "full_percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_suppressed": {
+          "name": "is_suppressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppression_reason": {
+          "name": "suppression_reason",
+          "type": "survey_aggregate_suppression_reason_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_aggregate_result_snapshot_idx": {
+          "name": "survey_aggregate_result_snapshot_idx",
+          "columns": [
+            {
+              "expression": "survey_aggregate_snapshot_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_aggregate_result_group_idx": {
+          "name": "survey_aggregate_result_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_aggregate_result_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk": {
+          "name": "survey_aggregate_result_survey_aggregate_snapshot_id_survey_aggregate_snapshot_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "survey_aggregate_snapshot",
+          "columnsFrom": [
+            "survey_aggregate_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_result_candidate_id_opinion_group_candidate_id_fk": {
+          "name": "survey_aggregate_result_candidate_id_opinion_group_candidate_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "opinion_group_candidate",
+          "columnsFrom": [
+            "candidate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_result_group_id_opinion_group_id_fk": {
+          "name": "survey_aggregate_result_group_id_opinion_group_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "opinion_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_result_survey_aggregate_question_id_survey_aggregate_question_id_fk": {
+          "name": "survey_aggregate_result_survey_aggregate_question_id_survey_aggregate_question_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "survey_aggregate_question",
+          "columnsFrom": [
+            "survey_aggregate_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_result_survey_aggregate_option_id_survey_aggregate_option_id_fk": {
+          "name": "survey_aggregate_result_survey_aggregate_option_id_survey_aggregate_option_id_fk",
+          "tableFrom": "survey_aggregate_result",
+          "tableTo": "survey_aggregate_option",
+          "columnsFrom": [
+            "survey_aggregate_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "survey_aggregate_result_scope_check": {
+          "name": "survey_aggregate_result_scope_check",
+          "value": "((\"survey_aggregate_result\".\"scope\" = 'overall' AND \"survey_aggregate_result\".\"candidate_id\" is null AND \"survey_aggregate_result\".\"group_id\" is null) OR (\"survey_aggregate_result\".\"scope\" = 'opinion_group' AND \"survey_aggregate_result\".\"candidate_id\" is not null AND \"survey_aggregate_result\".\"group_id\" is not null))"
+        },
+        "survey_aggregate_result_suppression_check": {
+          "name": "survey_aggregate_result_suppression_check",
+          "value": "((\"survey_aggregate_result\".\"is_suppressed\" = true AND \"survey_aggregate_result\".\"suppressed_count\" is null AND \"survey_aggregate_result\".\"suppressed_percentage\" is null AND \"survey_aggregate_result\".\"suppression_reason\" is not null) OR (\"survey_aggregate_result\".\"is_suppressed\" = false AND \"survey_aggregate_result\".\"suppressed_count\" is not null AND \"survey_aggregate_result\".\"suppression_reason\" is null))"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.survey_aggregate_snapshot": {
+      "name": "survey_aggregate_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_aggregate_snapshot_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_snapshot_id": {
+          "name": "analysis_snapshot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_config_id": {
+          "name": "survey_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_config_revision": {
+          "name": "survey_config_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppression_threshold": {
+          "name": "suppression_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_aggregate_snapshot_conversation_idx": {
+          "name": "survey_aggregate_snapshot_conversation_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_aggregate_snapshot_conversation_id_conversation_id_fk": {
+          "name": "survey_aggregate_snapshot_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_aggregate_snapshot",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_snapshot_analysis_snapshot_id_analysis_snapshot_id_fk": {
+          "name": "survey_aggregate_snapshot_analysis_snapshot_id_analysis_snapshot_id_fk",
+          "tableFrom": "survey_aggregate_snapshot",
+          "tableTo": "analysis_snapshot",
+          "columnsFrom": [
+            "analysis_snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_aggregate_snapshot_survey_config_id_survey_config_id_fk": {
+          "name": "survey_aggregate_snapshot_survey_config_id_survey_config_id_fk",
+          "tableFrom": "survey_aggregate_snapshot",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_aggregate_snapshot_checkpoint_unique": {
+          "name": "survey_aggregate_snapshot_checkpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "analysis_snapshot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answer_option": {
+      "name": "survey_answer_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_answer_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_answer_id": {
+          "name": "survey_answer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_answer_option_answer_option_active_uidx": {
+          "name": "survey_answer_option_answer_option_active_uidx",
+          "columns": [
+            {
+              "expression": "survey_answer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "survey_question_option_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_answer_option\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_option_survey_answer_id_survey_answer_id_fk": {
+          "name": "survey_answer_option_survey_answer_id_survey_answer_id_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_answer",
+          "columnsFrom": [
+            "survey_answer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_answer_option_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_answer_question_fk": {
+          "name": "survey_answer_option_answer_question_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_answer",
+          "columnsFrom": [
+            "survey_answer_id",
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "survey_question_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_option_option_question_fk": {
+          "name": "survey_answer_option_option_question_fk",
+          "tableFrom": "survey_answer_option",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id",
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id",
+            "survey_question_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_answer": {
+      "name": "survey_answer",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_answer_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_response_id": {
+          "name": "survey_response_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answered_question_semantic_version": {
+          "name": "answered_question_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_value_html": {
+          "name": "text_value_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_answer_response_question_active_uidx": {
+          "name": "survey_answer_response_question_active_uidx",
+          "columns": [
+            {
+              "expression": "survey_response_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "survey_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_answer\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_answer_survey_response_id_survey_response_id_fk": {
+          "name": "survey_answer_survey_response_id_survey_response_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "columnsFrom": [
+            "survey_response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_survey_question_id_survey_question_id_fk": {
+          "name": "survey_answer_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_response_conversation_fk": {
+          "name": "survey_answer_response_conversation_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_response",
+          "columnsFrom": [
+            "survey_response_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_answer_question_conversation_fk": {
+          "name": "survey_answer_question_conversation_fk",
+          "tableFrom": "survey_answer",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_answer_id_question_unique": {
+          "name": "survey_answer_id_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "survey_question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_config": {
+      "name": "survey_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_config_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_revision": {
+          "name": "current_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "survey_config_active_conversation_uidx": {
+          "name": "survey_config_active_conversation_uidx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_config\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_config_conversation_id_conversation_id_fk": {
+          "name": "survey_config_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_config",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_config_id_conversation_unique": {
+          "name": "survey_config_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_content": {
+      "name": "survey_question_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_text": {
+          "name": "question_text",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "constraints": {
+          "name": "constraints",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language_code": {
+          "name": "source_language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_language_confidence": {
+          "name": "source_language_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_content_survey_question_id_survey_question_id_fk": {
+          "name": "survey_question_content_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_question_content",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_content_translation": {
+      "name": "survey_question_content_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_content_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_content_id": {
+          "name": "survey_question_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_language_code": {
+          "name": "display_language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_question_text": {
+          "name": "translated_question_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_content_translation_survey_question_content_id_survey_question_content_id_fk": {
+          "name": "survey_question_content_translation_survey_question_content_id_survey_question_content_id_fk",
+          "tableFrom": "survey_question_content_translation",
+          "tableTo": "survey_question_content",
+          "columnsFrom": [
+            "survey_question_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_content_translation_unique": {
+          "name": "survey_question_content_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_question_content_id",
+            "display_language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option_content": {
+      "name": "survey_question_option_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_option_id": {
+          "name": "survey_question_option_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_text": {
+          "name": "option_text",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_language_code": {
+          "name": "source_language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_language_confidence": {
+          "name": "source_language_confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_option_content_survey_question_option_id_survey_question_option_id_fk": {
+          "name": "survey_question_option_content_survey_question_option_id_survey_question_option_id_fk",
+          "tableFrom": "survey_question_option_content",
+          "tableTo": "survey_question_option",
+          "columnsFrom": [
+            "survey_question_option_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option_content_translation": {
+      "name": "survey_question_option_content_translation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_content_translation_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "survey_question_option_content_id": {
+          "name": "survey_question_option_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_language_code": {
+          "name": "display_language_code",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "translated_option_text": {
+          "name": "translated_option_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_question_option_content_translation_survey_question_option_content_id_survey_question_option_content_id_fk": {
+          "name": "survey_question_option_content_translation_survey_question_option_content_id_survey_question_option_content_id_fk",
+          "tableFrom": "survey_question_option_content_translation",
+          "tableTo": "survey_question_option_content",
+          "columnsFrom": [
+            "survey_question_option_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_option_content_translation_unique": {
+          "name": "survey_question_option_content_translation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_question_option_content_id",
+            "display_language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question_option": {
+      "name": "survey_question_option",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_option_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_question_id": {
+          "name": "survey_question_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_option_active_question_display_order_uidx": {
+          "name": "survey_question_option_active_question_display_order_uidx",
+          "columns": [
+            {
+              "expression": "survey_question_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_question_option\".\"current_content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_option_survey_question_id_survey_question_id_fk": {
+          "name": "survey_question_option_survey_question_id_survey_question_id_fk",
+          "tableFrom": "survey_question_option",
+          "tableTo": "survey_question",
+          "columnsFrom": [
+            "survey_question_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_option_current_content_id_survey_question_option_content_id_fk": {
+          "name": "survey_question_option_current_content_id_survey_question_option_content_id_fk",
+          "tableFrom": "survey_question_option",
+          "tableTo": "survey_question_option_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_option_slug_id_unique": {
+          "name": "survey_question_option_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "survey_question_option_current_content_id_unique": {
+          "name": "survey_question_option_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "survey_question_option_id_question_unique": {
+          "name": "survey_question_option_id_question_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "survey_question_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_question": {
+      "name": "survey_question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_question_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug_id": {
+          "name": "slug_id",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "survey_config_id": {
+          "name": "survey_config_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "survey_question_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "choice_display": {
+          "name": "choice_display",
+          "type": "survey_choice_display",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_semantic_version": {
+          "name": "current_semantic_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_required": {
+          "name": "is_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_public_aggregate_suppression_enabled": {
+          "name": "is_public_aggregate_suppression_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_question_active_config_display_order_uidx": {
+          "name": "survey_question_active_config_display_order_uidx",
+          "columns": [
+            {
+              "expression": "survey_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"survey_question\".\"current_content_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "survey_question_config_idx": {
+          "name": "survey_question_config_idx",
+          "columns": [
+            {
+              "expression": "survey_config_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_question_survey_config_id_survey_config_id_fk": {
+          "name": "survey_question_survey_config_id_survey_config_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_conversation_id_conversation_id_fk": {
+          "name": "survey_question_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_current_content_id_survey_question_content_id_fk": {
+          "name": "survey_question_current_content_id_survey_question_content_id_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_question_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_question_config_conversation_fk": {
+          "name": "survey_question_config_conversation_fk",
+          "tableFrom": "survey_question",
+          "tableTo": "survey_config",
+          "columnsFrom": [
+            "survey_config_id",
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id",
+            "conversation_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_question_slug_id_unique": {
+          "name": "survey_question_slug_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug_id"
+          ]
+        },
+        "survey_question_current_content_id_unique": {
+          "name": "survey_question_current_content_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "current_content_id"
+          ]
+        },
+        "survey_question_id_conversation_unique": {
+          "name": "survey_question_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_response": {
+      "name": "survey_response",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "survey_response_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "survey_response_conversation_created_idx": {
+          "name": "survey_response_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "survey_response_participant_id_user_id_fk": {
+          "name": "survey_response_participant_id_user_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "user",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "survey_response_conversation_id_conversation_id_fk": {
+          "name": "survey_response_conversation_id_conversation_id_fk",
+          "tableFrom": "survey_response",
+          "tableTo": "conversation",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_response_conversation_participant_unique": {
+          "name": "survey_response_conversation_participant_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "conversation_id",
+            "participant_id"
+          ]
+        },
+        "survey_response_id_conversation_unique": {
+          "name": "survey_response_id_conversation_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "conversation_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topic": {
+      "name": "topic",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "topic_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_weight": {
+          "name": "score_weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "topic_code_unique": {
+          "name": "topic_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        },
+        "topic_name_unique": {
+          "name": "topic_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        },
+        "topic_description_unique": {
+          "name": "topic_description_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "description"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_display_language": {
+      "name": "user_display_language",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_display_language_user_id_user_id_fk": {
+          "name": "user_display_language_user_id_user_id_fk",
+          "tableFrom": "user_display_language",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_display_language_unique": {
+          "name": "user_display_language_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_mute_preference": {
+      "name": "user_mute_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "user_mute_preference_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_mute_preference_source_user_id_user_id_fk": {
+          "name": "user_mute_preference_source_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "source_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_mute_preference_target_user_id_user_id_fk": {
+          "name": "user_mute_preference_target_user_id_user_id_fk",
+          "tableFrom": "user_mute_preference",
+          "tableTo": "user",
+          "columnsFrom": [
+            "target_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_unique_mute": {
+          "name": "user_unique_mute",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_user_id",
+            "target_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_spoken_languages": {
+      "name": "user_spoken_languages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "varchar(35)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_spoken_languages_user_id_user_id_fk": {
+          "name": "user_spoken_languages_user_id_user_id_fk",
+          "tableFrom": "user_spoken_languages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_spoken_languages_unique": {
+          "name": "user_spoken_languages_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "language_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "polis_participant_id": {
+          "name": "polis_participant_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(65)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_site_moderator": {
+          "name": "is_site_moderator",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_site_org_admin": {
+          "name": "is_site_org_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_imported": {
+          "name": "is_imported",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_conversation_count": {
+          "name": "active_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_conversation_count": {
+          "name": "total_conversation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_opinion_count": {
+          "name": "total_opinion_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote_content": {
+      "name": "vote_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_content_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_content_id": {
+          "name": "opinion_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "vote_enum_all",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vote_content_vote_id_vote_id_fk": {
+          "name": "vote_content_vote_id_vote_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "vote",
+          "columnsFrom": [
+            "vote_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_content_opinion_content_id_opinion_content_id_fk": {
+          "name": "vote_content_opinion_content_id_opinion_content_id_fk",
+          "tableFrom": "vote_content",
+          "tableTo": "opinion_content",
+          "columnsFrom": [
+            "opinion_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vote": {
+      "name": "vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "vote_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "opinion_id": {
+          "name": "opinion_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "polis_vote_id": {
+          "name": "polis_vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_content_id": {
+          "name": "current_content_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vote_authorId_idx": {
+          "name": "vote_authorId_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_author_active_updated_id_idx": {
+          "name": "vote_author_active_updated_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"updated_at\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"id\" DESC",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"vote\".\"current_content_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vote_opinion_active_idx": {
+          "name": "vote_opinion_active_idx",
+          "columns": [
+            {
+              "expression": "opinion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "current_content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vote_author_id_user_id_fk": {
+          "name": "vote_author_id_user_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_opinion_id_opinion_id_fk": {
+          "name": "vote_opinion_id_opinion_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "opinion",
+          "columnsFrom": [
+            "opinion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vote_current_content_id_vote_content_id_fk": {
+          "name": "vote_current_content_id_vote_content_id_fk",
+          "tableFrom": "vote",
+          "tableTo": "vote_content",
+          "columnsFrom": [
+            "current_content_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "vote_author_id_opinion_id_unique": {
+          "name": "vote_author_id_opinion_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "author_id",
+            "opinion_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.zk_passport": {
+      "name": "zk_passport",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "zk_passport_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "citizenship": {
+          "name": "citizenship",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nullifier": {
+          "name": "nullifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sex": {
+          "name": "sex",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (0)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "zk_passport_nullifier_active_unique": {
+          "name": "zk_passport_nullifier_active_unique",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"zk_passport\".\"is_deleted\" = false",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zk_passport_nullifier_idx": {
+          "name": "zk_passport_nullifier_idx",
+          "columns": [
+            {
+              "expression": "nullifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zk_passport_user_id_user_id_fk": {
+          "name": "zk_passport_user_id_user_id_fk",
+          "tableFrom": "zk_passport",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.analysis_compression_enum": {
+      "name": "analysis_compression_enum",
+      "schema": "public",
+      "values": [
+        "zstd"
+      ]
+    },
+    "public.analysis_family_enum": {
+      "name": "analysis_family_enum",
+      "schema": "public",
+      "values": [
+        "opinion_groups"
+      ]
+    },
+    "public.analysis_insufficient_data_reason_enum": {
+      "name": "analysis_insufficient_data_reason_enum",
+      "schema": "public",
+      "values": [
+        "empty_vote_matrix",
+        "not_enough_clusterable_participants",
+        "not_enough_unique_points",
+        "not_enough_samples_for_group_count",
+        "other"
+      ]
+    },
+    "public.analysis_result_outcome_enum": {
+      "name": "analysis_result_outcome_enum",
+      "schema": "public",
+      "values": [
+        "success",
+        "insufficient_data"
+      ]
+    },
+    "public.analysis_work_error_kind_enum": {
+      "name": "analysis_work_error_kind_enum",
+      "schema": "public",
+      "values": [
+        "red_dwarf_exception",
+        "red_dwarf_contract_violation",
+        "database_error",
+        "valkey_error",
+        "transaction_error",
+        "unknown_error"
+      ]
+    },
+    "public.auth_type": {
+      "name": "auth_type",
+      "schema": "public",
+      "values": [
+        "register",
+        "login_known_device",
+        "login_new_device",
+        "merge",
+        "restore_deleted",
+        "restore_and_merge"
+      ]
+    },
+    "public.conversation_moderation_action": {
+      "name": "conversation_moderation_action",
+      "schema": "public",
+      "values": [
+        "lock"
+      ]
+    },
+    "public.conversation_type": {
+      "name": "conversation_type",
+      "schema": "public",
+      "values": [
+        "polis",
+        "maxdiff"
+      ]
+    },
+    "public.conversation_view_snapshot_checkpoint_reason_enum": {
+      "name": "conversation_view_snapshot_checkpoint_reason_enum",
+      "schema": "public",
+      "values": [
+        "first_displayable_analysis",
+        "first_group_count_available",
+        "default_group_count_changed",
+        "major_participation_milestone",
+        "major_vote_milestone",
+        "conversation_closed"
+      ]
+    },
+    "public.conversation_view_snapshot_reason_enum": {
+      "name": "conversation_view_snapshot_reason_enum",
+      "schema": "public",
+      "values": [
+        "analysis_completed",
+        "survey_refreshed",
+        "conversation_content_updated",
+        "conversation_lifecycle_updated"
+      ]
+    },
+    "public.directory_visibility": {
+      "name": "directory_visibility",
+      "schema": "public",
+      "values": [
+        "listed",
+        "unlisted"
+      ]
+    },
+    "public.email_reachability": {
+      "name": "email_reachability",
+      "schema": "public",
+      "values": [
+        "safe",
+        "risky",
+        "invalid",
+        "unknown"
+      ]
+    },
+    "public.email_type": {
+      "name": "email_type",
+      "schema": "public",
+      "values": [
+        "primary",
+        "backup",
+        "secondary",
+        "other"
+      ]
+    },
+    "public.event_slug": {
+      "name": "event_slug",
+      "schema": "public",
+      "values": [
+        "devconnect-2025"
+      ]
+    },
+    "public.export_artifact_status_enum": {
+      "name": "export_artifact_status_enum",
+      "schema": "public",
+      "values": [
+        "queued",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.export_cancellation_reason_enum": {
+      "name": "export_cancellation_reason_enum",
+      "schema": "public",
+      "values": [
+        "duplicate_in_batch",
+        "cooldown_active"
+      ]
+    },
+    "public.export_failure_reason_enum": {
+      "name": "export_failure_reason_enum",
+      "schema": "public",
+      "values": [
+        "processing_error",
+        "timeout",
+        "server_restart"
+      ]
+    },
+    "public.export_file_audience_enum": {
+      "name": "export_file_audience_enum",
+      "schema": "public",
+      "values": [
+        "redacted",
+        "owner",
+        "requester"
+      ]
+    },
+    "public.export_file_type_enum": {
+      "name": "export_file_type_enum",
+      "schema": "public",
+      "values": [
+        "bundle",
+        "comments",
+        "votes",
+        "participants",
+        "summary",
+        "stats",
+        "survey_questions",
+        "survey_question_options",
+        "survey_participant_responses",
+        "survey_public_aggregates",
+        "survey_full_aggregates"
+      ]
+    },
+    "public.export_generation_status_enum": {
+      "name": "export_generation_status_enum",
+      "schema": "public",
+      "values": [
+        "collecting",
+        "queued",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.export_status_enum": {
+      "name": "export_status_enum",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.external_source_type": {
+      "name": "external_source_type",
+      "schema": "public",
+      "values": [
+        "github_issue"
+      ]
+    },
+    "public.import_failure_reason_enum": {
+      "name": "import_failure_reason_enum",
+      "schema": "public",
+      "values": [
+        "processing_error",
+        "timeout",
+        "server_restart",
+        "invalid_data_format"
+      ]
+    },
+    "public.import_method": {
+      "name": "import_method",
+      "schema": "public",
+      "values": [
+        "url",
+        "csv"
+      ]
+    },
+    "public.import_status_enum": {
+      "name": "import_status_enum",
+      "schema": "public",
+      "values": [
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.maxdiff_lifecycle_status": {
+      "name": "maxdiff_lifecycle_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "completed",
+        "in_progress",
+        "canceled"
+      ]
+    },
+    "public.moderation_reason_enum": {
+      "name": "moderation_reason_enum",
+      "schema": "public",
+      "values": [
+        "misleading",
+        "antisocial",
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "opinion_vote",
+        "new_opinion",
+        "export_started",
+        "export_completed",
+        "export_failed",
+        "export_cancelled",
+        "import_started",
+        "import_completed",
+        "import_failed"
+      ]
+    },
+    "public.opinion_group_candidate_hidden_reason_enum": {
+      "name": "opinion_group_candidate_hidden_reason_enum",
+      "schema": "public",
+      "values": [
+        "singleton_group",
+        "duplicate_representative_opinions",
+        "missing_representative_opinions",
+        "invalid_candidate_output"
+      ]
+    },
+    "public.opinion_group_clusterer_enum": {
+      "name": "opinion_group_clusterer_enum",
+      "schema": "public",
+      "values": [
+        "kmeans"
+      ]
+    },
+    "public.opinion_group_reducer_enum": {
+      "name": "opinion_group_reducer_enum",
+      "schema": "public",
+      "values": [
+        "pca"
+      ]
+    },
+    "public.opinion_group_selection_policy_enum": {
+      "name": "opinion_group_selection_policy_enum",
+      "schema": "public",
+      "values": [
+        "silhouette_size_balance"
+      ]
+    },
+    "public.opinion_moderation_action": {
+      "name": "opinion_moderation_action",
+      "schema": "public",
+      "values": [
+        "move",
+        "hide"
+      ]
+    },
+    "public.organization_membership_all_project_capability_enum": {
+      "name": "organization_membership_all_project_capability_enum",
+      "schema": "public",
+      "values": [
+        "project_update",
+        "project_delete",
+        "project_manage_owner_organizations",
+        "conversation_create",
+        "conversation_update",
+        "conversation_delete",
+        "conversation_view_private_results",
+        "conversation_export_owner_data",
+        "conversation_moderate",
+        "conversation_manage_integrations"
+      ]
+    },
+    "public.organization_membership_capability_enum": {
+      "name": "organization_membership_capability_enum",
+      "schema": "public",
+      "values": [
+        "organization_manage_members",
+        "organization_manage_profile",
+        "project_create"
+      ]
+    },
+    "public.participation_mode": {
+      "name": "participation_mode",
+      "schema": "public",
+      "values": [
+        "account_required",
+        "strong_verification",
+        "email_verification",
+        "guest"
+      ]
+    },
+    "public.phone_country_code": {
+      "name": "phone_country_code",
+      "schema": "public",
+      "values": [
+        "AC",
+        "AD",
+        "AE",
+        "AF",
+        "AG",
+        "AI",
+        "AL",
+        "AM",
+        "AO",
+        "AR",
+        "AS",
+        "AT",
+        "AU",
+        "AW",
+        "AX",
+        "AZ",
+        "BA",
+        "BB",
+        "BD",
+        "BE",
+        "BF",
+        "BG",
+        "BH",
+        "BI",
+        "BJ",
+        "BL",
+        "BM",
+        "BN",
+        "BO",
+        "BQ",
+        "BR",
+        "BS",
+        "BT",
+        "BW",
+        "BY",
+        "BZ",
+        "CA",
+        "CC",
+        "CD",
+        "CF",
+        "CG",
+        "CH",
+        "CI",
+        "CK",
+        "CL",
+        "CM",
+        "CN",
+        "CO",
+        "CR",
+        "CU",
+        "CV",
+        "CW",
+        "CX",
+        "CY",
+        "CZ",
+        "DE",
+        "DJ",
+        "DK",
+        "DM",
+        "DO",
+        "DZ",
+        "EC",
+        "EE",
+        "EG",
+        "EH",
+        "ER",
+        "ES",
+        "ET",
+        "FI",
+        "FJ",
+        "FK",
+        "FM",
+        "FO",
+        "FR",
+        "GA",
+        "GB",
+        "GD",
+        "GE",
+        "GF",
+        "GG",
+        "GH",
+        "GI",
+        "GL",
+        "GM",
+        "GN",
+        "GP",
+        "GQ",
+        "GR",
+        "GT",
+        "GU",
+        "GW",
+        "GY",
+        "HK",
+        "HN",
+        "HR",
+        "HT",
+        "HU",
+        "ID",
+        "IE",
+        "IL",
+        "IM",
+        "IN",
+        "IO",
+        "IQ",
+        "IR",
+        "IS",
+        "IT",
+        "JE",
+        "JM",
+        "JO",
+        "JP",
+        "KE",
+        "KG",
+        "KH",
+        "KI",
+        "KM",
+        "KN",
+        "KP",
+        "KR",
+        "KW",
+        "KY",
+        "KZ",
+        "LA",
+        "LB",
+        "LC",
+        "LI",
+        "LK",
+        "LR",
+        "LS",
+        "LT",
+        "LU",
+        "LV",
+        "LY",
+        "MA",
+        "MC",
+        "MD",
+        "ME",
+        "MF",
+        "MG",
+        "MH",
+        "MK",
+        "ML",
+        "MM",
+        "MN",
+        "MO",
+        "MP",
+        "MQ",
+        "MR",
+        "MS",
+        "MT",
+        "MU",
+        "MV",
+        "MW",
+        "MX",
+        "MY",
+        "MZ",
+        "NA",
+        "NC",
+        "NE",
+        "NF",
+        "NG",
+        "NI",
+        "NL",
+        "NO",
+        "NP",
+        "NR",
+        "NU",
+        "NZ",
+        "OM",
+        "PA",
+        "PE",
+        "PF",
+        "PG",
+        "PH",
+        "PK",
+        "PL",
+        "PM",
+        "PR",
+        "PS",
+        "PT",
+        "PW",
+        "PY",
+        "QA",
+        "RE",
+        "RO",
+        "RS",
+        "RU",
+        "RW",
+        "SA",
+        "SB",
+        "SC",
+        "SD",
+        "SE",
+        "SG",
+        "SH",
+        "SI",
+        "SJ",
+        "SK",
+        "SL",
+        "SM",
+        "SN",
+        "SO",
+        "SR",
+        "SS",
+        "ST",
+        "SV",
+        "SX",
+        "SY",
+        "SZ",
+        "TA",
+        "TC",
+        "TD",
+        "TG",
+        "TH",
+        "TJ",
+        "TK",
+        "TL",
+        "TM",
+        "TN",
+        "TO",
+        "TR",
+        "TT",
+        "TV",
+        "TW",
+        "TZ",
+        "UA",
+        "UG",
+        "US",
+        "UY",
+        "UZ",
+        "VA",
+        "VC",
+        "VE",
+        "VG",
+        "VI",
+        "VN",
+        "VU",
+        "WF",
+        "WS",
+        "XK",
+        "YE",
+        "YT",
+        "ZA",
+        "ZM",
+        "ZW"
+      ]
+    },
+    "public.premium_feature": {
+      "name": "premium_feature",
+      "schema": "public",
+      "values": [
+        "survey",
+        "event_ticket",
+        "analysis_variants"
+      ]
+    },
+    "public.report_reason_enum": {
+      "name": "report_reason_enum",
+      "schema": "public",
+      "values": [
+        "illegal",
+        "doxing",
+        "sexual",
+        "spam",
+        "misleading",
+        "antisocial"
+      ]
+    },
+    "public.sex": {
+      "name": "sex",
+      "schema": "public",
+      "values": [
+        "F",
+        "M",
+        "X"
+      ]
+    },
+    "public.survey_aggregate_scope_enum": {
+      "name": "survey_aggregate_scope_enum",
+      "schema": "public",
+      "values": [
+        "overall",
+        "opinion_group"
+      ]
+    },
+    "public.survey_aggregate_suppression_reason_enum": {
+      "name": "survey_aggregate_suppression_reason_enum",
+      "schema": "public",
+      "values": [
+        "count_below_threshold",
+        "cluster_deductive_disclosure"
+      ]
+    },
+    "public.survey_choice_display": {
+      "name": "survey_choice_display",
+      "schema": "public",
+      "values": [
+        "auto",
+        "list",
+        "dropdown"
+      ]
+    },
+    "public.survey_question_type": {
+      "name": "survey_question_type",
+      "schema": "public",
+      "values": [
+        "choice",
+        "free_text"
+      ]
+    },
+    "public.ticket_provider": {
+      "name": "ticket_provider",
+      "schema": "public",
+      "values": [
+        "zupass"
+      ]
+    },
+    "public.vote_enum_all": {
+      "name": "vote_enum_all",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree",
+        "pass"
+      ]
+    },
+    "public.vote_enum_simple": {
+      "name": "vote_enum_simple",
+      "schema": "public",
+      "values": [
+        "agree",
+        "disagree"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/services/api/drizzle/meta/_journal.json
+++ b/services/api/drizzle/meta/_journal.json
@@ -491,6 +491,20 @@
       "when": 1781188761613,
       "tag": "0069_mute_zaran",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1781294622462,
+      "tag": "0070_abnormal_dakota_north",
+      "breakpoints": true
+    },
+    {
+      "idx": 71,
+      "version": "7",
+      "when": 1781295057991,
+      "tag": "0071_nervous_killraven",
+      "breakpoints": true
     }
   ]
 }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -54,6 +54,7 @@ import { fetchAnalysisCheckpointsByConversationSlugId } from "@/service/conversa
 import { createExportWorker } from "@/service/conversationExport/core.js";
 import type { ValkeyRef } from "@/service/valkeyRef.js";
 import { validateS3Access } from "./service/s3.js";
+import { resolveConversationCreateTarget } from "@/service/projectAccess.js";
 
 import {
     httpMethodToAbility,
@@ -181,8 +182,9 @@ import {
     conversationTable,
     deviceTable,
     organizationTable,
+    projectOrganizationOwnershipTable,
 } from "./shared-backend/schema.js";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import {
     initializeGoogleCloudCredentials,
     type GoogleCloudCredentials,
@@ -432,14 +434,29 @@ async function assertMaxdiffGitHubAllowedForConversation({
 }): Promise<void> {
     const rows = await db
         .select({
-            organizationName: organizationTable.name,
+            organizationName: organizationTable.slug,
         })
         .from(conversationTable)
-        .leftJoin(
-            organizationTable,
-            eq(conversationTable.organizationId, organizationTable.id),
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            eq(
+                projectOrganizationOwnershipTable.projectId,
+                conversationTable.projectId,
+            ),
         )
-        .where(eq(conversationTable.slugId, conversationSlugId))
+        .innerJoin(
+            organizationTable,
+            eq(
+                organizationTable.id,
+                projectOrganizationOwnershipTable.organizationId,
+            ),
+        )
+        .where(
+            and(
+                eq(conversationTable.slugId, conversationSlugId),
+                isNull(organizationTable.autoProvisionedForUserId),
+            ),
+        )
         .limit(1);
 
     assertMaxdiffGitHubAllowed({
@@ -2300,13 +2317,14 @@ server.after(() => {
             const displayLanguage = getRequestDisplayLanguage({
                 request,
             });
+            const personalizationUserId = deviceStatus.isKnown
+                ? deviceStatus.userId
+                : undefined;
 
             return await fetchAnalysisFrameManifestByConversationSlugId({
                 db,
                 conversationSlugId: request.body.conversationSlugId,
-                personalizationUserId: deviceStatus.isKnown
-                    ? deviceStatus.userId
-                    : undefined,
+                personalizationUserId,
                 displayLanguage,
                 analysisView: request.body.analysisView,
                 checkpointViewSnapshotId: request.body.checkpointViewSnapshotId,
@@ -2349,7 +2367,7 @@ server.after(() => {
             },
         },
         handler: async (request) => {
-            const { deviceStatus } = await verifyUcanOptionalAuth(db, request);
+            await verifyUcanOptionalAuth(db, request);
             const displayLanguage = getRequestDisplayLanguage({
                 request,
             });
@@ -2678,23 +2696,11 @@ server.after(() => {
                 }
             }
 
-            // Verify organization membership if specified
-            if (
-                request.body.postAsOrganization !== undefined &&
-                request.body.postAsOrganization !== ""
-            ) {
-                const organizationId =
-                    await authUtilService.isUserPartOfOrganization({
-                        db,
-                        organizationName: request.body.postAsOrganization,
-                        userId: deviceStatus.userId,
-                    });
-                if (organizationId === undefined) {
-                    throw server.httpErrors.forbidden(
-                        `User '${deviceStatus.userId}' is not part of the organization: '${request.body.postAsOrganization}'`,
-                    );
-                }
-            }
+            const createTarget = await resolveConversationCreateTarget({
+                db,
+                userId: deviceStatus.userId,
+                postAsOrganizationSlug: request.body.postAsOrganization,
+            });
 
             const premiumFeatures =
                 premiumEntitlementService.getPremiumFeaturesFromCreateRequest({
@@ -2706,15 +2712,10 @@ server.after(() => {
             if (premiumFeatures.length > 0) {
                 await premiumEntitlementService.requirePremiumAccess({
                     db,
-                    subject:
-                        await premiumEntitlementService.getPremiumEntitlementSubjectForCreate(
-                            {
-                                db,
-                                userId: deviceStatus.userId,
-                                postAsOrganization:
-                                    request.body.postAsOrganization,
-                            },
-                        ),
+                    subject: {
+                        projectId: createTarget.projectId,
+                        userId: deviceStatus.userId,
+                    },
                     features: premiumFeatures,
                     mode: "creation",
                     now: nowZeroMs(),
@@ -2725,9 +2726,9 @@ server.after(() => {
             return await conversationImportService.requestUrlImport({
                 db,
                 userId: deviceStatus.userId,
+                projectId: createTarget.projectId,
                 polisUrl: request.body.polisUrl,
                 formData: {
-                    postAsOrganization: request.body.postAsOrganization,
                     participationMode: request.body.participationMode,
                     isIndexed: request.body.isIndexed,
                     requiresEventTicket: request.body.requiresEventTicket,
@@ -2871,20 +2872,11 @@ server.after(() => {
                 }
             }
 
-            // Verify organization membership if specified
-            if (parsedFields.postAsOrganization !== undefined) {
-                const organizationId =
-                    await authUtilService.isUserPartOfOrganization({
-                        db,
-                        organizationName: parsedFields.postAsOrganization,
-                        userId: deviceStatus.userId,
-                    });
-                if (organizationId === undefined) {
-                    throw server.httpErrors.forbidden(
-                        `User '${deviceStatus.userId}' is not part of the organization: '${parsedFields.postAsOrganization}'`,
-                    );
-                }
-            }
+            const createTarget = await resolveConversationCreateTarget({
+                db,
+                userId: deviceStatus.userId,
+                postAsOrganizationSlug: parsedFields.postAsOrganization,
+            });
 
             const premiumFeatures =
                 premiumEntitlementService.getPremiumFeaturesFromCreateRequest({
@@ -2896,15 +2888,10 @@ server.after(() => {
             if (premiumFeatures.length > 0) {
                 await premiumEntitlementService.requirePremiumAccess({
                     db,
-                    subject:
-                        await premiumEntitlementService.getPremiumEntitlementSubjectForCreate(
-                            {
-                                db,
-                                userId: deviceStatus.userId,
-                                postAsOrganization:
-                                    parsedFields.postAsOrganization,
-                            },
-                        ),
+                    subject: {
+                        projectId: createTarget.projectId,
+                        userId: deviceStatus.userId,
+                    },
                     features: premiumFeatures,
                     mode: "creation",
                     now: nowZeroMs(),
@@ -2916,9 +2903,9 @@ server.after(() => {
                 await conversationImportService.requestConversationImport({
                     db,
                     userId: deviceStatus.userId,
+                    projectId: createTarget.projectId,
                     files: parsedFiles.data,
                     formData: {
-                        postAsOrganization: parsedFields.postAsOrganization,
                         participationMode: parsedFields.participationMode,
                         isIndexed: parsedFields.isIndexed,
                         requiresEventTicket: parsedFields.requiresEventTicket,

--- a/services/api/src/service/account.ts
+++ b/services/api/src/service/account.ts
@@ -8,6 +8,8 @@ import {
     voteTable,
     opinionTable,
     conversationTable,
+    organizationMembershipTable,
+    projectOrganizationOwnershipTable,
 } from "@/shared-backend/schema.js";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { eq } from "drizzle-orm";
@@ -693,17 +695,31 @@ export async function deleteUserAccount({ db, userId }: DeleteAccountProps) {
             conversationIdsSet.add(opinion.conversationId),
         );
 
-        // From conversations (as author)
+        // From conversations owned through organization/project membership
         log.info(`[Account] Querying conversations for user: ${userId}`);
         const userConversations = await tx
-            .select()
+            .select({ conversationId: conversationTable.id })
             .from(conversationTable)
-            .where(eq(conversationTable.authorId, userId));
+            .innerJoin(
+                projectOrganizationOwnershipTable,
+                eq(
+                    projectOrganizationOwnershipTable.projectId,
+                    conversationTable.projectId,
+                ),
+            )
+            .innerJoin(
+                organizationMembershipTable,
+                eq(
+                    organizationMembershipTable.organizationId,
+                    projectOrganizationOwnershipTable.organizationId,
+                ),
+            )
+            .where(eq(organizationMembershipTable.userId, userId));
         log.info(
             `[Account] Found ${String(userConversations.length)} conversations`,
         );
         userConversations.forEach((conversation) =>
-            conversationIdsSet.add(conversation.id),
+            conversationIdsSet.add(conversation.conversationId),
         );
 
         log.info(

--- a/services/api/src/service/administrator/organization.ts
+++ b/services/api/src/service/administrator/organization.ts
@@ -1,6 +1,6 @@
 import {
+    organizationMembershipTable,
     organizationTable,
-    userOrganizationMappingTable,
 } from "@/shared-backend/schema.js";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { and, eq } from "drizzle-orm";
@@ -13,6 +13,16 @@ import type {
 } from "@/shared/types/dto.js";
 import type { OrganizationProperties } from "@/shared/types/zod.js";
 import { imagePathToUrl } from "@/utils/organizationLogic.js";
+
+function slugifyOrganizationName(name: string): string {
+    const slug = name
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 65);
+    return slug === "" ? "organization" : slug;
+}
 
 interface GetAllOrganizationsProps {
     db: PostgresJsDatabase;
@@ -27,7 +37,7 @@ export async function getAllOrganizations({
 
     const organizationTableResponse = await db
         .select({
-            name: organizationTable.name,
+            name: organizationTable.displayName,
             description: organizationTable.description,
             imagePath: organizationTable.imagePath,
             isFullImagePath: organizationTable.isFullImagePath,
@@ -123,9 +133,9 @@ export async function getOrganizationIdsByUserId({
     userId,
 }: GetOrganizationIdsByUserIdProps): Promise<number[]> {
     const organizationTableResponse = await db
-        .select({ organizationId: userOrganizationMappingTable.organizationId })
-        .from(userOrganizationMappingTable)
-        .where(eq(userOrganizationMappingTable.userId, userId));
+        .select({ organizationId: organizationMembershipTable.organizationId })
+        .from(organizationMembershipTable)
+        .where(eq(organizationMembershipTable.userId, userId));
 
     return organizationTableResponse.map((response) => response.organizationId);
 }
@@ -138,21 +148,21 @@ export async function getOrganizationMembershipsByUserId({
     const organizationTableResponse = await db
         .select({
             organizationId: organizationTable.id,
-            name: organizationTable.name,
+            name: organizationTable.displayName,
             description: organizationTable.description,
             imagePath: organizationTable.imagePath,
             isFullImagePath: organizationTable.isFullImagePath,
             websiteUrl: organizationTable.websiteUrl,
         })
-        .from(userOrganizationMappingTable)
+        .from(organizationMembershipTable)
         .innerJoin(
             organizationTable,
             eq(
                 organizationTable.id,
-                userOrganizationMappingTable.organizationId,
+                organizationMembershipTable.organizationId,
             ),
         )
-        .where(eq(userOrganizationMappingTable.userId, userId));
+        .where(eq(organizationMembershipTable.userId, userId));
 
     return organizationTableResponse.map((response) => ({
         organizationId: response.organizationId,
@@ -195,12 +205,12 @@ export async function removeUserOrganizationMapping({
             throw httpErrors.notFound("Failed to locate organization ID");
         } else {
             const deletedMapping = await db
-                .delete(userOrganizationMappingTable)
+                .delete(organizationMembershipTable)
                 .where(
                     and(
-                        eq(userOrganizationMappingTable.userId, targetUserId),
+                        eq(organizationMembershipTable.userId, targetUserId),
                         eq(
-                            userOrganizationMappingTable.organizationId,
+                            organizationMembershipTable.organizationId,
                             organizationId,
                         ),
                     ),
@@ -246,7 +256,7 @@ export async function addUserOrganizationMapping({
         if (organizationId == undefined) {
             throw httpErrors.notFound("Failed to locate organization ID");
         } else {
-            await db.insert(userOrganizationMappingTable).values({
+            await db.insert(organizationMembershipTable).values({
                 userId: targetUserId,
                 organizationId: organizationId,
             });
@@ -279,7 +289,9 @@ export async function createOrganization({
     try {
         // Create a new organization entry
         await db.insert(organizationTable).values({
-            name: organizationName,
+            slug: slugifyOrganizationName(organizationName),
+            displayName: organizationName,
+            directoryVisibility: "listed",
             imagePath: imagePath,
             isFullImagePath: isFullImagePath,
             websiteUrl: websiteUrl,
@@ -305,7 +317,7 @@ export async function deleteOrganization({
     try {
         await db
             .delete(organizationTable)
-            .where(eq(organizationTable.name, organizationName));
+            .where(eq(organizationTable.slug, organizationName));
     } catch (err: unknown) {
         log.error(err);
         throw httpErrors.internalServerError(
@@ -325,7 +337,7 @@ async function getOrganizationIdFromOrganizationName(
                 organizationId: organizationTable.id,
             })
             .from(organizationTable)
-            .where(eq(organizationTable.name, organizationName));
+            .where(eq(organizationTable.slug, organizationName));
 
         if (organizationTableResponse.length != 1) {
             return undefined;

--- a/services/api/src/service/auth.ts
+++ b/services/api/src/service/auth.ts
@@ -909,10 +909,12 @@ export async function registerWithPhoneNumber({
 
         if (existingUser.length === 0) {
             // New user registration
+            const username = await generateUnusedRandomUsername({
+                db: db,
+            });
             await tx.insert(userTable).values({
-                username: await generateUnusedRandomUsername({
-                    db: db,
-                }),
+                username,
+                firstName: username,
                 id: userId,
             });
             await tx.insert(deviceTable).values({
@@ -961,8 +963,10 @@ export async function createGuestUser({
     const loginSessionExpiry = new Date(now);
     try {
         return await db.transaction(async (tx) => {
+            const username = await generateUnusedRandomUsername({ db: db });
             await tx.insert(userTable).values({
-                username: await generateUnusedRandomUsername({ db: db }),
+                username,
+                firstName: username,
                 id: userId,
             });
             const insertedDevice = await tx
@@ -1024,8 +1028,10 @@ export async function registerWithZKP({
 
         if (existingUser.length === 0) {
             // New user registration
+            const username = await generateUnusedRandomUsername({ db: db });
             await tx.insert(userTable).values({
-                username: await generateUnusedRandomUsername({ db: db }),
+                username,
+                firstName: username,
                 id: userId,
             });
             await tx.insert(deviceTable).values({
@@ -2875,10 +2881,12 @@ async function registerWithEmail({
 
         if (existingUser.length === 0) {
             // New user registration
+            const username = await generateUnusedRandomUsername({
+                db: db,
+            });
             await tx.insert(userTable).values({
-                username: await generateUnusedRandomUsername({
-                    db: db,
-                }),
+                username,
+                firstName: username,
                 id: userId,
             });
             await tx.insert(deviceTable).values({

--- a/services/api/src/service/authUtil.ts
+++ b/services/api/src/service/authUtil.ts
@@ -4,9 +4,9 @@ import {
     deviceTable,
     emailTable,
     opinionTable,
+    organizationMembershipTable,
     organizationTable,
     phoneTable,
-    userOrganizationMappingTable,
     userTable,
     zkPassportTable,
 } from "@/shared-backend/schema.js";
@@ -34,6 +34,7 @@ export type DeviceLoginStatusInternal =
     | Extract<DeviceLoginStatusExtended, { isKnown: false }>;
 import * as authService from "@/service/auth.js";
 import { log } from "@/app.js";
+import { hasConversationCapability } from "@/service/projectAccess.js";
 
 interface InfoDevice {
     userAgent: string;
@@ -177,20 +178,20 @@ export async function isUserPartOfOrganization({
         .select({ organizationId: organizationTable.id })
         .from(userTable)
         .innerJoin(
-            userOrganizationMappingTable,
-            eq(userTable.id, userOrganizationMappingTable.userId),
+            organizationMembershipTable,
+            eq(userTable.id, organizationMembershipTable.userId),
         )
         .innerJoin(
             organizationTable,
             eq(
                 organizationTable.id,
-                userOrganizationMappingTable.organizationId,
+                organizationMembershipTable.organizationId,
             ),
         )
         .where(
             and(
                 eq(userTable.id, userId),
-                eq(organizationTable.name, organizationName),
+                eq(organizationTable.slug, organizationName),
             ),
         );
     if (result.length === 0) {
@@ -211,12 +212,12 @@ export async function isUserPartOfOrganizationById({
     organizationId,
 }: IsUserPartOfOrganizationByIdProps): Promise<boolean> {
     const result = await db
-        .select({ id: userOrganizationMappingTable.id })
-        .from(userOrganizationMappingTable)
+        .select({ id: organizationMembershipTable.id })
+        .from(organizationMembershipTable)
         .where(
             and(
-                eq(userOrganizationMappingTable.userId, userId),
-                eq(userOrganizationMappingTable.organizationId, organizationId),
+                eq(organizationMembershipTable.userId, userId),
+                eq(organizationMembershipTable.organizationId, organizationId),
             ),
         )
         .limit(1);
@@ -546,9 +547,7 @@ interface CanModerateConversationParams {
 }
 
 /**
- * Checks if a user can moderate content in a conversation.
- * Returns authorized if user is a site moderator, the conversation author,
- * or a member of the organization that owns the conversation.
+ * Checks move-style moderation rights. Hide moderation remains site-moderator-only.
  */
 export async function canModerateConversation({
     db,
@@ -562,8 +561,7 @@ export async function canModerateConversation({
 
     const conversation = await db
         .select({
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
+            conversationId: conversationTable.id,
         })
         .from(conversationTable)
         .where(eq(conversationTable.slugId, conversationSlugId))
@@ -573,23 +571,14 @@ export async function canModerateConversation({
         throw httpErrors.notFound("Conversation not found");
     }
 
-    const isAuthor = conversation[0].authorId === userId;
-    if (isAuthor) {
-        return { isAuthorized: true, isSiteModerator: false };
-    }
+    const canModerate = await hasConversationCapability({
+        db,
+        userId,
+        conversationId: conversation[0].conversationId,
+        capability: "conversation_moderate",
+    });
 
-    if (conversation[0].organizationId !== null) {
-        const isOrgMember = await isUserPartOfOrganizationById({
-            db,
-            userId,
-            organizationId: conversation[0].organizationId,
-        });
-        if (isOrgMember) {
-            return { isAuthorized: true, isSiteModerator: false };
-        }
-    }
-
-    return { isAuthorized: false, isSiteModerator: false };
+    return { isAuthorized: canModerate, isSiteModerator: false };
 }
 
 interface CanModerateConversationByOpinionSlugIdParams {

--- a/services/api/src/service/common.ts
+++ b/services/api/src/service/common.ts
@@ -7,6 +7,7 @@ import {
     conversationModerationTable,
     organizationTable,
     maxdiffItemTable,
+    projectOrganizationOwnershipTable,
 } from "@/shared-backend/schema.js";
 import { toUnionUndefined } from "@/shared/shared.js";
 import type {
@@ -21,7 +22,17 @@ import type {
 } from "@/shared/types/zod.js";
 import { zodExternalSourceConfig } from "@/shared/types/zod.js";
 import { httpErrors } from "@fastify/sensible";
-import { eq, desc, SQL, and, sql, isNotNull, inArray } from "drizzle-orm";
+import {
+    eq,
+    desc,
+    SQL,
+    and,
+    sql,
+    isNotNull,
+    inArray,
+    isNull,
+    or,
+} from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import sanitizeHtml from "sanitize-html";
 import { createPostModerationPropertyObject } from "./moderation.js";
@@ -29,6 +40,7 @@ import { getUserMutePreferences } from "./muteUser.js";
 import { imagePathToUrl } from "@/utils/organizationLogic.js";
 import { getConversationEngagementScore } from "./recommendationSystem.js";
 import { log } from "@/app.js";
+import { alias } from "drizzle-orm/pg-core";
 
 export function useCommonUser() {
     interface GetUserIdFromUsernameProps {
@@ -218,6 +230,11 @@ export function useCommonPost() {
     }: FetchPostItemsProps): Promise<ExtendedConversationPerSlugId> {
         let postItems;
 
+        const personalOrganizationUserTable = alias(
+            userTable,
+            "personalOrganizationUser",
+        );
+
         const postItemsQuery = db
             .select({
                 title: conversationContentTable.title,
@@ -228,8 +245,8 @@ export function useCommonPost() {
                 createdAt: conversationTable.createdAt,
                 updatedAt: conversationTable.updatedAt,
                 lastReactedAt: conversationTable.lastReactedAt,
-                authorName: userTable.username,
-                organizationName: organizationTable.name,
+                authorName: personalOrganizationUserTable.username,
+                organizationName: organizationTable.displayName,
                 organizationImagePath: organizationTable.imagePath,
                 organizationWebsiteUrl: organizationTable.websiteUrl,
                 organizationIsFullImagePath: organizationTable.isFullImagePath,
@@ -267,7 +284,27 @@ export function useCommonPost() {
                     conversationTable.currentContentId,
                 ),
             )
-            .innerJoin(userTable, eq(userTable.id, conversationTable.authorId))
+            .innerJoin(
+                projectOrganizationOwnershipTable,
+                eq(
+                    projectOrganizationOwnershipTable.projectId,
+                    conversationTable.projectId,
+                ),
+            )
+            .innerJoin(
+                organizationTable,
+                eq(
+                    organizationTable.id,
+                    projectOrganizationOwnershipTable.organizationId,
+                ),
+            )
+            .leftJoin(
+                personalOrganizationUserTable,
+                eq(
+                    personalOrganizationUserTable.id,
+                    organizationTable.autoProvisionedForUserId,
+                ),
+            )
             .leftJoin(
                 conversationModerationTable,
                 eq(
@@ -275,12 +312,16 @@ export function useCommonPost() {
                     conversationTable.id,
                 ),
             )
-            .leftJoin(
-                organizationTable,
-                eq(organizationTable.id, conversationTable.organizationId),
-            )
             // whereClause = and(whereClause, lt(postTable.createdAt, lastCreatedAt));
-            .where(and(where, eq(userTable.isDeleted, false)))
+            .where(
+                and(
+                    where,
+                    or(
+                        isNull(organizationTable.autoProvisionedForUserId),
+                        eq(personalOrganizationUserTable.isDeleted, false),
+                    ),
+                ),
+            )
             .orderBy(
                 desc(conversationTable.createdAt),
                 desc(conversationTable.id),
@@ -370,7 +411,7 @@ export function useCommonPost() {
                 totalParticipantCount: displayCounts.totalParticipantCount,
                 moderatedOpinionCount: displayCounts.moderatedOpinionCount,
                 hiddenOpinionCount: displayCounts.hiddenOpinionCount,
-                authorUsername: postItem.authorName,
+                authorUsername: postItem.authorName ?? postItem.organizationName,
                 isIndexed: postItem.isIndexed,
                 aiLabelingEnabled: postItem.aiLabelingEnabled,
                 preferredOpinionGroupCount: postItem.preferredOpinionGroupCount,
@@ -380,10 +421,8 @@ export function useCommonPost() {
                 isEdited: postItem.isEdited,
                 requiresEventTicket: postItem.requiresEventTicket ?? undefined,
                 organization:
-                    postItem.organizationName !== null &&
+                    postItem.authorName === null &&
                     postItem.organizationDescription !== null &&
-                    postItem.organizationImagePath !== null &&
-                    postItem.organizationIsFullImagePath !== null &&
                     postItem.organizationWebsiteUrl !== null
                         ? {
                               name: postItem.organizationName,
@@ -508,7 +547,6 @@ export function useCommonPost() {
     interface PostMetadata {
         id: number;
         contentId: number | null;
-        authorId: string;
         conversationType: ConversationType;
         participantCount: number;
         opinionCount: number;
@@ -538,7 +576,6 @@ export function useCommonPost() {
             .select({
                 id: conversationTable.id,
                 currentContentId: conversationTable.currentContentId,
-                authorId: conversationTable.authorId,
                 isIndexed: conversationTable.isIndexed,
                 participationMode: conversationTable.participationMode,
                 conversationType: conversationTable.conversationType,
@@ -564,7 +601,6 @@ export function useCommonPost() {
         return {
             contentId: postTableResponse[0].currentContentId,
             id: postTableResponse[0].id,
-            authorId: postTableResponse[0].authorId,
             participantCount: displayCounts.participantCount,
             voteCount: displayCounts.voteCount,
             opinionCount: displayCounts.opinionCount,

--- a/services/api/src/service/conversationAccess.ts
+++ b/services/api/src/service/conversationAccess.ts
@@ -1,77 +1,31 @@
-import { eq, inArray, or } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import type { PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
 import { httpErrors } from "@fastify/sensible";
 import { conversationTable } from "@/shared-backend/schema.js";
-import * as authUtilService from "@/service/authUtil.js";
+import { hasProjectCapability } from "@/service/projectAccess.js";
 
 export type ConversationViewAccessLevel = "public" | "owner";
-
-export function getConversationOwnerFilter({
-    userId,
-    organizationIds,
-}: {
-    userId: string;
-    organizationIds: number[];
-}) {
-    const authorFilter = eq(conversationTable.authorId, userId);
-    if (organizationIds.length === 0) {
-        return authorFilter;
-    }
-
-    return or(
-        authorFilter,
-        inArray(conversationTable.organizationId, organizationIds),
-    );
-}
-
-export async function isConversationOwner({
-    db,
-    userId,
-    authorId,
-    organizationId,
-}: {
-    db: PostgresDatabase;
-    userId: string;
-    authorId: string;
-    organizationId: number | null;
-}): Promise<boolean> {
-    if (authorId === userId) {
-        return true;
-    }
-
-    if (organizationId === null) {
-        return false;
-    }
-
-    return await authUtilService.isUserPartOfOrganizationById({
-        db,
-        userId,
-        organizationId,
-    });
-}
 
 export async function getConversationViewAccessLevelForConversation({
     db,
     userId,
-    authorId,
-    organizationId,
+    projectId,
 }: {
     db: PostgresDatabase;
     userId: string | undefined;
-    authorId: string;
-    organizationId: number | null;
+    projectId: number;
 }): Promise<ConversationViewAccessLevel> {
     if (userId === undefined) {
         return "public";
     }
 
-    const isOwner = await isConversationOwner({
+    const canUpdateConversation = await hasProjectCapability({
         db,
         userId,
-        authorId,
-        organizationId,
+        projectId,
+        capability: "conversation_update",
     });
-    return isOwner ? "owner" : "public";
+    return canUpdateConversation ? "owner" : "public";
 }
 
 export async function getConversationViewAccessLevel({
@@ -85,8 +39,7 @@ export async function getConversationViewAccessLevel({
 }): Promise<ConversationViewAccessLevel> {
     const conversationRows = await db
         .select({
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
+            projectId: conversationTable.projectId,
         })
         .from(conversationTable)
         .where(eq(conversationTable.id, conversationId))
@@ -99,7 +52,6 @@ export async function getConversationViewAccessLevel({
     return await getConversationViewAccessLevelForConversation({
         db,
         userId,
-        authorId: conversation.authorId,
-        organizationId: conversation.organizationId,
+        projectId: conversation.projectId,
     });
 }

--- a/services/api/src/service/conversationExport/core.ts
+++ b/services/api/src/service/conversationExport/core.ts
@@ -206,8 +206,7 @@ interface ConversationExportConversationRecord {
     id: number;
     slugId: string;
     title: string;
-    authorId: string;
-    organizationId: number | null;
+    projectId: number;
 }
 
 async function findConversationRecord({
@@ -222,8 +221,7 @@ async function findConversationRecord({
             id: conversationTable.id,
             slugId: conversationTable.slugId,
             title: conversationContentTable.title,
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
+            projectId: conversationTable.projectId,
         })
         .from(conversationTable)
         .innerJoin(
@@ -735,8 +733,7 @@ export async function requestConversationExport({
         await getConversationViewAccessLevelForConversation({
             db,
             userId,
-            authorId: conversation.authorId,
-            organizationId: conversation.organizationId,
+            projectId: conversation.projectId,
         });
 
     const opinionCount = await getOpinionCount({
@@ -875,8 +872,7 @@ interface RequestStatusRecord {
     status: ExportRequestStatus;
     conversationId: number;
     conversationSlugId: string;
-    conversationAuthorId: string;
-    conversationOrganizationId: number | null;
+    conversationProjectId: number;
     failureReason: ExportFailureReason | null;
     cancellationReason: ExportCancellationReason | null;
     createdAt: Date;
@@ -896,8 +892,7 @@ async function getRequestStatusRecord({
             status: conversationExportRequestTable.status,
             conversationId: conversationTable.id,
             conversationSlugId: conversationTable.slugId,
-            conversationAuthorId: conversationTable.authorId,
-            conversationOrganizationId: conversationTable.organizationId,
+            conversationProjectId: conversationTable.projectId,
             failureReason: conversationExportRequestTable.failureReason,
             cancellationReason:
                 conversationExportRequestTable.cancellationReason,
@@ -1039,8 +1034,7 @@ export async function getConversationExportStatus({
         await getConversationViewAccessLevelForConversation({
             db,
             userId,
-            authorId: request.conversationAuthorId,
-            organizationId: request.conversationOrganizationId,
+            projectId: request.conversationProjectId,
         });
 
     if (request.deletedAt !== null || request.expiresAt < new Date()) {

--- a/services/api/src/service/conversationImport/index.ts
+++ b/services/api/src/service/conversationImport/index.ts
@@ -26,9 +26,9 @@ import { log } from "@/app.js";
 interface RequestConversationImportParams {
     db: PostgresDatabase;
     userId: string;
+    projectId: number;
     files: CsvFiles;
     formData: {
-        postAsOrganization?: string;
         participationMode: ParticipationMode;
         isIndexed: boolean;
         requiresEventTicket?: EventSlug;
@@ -53,6 +53,7 @@ export async function requestConversationImport(
     const {
         db,
         userId,
+        projectId,
         files,
         formData,
         didWrite,
@@ -113,10 +114,11 @@ export async function requestConversationImport(
             type: "csv",
             importSlugId: createImportResult.importSlugId,
             userId,
+            actorUserId: userId,
+            projectId,
             files,
             formData,
             didWrite,
-            authorId: userId,
         });
     } catch (error) {
         try {
@@ -157,9 +159,9 @@ export async function requestConversationImport(
 interface RequestUrlImportParams {
     db: PostgresDatabase;
     userId: string;
+    projectId: number;
     polisUrl: string;
     formData: {
-        postAsOrganization?: string;
         participationMode: ParticipationMode;
         isIndexed: boolean;
         requiresEventTicket?: EventSlug;
@@ -180,6 +182,7 @@ export async function requestUrlImport(
     const {
         db,
         userId,
+        projectId,
         polisUrl,
         formData,
         didWrite,
@@ -203,10 +206,11 @@ export async function requestUrlImport(
             type: "url",
             importSlugId: createImportResult.importSlugId,
             userId,
+            actorUserId: userId,
+            projectId,
             polisUrl,
             formData,
             didWrite,
-            authorId: userId,
         });
     } catch (error) {
         try {

--- a/services/api/src/service/externalSource/github.ts
+++ b/services/api/src/service/externalSource/github.ts
@@ -1,12 +1,14 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { z } from "zod";
 import { type PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and, sql, asc } from "drizzle-orm";
 import {
     conversationTable,
     maxdiffItemTable,
     maxdiffItemContentTable,
     maxdiffItemExternalSourceTable,
+    organizationMembershipTable,
+    projectOrganizationOwnershipTable,
 } from "@/shared-backend/schema.js";
 import { zodExternalSourceConfig } from "@/shared/types/zod.js";
 import { createMaxdiffItem } from "@/service/maxdiffItem.js";
@@ -18,7 +20,31 @@ import {
 } from "@/shared-app-api/html.js";
 import { marked } from "marked";
 import type { GitHubClient, GitHubIssue, SyncResult } from "./index.js";
-import { isConversationOwner } from "@/service/conversationAccess.js";
+import { requireProjectCapability } from "@/service/projectAccess.js";
+
+async function getDeterministicProjectMemberUserId({
+    db,
+    projectId,
+}: {
+    db: PostgresDatabase;
+    projectId: number;
+}): Promise<string | undefined> {
+    const rows = await db
+        .select({ userId: organizationMembershipTable.userId })
+        .from(projectOrganizationOwnershipTable)
+        .innerJoin(
+            organizationMembershipTable,
+            eq(
+                organizationMembershipTable.organizationId,
+                projectOrganizationOwnershipTable.organizationId,
+            ),
+        )
+        .where(eq(projectOrganizationOwnershipTable.projectId, projectId))
+        .orderBy(asc(organizationMembershipTable.createdAt), asc(organizationMembershipTable.id))
+        .limit(1);
+
+    return rows.at(0)?.userId;
+}
 
 // --- Pure functions ---
 
@@ -148,9 +174,9 @@ export async function handleIssueWebhook({
     const conversations = await db
         .select({
             id: conversationTable.id,
+            projectId: conversationTable.projectId,
             slugId: conversationTable.slugId,
             currentContentId: conversationTable.currentContentId,
-            authorId: conversationTable.authorId,
             externalSourceConfig: conversationTable.externalSourceConfig,
         })
         .from(conversationTable)
@@ -198,12 +224,23 @@ export async function handleIssueWebhook({
         if (conversation.currentContentId === null) continue;
 
         try {
+            const authorId = await getDeterministicProjectMemberUserId({
+                db,
+                projectId: conversation.projectId,
+            });
+            if (authorId === undefined) {
+                log.warn(
+                    `[GitHub] Skipping webhook item for conversation ${conversation.slugId}: no project member author found`,
+                );
+                continue;
+            }
+
             await upsertItemFromGitHubIssue({
                 db,
                 conversationId: conversation.id,
                 conversationSlugId: conversation.slugId,
                 conversationContentId: conversation.currentContentId,
-                authorId: conversation.authorId,
+                authorId,
                 externalId,
                 issue: {
                     number: issue.number,
@@ -556,8 +593,7 @@ export async function syncGitHubIssues({
         .select({
             id: conversationTable.id,
             currentContentId: conversationTable.currentContentId,
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
+            projectId: conversationTable.projectId,
             externalSourceConfig: conversationTable.externalSourceConfig,
             conversationType: conversationTable.conversationType,
         })
@@ -570,15 +606,13 @@ export async function syncGitHubIssues({
 
     const conversation = conversationRows[0];
 
-    const isOwner = await isConversationOwner({
+    await requireProjectCapability({
         db,
         userId: requestingUserId,
-        authorId: conversation.authorId,
-        organizationId: conversation.organizationId,
+        projectId: conversation.projectId,
+        capability: "conversation_manage_integrations",
+        message: "Missing conversation_manage_integrations capability",
     });
-    if (!isOwner) {
-        throw new Error("Only conversation owners can trigger sync");
-    }
 
     if (conversation.conversationType !== "maxdiff") {
         throw new Error("Sync is only available for MaxDiff conversations");
@@ -616,7 +650,7 @@ export async function syncGitHubIssues({
                 conversationId: conversation.id,
                 conversationSlugId,
                 conversationContentId: conversation.currentContentId,
-                authorId: conversation.authorId,
+                authorId: requestingUserId,
                 externalId,
                 issue,
                 valkey,

--- a/services/api/src/service/importQueueContract.ts
+++ b/services/api/src/service/importQueueContract.ts
@@ -19,7 +19,6 @@ const zodImportFormData = withJsonSchemaId(
     "ImportFormData",
     z
         .object({
-            postAsOrganization: z.string().optional(),
             participationMode: zodParticipationMode,
             isIndexed: z.boolean(),
             requiresEventTicket: zodEventSlug.optional(),
@@ -41,9 +40,10 @@ const zodImportRequestBase = withJsonSchemaId(
         .object({
             importSlugId: z.string(),
             userId: z.string(),
+            actorUserId: z.string(),
+            projectId: z.number().int().positive(),
             formData: zodImportFormData,
             didWrite: z.string(),
-            authorId: z.string(),
         })
         .strict(),
 );
@@ -111,8 +111,9 @@ export const zodImportWorkerContracts = withJsonSchemaId(
 interface ImportRequestBase {
     importSlugId: string;
     userId: string;
+    actorUserId: string;
+    projectId: number;
     formData: {
-        postAsOrganization?: string;
         participationMode: ParticipationMode;
         isIndexed: boolean;
         requiresEventTicket?: EventSlug;
@@ -120,7 +121,6 @@ interface ImportRequestBase {
         preferredOpinionGroupCount?: PreferredOpinionGroupCount;
     };
     didWrite: string;
-    authorId: string;
 }
 
 export interface CsvImportRequest extends ImportRequestBase {

--- a/services/api/src/service/maxdiffItem.ts
+++ b/services/api/src/service/maxdiffItem.ts
@@ -19,7 +19,7 @@ import { processUserGeneratedHtml } from "@/shared-app-api/html.js";
 import { log } from "@/app.js";
 import type { Valkey } from "@/shared-backend/valkey.js";
 import { VALKEY_QUEUE_KEYS } from "@/shared-backend/valkeyQueues.js";
-import { isConversationOwner } from "@/service/conversationAccess.js";
+import { requireProjectCapability } from "@/service/projectAccess.js";
 
 /**
  * Mark a MaxDiff conversation as dirty so the scoring worker re-scores
@@ -263,23 +263,18 @@ export async function updateMaxdiffItemLifecycle({
 
     const [conversation] = await db
         .select({
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
+            projectId: conversationTable.projectId,
         })
         .from(conversationTable)
         .where(eq(conversationTable.id, conversationId));
 
-    const isOwner = await isConversationOwner({
+    await requireProjectCapability({
         db,
         userId: requestingUserId,
-        authorId: conversation.authorId,
-        organizationId: conversation.organizationId,
+        projectId: conversation.projectId,
+        capability: "conversation_update",
+        message: "Missing conversation_update capability",
     });
-    if (!isOwner) {
-        throw httpErrors.forbidden(
-            "Only conversation owners can update item lifecycle",
-        );
-    }
 
     // Find the item
     const itemRows = await db

--- a/services/api/src/service/merge.ts
+++ b/services/api/src/service/merge.ts
@@ -6,9 +6,10 @@ import {
     followedTopicTable,
     notificationTable,
     opinionTable,
+    organizationMembershipTable,
     phoneTable,
+    projectOrganizationOwnershipTable,
     userDisplayLanguageTable,
-    userOrganizationMappingTable,
     userSpokenLanguagesTable,
     userTable,
     voteTable,
@@ -78,25 +79,19 @@ export async function mergeGuestIntoVerifiedUser({
         .set({ userId: verifiedUserId })
         .where(eq(zkPassportTable.userId, guestUserId));
 
-    // 6. Transfer conversations (uses authorId, not userId)
-    await db
-        .update(conversationTable)
-        .set({ authorId: verifiedUserId })
-        .where(eq(conversationTable.authorId, guestUserId));
-
-    // 7. Transfer opinions (uses authorId, not userId)
+    // 6. Transfer opinions (uses authorId, not userId)
     await db
         .update(opinionTable)
         .set({ authorId: verifiedUserId })
         .where(eq(opinionTable.authorId, guestUserId));
 
-    // 8. Transfer notifications (uses userId)
+    // 7. Transfer notifications (uses userId)
     await db
         .update(notificationTable)
         .set({ userId: verifiedUserId })
         .where(eq(notificationTable.userId, guestUserId));
 
-    // 9. Transfer followed topics (unique constraint: userId + topicId)
+    // 8. Transfer followed topics (unique constraint: userId + topicId)
     // Get guest topics, insert as verified user, skip conflicts
     const guestFollowedTopics = await db
         .select()
@@ -114,7 +109,7 @@ export async function mergeGuestIntoVerifiedUser({
             .onConflictDoNothing();
     }
 
-    // 10. Transfer user spoken languages (unique constraint: userId + languageCode)
+    // 9. Transfer user spoken languages (unique constraint: userId + languageCode)
     const guestSpokenLanguages = await db
         .select()
         .from(userSpokenLanguagesTable)
@@ -130,7 +125,7 @@ export async function mergeGuestIntoVerifiedUser({
             .onConflictDoNothing();
     }
 
-    // 11. Transfer user display language (unique constraint: userId + languageCode)
+    // 10. Transfer user display language (unique constraint: userId + languageCode)
     const guestDisplayLanguages = await db
         .select()
         .from(userDisplayLanguageTable)
@@ -146,15 +141,15 @@ export async function mergeGuestIntoVerifiedUser({
             .onConflictDoNothing();
     }
 
-    // 12. Transfer organization mappings (unique constraint: userId + organizationId)
+    // 11. Transfer organization memberships (unique constraint: userId + organizationId)
     const guestOrgMappings = await db
         .select()
-        .from(userOrganizationMappingTable)
-        .where(eq(userOrganizationMappingTable.userId, guestUserId));
+        .from(organizationMembershipTable)
+        .where(eq(organizationMembershipTable.userId, guestUserId));
 
     for (const mapping of guestOrgMappings) {
         await db
-            .insert(userOrganizationMappingTable)
+            .insert(organizationMembershipTable)
             .values({
                 userId: verifiedUserId,
                 organizationId: mapping.organizationId,
@@ -162,7 +157,7 @@ export async function mergeGuestIntoVerifiedUser({
             .onConflictDoNothing();
     }
 
-    // 13. Transfer votes (uses authorId, unique constraint: authorId + opinionId)
+    // 12. Transfer votes (uses authorId, unique constraint: authorId + opinionId)
     const guestVotes = await db
         .select()
         .from(voteTable)
@@ -181,7 +176,7 @@ export async function mergeGuestIntoVerifiedUser({
             .onConflictDoNothing();
     }
 
-    // 14. Reconcile conversation counters for all affected conversations
+    // 13. Reconcile conversation counters for all affected conversations
     // This ensures vote counts, opinion counts, and participant counts are updated
     const conversationIdsSet = new Set<number>();
 
@@ -208,13 +203,27 @@ export async function mergeGuestIntoVerifiedUser({
         conversationIdsSet.add(opinion.conversationId),
     );
 
-    // From transferred conversations
+    // From conversations owned through transferred memberships
     const transferredConversations = await db
-        .select()
+        .select({ conversationId: conversationTable.id })
         .from(conversationTable)
-        .where(eq(conversationTable.authorId, verifiedUserId));
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            eq(
+                projectOrganizationOwnershipTable.projectId,
+                conversationTable.projectId,
+            ),
+        )
+        .innerJoin(
+            organizationMembershipTable,
+            eq(
+                organizationMembershipTable.organizationId,
+                projectOrganizationOwnershipTable.organizationId,
+            ),
+        )
+        .where(eq(organizationMembershipTable.userId, verifiedUserId));
     transferredConversations.forEach((conversation) =>
-        conversationIdsSet.add(conversation.id),
+        conversationIdsSet.add(conversation.conversationId),
     );
 
     log.info(
@@ -229,7 +238,7 @@ export async function mergeGuestIntoVerifiedUser({
         });
     }
 
-    // 15. Soft-delete the guest user
+    // 14. Soft-delete the guest user
     await db
         .update(userTable)
         .set({

--- a/services/api/src/service/notification.ts
+++ b/services/api/src/service/notification.ts
@@ -9,8 +9,9 @@ import {
     opinionContentTable,
     opinionTable,
     notificationTable,
+    organizationMembershipTable,
+    projectOrganizationOwnershipTable,
     userTable,
-    userOrganizationMappingTable,
 } from "@/shared-backend/schema.js";
 import type { FetchNotificationsResponse } from "@/shared/types/dto.js";
 import type {
@@ -846,8 +847,7 @@ export async function getNotificationRecipients({
 }: GetNotificationRecipientsProps): Promise<NotificationRecipients> {
     const conversationResult = await db
         .select({
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
+            projectId: conversationTable.projectId,
         })
         .from(conversationTable)
         .where(eq(conversationTable.id, conversationId))
@@ -861,20 +861,29 @@ export async function getNotificationRecipients({
         };
     }
 
-    const { authorId, organizationId } = conversationResult[0];
-    const recipientSet = new Set<string>([authorId]);
+    const { projectId } = conversationResult[0];
+    const recipientSet = new Set<string>();
+    const orgMembers = await db
+        .select({
+            userId: organizationMembershipTable.userId,
+            organizationId: organizationMembershipTable.organizationId,
+        })
+        .from(projectOrganizationOwnershipTable)
+        .innerJoin(
+            organizationMembershipTable,
+            eq(
+                organizationMembershipTable.organizationId,
+                projectOrganizationOwnershipTable.organizationId,
+            ),
+        )
+        .where(eq(projectOrganizationOwnershipTable.projectId, projectId));
 
-    if (organizationId !== null) {
-        const orgMembers = await db
-            .select({ userId: userOrganizationMappingTable.userId })
-            .from(userOrganizationMappingTable)
-            .where(
-                eq(userOrganizationMappingTable.organizationId, organizationId),
-            );
-        for (const member of orgMembers) {
-            recipientSet.add(member.userId);
-        }
+    for (const member of orgMembers) {
+        recipientSet.add(member.userId);
     }
+
+    const firstOrganizationId = orgMembers.at(0)?.organizationId ?? null;
+    const firstRecipientId = orgMembers.at(0)?.userId ?? "";
 
     if (excludeUserIds) {
         for (const id of excludeUserIds) {
@@ -884,8 +893,8 @@ export async function getNotificationRecipients({
 
     return {
         recipientUserIds: Array.from(recipientSet),
-        conversationAuthorId: authorId,
-        organizationId,
+        conversationAuthorId: firstRecipientId,
+        organizationId: firstOrganizationId,
     };
 }
 

--- a/services/api/src/service/opinionGroupAnalysis.ts
+++ b/services/api/src/service/opinionGroupAnalysis.ts
@@ -34,7 +34,7 @@ import {
     buildAnalysisDescriptionReadiness,
     shouldUseSystemDescriptions,
 } from "./analysisDescriptionReadiness.js";
-import { hasPremiumAnalysisVariantsAccess } from "./premiumEntitlement.js";
+import { isPremiumFeatureEnabledForProject } from "./projectAccess.js";
 
 export type { AnalysisViewState };
 
@@ -89,8 +89,7 @@ export interface OpinionGroupAnalysisSelection {
 
 export interface LatestOpinionGroupResultRow {
     conversationId: number;
-    authorId: string;
-    organizationId: number | null;
+    projectId: number;
     preferredOpinionGroupCount: number | null;
     variantsEnabled: boolean;
     aiLabelingEnabled: boolean;
@@ -230,8 +229,7 @@ async function getEmptyAnalysisSelectionContext({
         checkpointViewSnapshotId === undefined
             ? await db
                   .select({
-                      authorId: conversationTable.authorId,
-                      organizationId: conversationTable.organizationId,
+                      projectId: conversationTable.projectId,
                       preferredGroupCount:
                           conversationTable.preferredOpinionGroupCount,
                   })
@@ -240,8 +238,7 @@ async function getEmptyAnalysisSelectionContext({
                   .limit(1)
             : await db
                   .select({
-                      authorId: conversationTable.authorId,
-                      organizationId: conversationTable.organizationId,
+                      projectId: conversationTable.projectId,
                       preferredGroupCount:
                           conversationViewSnapshotTable.preferredOpinionGroupCount,
                   })
@@ -273,9 +270,10 @@ async function getEmptyAnalysisSelectionContext({
     }
 
     return {
-        variantsEnabled: await hasPremiumAnalysisVariantsAccess({
+        variantsEnabled: await isPremiumFeatureEnabledForProject({
             db,
-            conversation,
+            projectId: conversation.projectId,
+            feature: "analysis_variants",
             now: new Date(),
         }),
         preferredGroupCount: conversation.preferredGroupCount,
@@ -747,8 +745,7 @@ export async function getOpinionGroupAnalysisSelection({
     const latestResultRows = await db
         .select({
             conversationId: conversationTable.id,
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
+            projectId: conversationTable.projectId,
             preferredOpinionGroupCount:
                 checkpointViewSnapshotId === undefined
                     ? conversationTable.preferredOpinionGroupCount

--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -6,7 +6,7 @@ import {
     conversationTable,
     userTable,
 } from "@/shared-backend/schema.js";
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { generateRandomSlugId } from "@/crypto.js";
 import { log } from "@/app.js";
 import { useCommonPost } from "./common.js";
@@ -30,7 +30,6 @@ import { postNewOpinion } from "./comment.js";
 import { createMaxdiffItem } from "./maxdiffItem.js";
 import { processUserGeneratedHtml } from "@/shared-app-api/html.js";
 import { deleteAllConversationExports } from "@/service/conversationExport/index.js";
-import * as authUtilService from "@/service/authUtil.js";
 import type { GoogleCloudCredentials } from "@/shared-backend/googleCloudAuth.js";
 import {
     getSurveyGateSummary,
@@ -38,9 +37,13 @@ import {
     warmSurveyTranslationsForConversation,
 } from "@/service/survey.js";
 import { scheduleConversationAnalysisRefresh } from "@/shared-backend/conversationCounters.js";
-import { isConversationOwner } from "@/service/conversationAccess.js";
 import { createConversationViewSnapshotsFromCurrentState } from "@/service/conversationViewSnapshot.js";
 import { queueConversationSettingsUpdatedEvent } from "@/service/realtimeEventOutbox.js";
+import {
+    hasProjectCapability,
+    requireProjectCapability,
+    resolveConversationCreateTarget,
+} from "@/service/projectAccess.js";
 
 const MAX_CONVERSATION_SEED_ITEMS = 50;
 
@@ -100,19 +103,11 @@ export async function createNewPost({
             `A conversation can have at most ${String(MAX_CONVERSATION_SEED_ITEMS)} seed items`,
         );
     }
-    let organizationId: number | undefined = undefined;
-    if (postAsOrganization !== undefined && postAsOrganization !== "") {
-        organizationId = await authUtilService.isUserPartOfOrganization({
-            db,
-            organizationName: postAsOrganization,
-            userId: authorId,
-        });
-        if (organizationId === undefined) {
-            throw httpErrors.forbidden(
-                `User '${authorId}' is not part of the organization: '${postAsOrganization}'`,
-            );
-        }
-    }
+    const target = await resolveConversationCreateTarget({
+        db,
+        userId: authorId,
+        postAsOrganizationSlug: postAsOrganization,
+    });
     const conversationSlugId = generateRandomSlugId();
 
     if (conversationBody != null) {
@@ -168,9 +163,8 @@ export async function createNewPost({
             const insertPostResponse = await tx
                 .insert(conversationTable)
                 .values({
-                    authorId: authorId,
                     slugId: conversationSlugId,
-                    organizationId: organizationId,
+                    projectId: target.projectId,
                     isIndexed: isIndexed,
                     participationMode: participationMode,
                     conversationType: conversationType,
@@ -214,15 +208,6 @@ export async function createNewPost({
                     currentContentId: insertedConversationContentId,
                 })
                 .where(eq(conversationTable.id, insertedConversationId));
-
-            // Update the user profile's conversation count
-            await tx
-                .update(userTable)
-                .set({
-                    activeConversationCount: sql`${userTable.activeConversationCount} + 1`,
-                    totalConversationCount: sql`${userTable.totalConversationCount} + 1`,
-                })
-                .where(eq(userTable.id, authorId));
 
             if (seedOpinionList.length > 0) {
                 if (conversationType === "maxdiff") {
@@ -409,8 +394,7 @@ export async function deletePostBySlugId({
         const conversationRows = await tx
             .select({
                 conversationId: conversationTable.id,
-                authorId: conversationTable.authorId,
-                organizationId: conversationTable.organizationId,
+                projectId: conversationTable.projectId,
                 currentContentId: conversationTable.currentContentId,
             })
             .from(conversationTable)
@@ -422,17 +406,13 @@ export async function deletePostBySlugId({
         }
 
         const conversation = conversationRows[0];
-        const isOwner = await isConversationOwner({
+        await requireProjectCapability({
             db: tx,
             userId,
-            authorId: conversation.authorId,
-            organizationId: conversation.organizationId,
+            projectId: conversation.projectId,
+            capability: "conversation_delete",
+            message: "Missing conversation_delete capability",
         });
-        if (!isOwner) {
-            throw httpErrors.forbidden(
-                "Only conversation owners can delete it",
-            );
-        }
         if (conversation.currentContentId === null) {
             throw httpErrors.notFound("Conversation not found");
         }
@@ -443,14 +423,6 @@ export async function deletePostBySlugId({
                 currentContentId: null,
             })
             .where(eq(conversationTable.id, conversation.conversationId));
-
-        // Update the original author's active conversation count
-        await tx
-            .update(userTable)
-            .set({
-                activeConversationCount: sql`${userTable.activeConversationCount} - 1`,
-            })
-            .where(eq(userTable.id, conversation.authorId));
 
         // Mark all of the opinions as deleted
         await tx
@@ -497,11 +469,11 @@ export async function closeConversation({
     conversationSlugId,
     userId,
 }: CloseConversationProps): Promise<CloseConversationResponse> {
-    // First, get the conversation to check ownership and current state
+    // First, get the conversation to check permissions and current state
     const conversation = await db
         .select({
             conversationId: conversationTable.id,
-            authorId: conversationTable.authorId,
+            projectId: conversationTable.projectId,
             isClosed: conversationTable.isClosed,
             isIndexed: conversationTable.isIndexed,
             participationMode: conversationTable.participationMode,
@@ -509,7 +481,6 @@ export async function closeConversation({
             aiLabelingEnabled: conversationTable.aiLabelingEnabled,
             preferredOpinionGroupCount:
                 conversationTable.preferredOpinionGroupCount,
-            organizationId: conversationTable.organizationId,
         })
         .from(conversationTable)
         .where(eq(conversationTable.slugId, conversationSlugId))
@@ -520,13 +491,13 @@ export async function closeConversation({
         throw httpErrors.notFound("Conversation not found");
     }
 
-    const isAuthorized = await isConversationOwner({
+    const canUpdateConversation = await hasProjectCapability({
         db,
         userId,
-        authorId: conversation[0].authorId,
-        organizationId: conversation[0].organizationId,
+        projectId: conversation[0].projectId,
+        capability: "conversation_update",
     });
-    if (!isAuthorized) {
+    if (!canUpdateConversation) {
         return { success: false, reason: "not_allowed" };
     }
 
@@ -584,11 +555,11 @@ export async function openConversation({
     conversationSlugId,
     userId,
 }: OpenConversationProps): Promise<OpenConversationResponse> {
-    // First, get the conversation to check ownership and current state
+    // First, get the conversation to check permissions and current state
     const conversation = await db
         .select({
             conversationId: conversationTable.id,
-            authorId: conversationTable.authorId,
+            projectId: conversationTable.projectId,
             isClosed: conversationTable.isClosed,
             isIndexed: conversationTable.isIndexed,
             participationMode: conversationTable.participationMode,
@@ -596,7 +567,6 @@ export async function openConversation({
             aiLabelingEnabled: conversationTable.aiLabelingEnabled,
             preferredOpinionGroupCount:
                 conversationTable.preferredOpinionGroupCount,
-            organizationId: conversationTable.organizationId,
         })
         .from(conversationTable)
         .where(eq(conversationTable.slugId, conversationSlugId))
@@ -607,13 +577,13 @@ export async function openConversation({
         throw httpErrors.notFound("Conversation not found");
     }
 
-    const isAuthorized = await isConversationOwner({
+    const canUpdateConversation = await hasProjectCapability({
         db,
         userId,
-        authorId: conversation[0].authorId,
-        organizationId: conversation[0].organizationId,
+        projectId: conversation[0].projectId,
+        capability: "conversation_update",
     });
-    if (!isAuthorized) {
+    if (!canUpdateConversation) {
         return { success: false, reason: "not_allowed" };
     }
 

--- a/services/api/src/service/postEdit.ts
+++ b/services/api/src/service/postEdit.ts
@@ -5,6 +5,7 @@ import {
     conversationTable,
     conversationModerationTable,
     organizationTable,
+    projectOrganizationOwnershipTable,
 } from "@/shared-backend/schema.js";
 import { eq } from "drizzle-orm";
 import { log } from "@/app.js";
@@ -23,7 +24,7 @@ import type {
     UpdateConversationRequest,
     UpdateConversationResponse,
 } from "@/shared/types/dto.js";
-import { isConversationOwner } from "@/service/conversationAccess.js";
+import { hasProjectCapability } from "@/service/projectAccess.js";
 import {
     buildConversationEditPermissions,
     getPremiumEntitlementSubjectForConversation,
@@ -50,8 +51,7 @@ export async function getConversationForEdit({
         .select({
             conversationId: conversationTable.id,
             conversationSlugId: conversationTable.slugId,
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
+            projectId: conversationTable.projectId,
             conversationTitle: conversationContentTable.title,
             conversationBody: conversationContentTable.body,
             isIndexed: conversationTable.isIndexed,
@@ -61,7 +61,8 @@ export async function getConversationForEdit({
             aiLabelingEnabled: conversationTable.aiLabelingEnabled,
             preferredOpinionGroupCount:
                 conversationTable.preferredOpinionGroupCount,
-            postAsOrganizationName: organizationTable.name,
+            postAsOrganizationName: organizationTable.displayName,
+            autoProvisionedForUserId: organizationTable.autoProvisionedForUserId,
             createdAt: conversationTable.createdAt,
             updatedAt: conversationTable.updatedAt,
             moderationAction: conversationModerationTable.moderationAction,
@@ -71,9 +72,19 @@ export async function getConversationForEdit({
             conversationContentTable,
             eq(conversationContentTable.id, conversationTable.currentContentId),
         )
-        .leftJoin(
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            eq(
+                projectOrganizationOwnershipTable.projectId,
+                conversationTable.projectId,
+            ),
+        )
+        .innerJoin(
             organizationTable,
-            eq(conversationTable.organizationId, organizationTable.id),
+            eq(
+                projectOrganizationOwnershipTable.organizationId,
+                organizationTable.id,
+            ),
         )
         .leftJoin(
             conversationModerationTable,
@@ -90,13 +101,13 @@ export async function getConversationForEdit({
 
     const conversation = results[0];
 
-    const isOwner = await isConversationOwner({
+    const canUpdateConversation = await hasProjectCapability({
         db,
         userId,
-        authorId: conversation.authorId,
-        organizationId: conversation.organizationId,
+        projectId: conversation.projectId,
+        capability: "conversation_update",
     });
-    if (!isOwner) {
+    if (!canUpdateConversation) {
         return { success: false, reason: "not_author" };
     }
 
@@ -110,12 +121,12 @@ export async function getConversationForEdit({
 
     const editPermissions = await buildConversationEditPermissions({
         db,
-        conversation: {
-            conversationId: conversation.conversationId,
-            requiresEventTicket: conversation.requiresEventTicket,
-            authorId: conversation.authorId,
-            organizationId: conversation.organizationId,
-        },
+            conversation: {
+                conversationId: conversation.conversationId,
+                projectId: conversation.projectId,
+                userId,
+                requiresEventTicket: conversation.requiresEventTicket,
+            },
         hasSurvey: surveyConfig !== undefined,
         now: new Date(),
     });
@@ -134,7 +145,9 @@ export async function getConversationForEdit({
                 ? conversation.preferredOpinionGroupCount
                 : null,
         postAsOrganizationName: toUnionUndefined(
-            conversation.postAsOrganizationName,
+            conversation.autoProvisionedForUserId === null
+                ? conversation.postAsOrganizationName
+                : null,
         ),
         surveyConfig,
         createdAt: conversation.createdAt,
@@ -211,9 +224,8 @@ export async function updateConversation({
         const conversationResults = await tx
             .select({
                 conversationId: conversationTable.id,
-                authorId: conversationTable.authorId,
-                organizationId: conversationTable.organizationId,
-                organizationName: organizationTable.name,
+                projectId: conversationTable.projectId,
+                organizationName: organizationTable.displayName,
                 currentContentId: conversationTable.currentContentId,
                 conversationType: conversationTable.conversationType,
                 isIndexed: conversationTable.isIndexed,
@@ -235,9 +247,19 @@ export async function updateConversation({
                     conversationTable.currentContentId,
                 ),
             )
-            .leftJoin(
+            .innerJoin(
+                projectOrganizationOwnershipTable,
+                eq(
+                    projectOrganizationOwnershipTable.projectId,
+                    conversationTable.projectId,
+                ),
+            )
+            .innerJoin(
                 organizationTable,
-                eq(conversationTable.organizationId, organizationTable.id),
+                eq(
+                    projectOrganizationOwnershipTable.organizationId,
+                    organizationTable.id,
+                ),
             )
             .leftJoin(
                 conversationModerationTable,
@@ -254,13 +276,13 @@ export async function updateConversation({
 
         const conversation = conversationResults[0];
 
-        const isOwner = await isConversationOwner({
+        const canUpdateConversation = await hasProjectCapability({
             db: tx,
             userId,
-            authorId: conversation.authorId,
-            organizationId: conversation.organizationId,
+            projectId: conversation.projectId,
+            capability: "conversation_update",
         });
-        if (!isOwner) {
+        if (!canUpdateConversation) {
             return { success: false, reason: "not_author" } as const;
         }
 
@@ -279,7 +301,7 @@ export async function updateConversation({
 
         const conversationId = conversation.conversationId;
         const subject = getPremiumEntitlementSubjectForConversation({
-            conversation,
+            conversation: { projectId: conversation.projectId, userId },
         });
         const currentBody = toUnionUndefined(conversation.currentBody);
         const contentChanged =

--- a/services/api/src/service/premiumEntitlement.ts
+++ b/services/api/src/service/premiumEntitlement.ts
@@ -8,8 +8,10 @@ import {
 } from "@/shared-backend/analysisScheduler.js";
 import {
     conversationTable,
+    organizationMembershipTable,
     organizationTable,
     premiumFeatureEntitlementTable,
+    projectOrganizationOwnershipTable,
     surveyConfigTable,
     userTable,
 } from "@/shared-backend/schema.js";
@@ -26,7 +28,10 @@ import {
     type PremiumFeature,
 } from "@/shared/types/zod.js";
 import { log } from "@/app.js";
-import * as authUtilService from "./authUtil.js";
+import {
+    getOrCreatePersonalOrganization,
+    resolveConversationCreateTarget,
+} from "./projectAccess.js";
 
 type PremiumFeatureEntitlementUpdateValues = Partial<
     typeof premiumFeatureEntitlementTable.$inferInsert
@@ -41,8 +46,8 @@ const premiumFeatureSortValues = {
 } satisfies Record<PremiumFeature, number>;
 
 export type PremiumEntitlementSubject =
-    | { userId: string; organizationId?: never }
-    | { organizationId: number; userId?: never };
+    | { organizationId: number; projectId?: never; userId?: never }
+    | { projectId: number; userId: string; organizationId?: never };
 
 type PremiumAccessMode = "creation" | "edit";
 
@@ -52,8 +57,8 @@ interface ConversationPremiumFeatureContext {
 }
 
 interface ConversationEntitlementContext {
-    authorId: string;
-    organizationId: number | null;
+    projectId: number;
+    userId: string;
 }
 
 export interface ConversationEditPermissions {
@@ -122,52 +127,12 @@ function getEditAccessEnd(entitlement: EntitlementRow): Date | undefined {
     return addDays(entitlement.expiresAt, PREMIUM_EDIT_GRACE_DAYS);
 }
 
-function getEntitlementSubjectFilter({
-    subject,
-}: {
-    subject: PremiumEntitlementSubject;
-}) {
-    if (subject.userId !== undefined) {
-        return and(
-            eq(premiumFeatureEntitlementTable.userId, subject.userId),
-            isNull(premiumFeatureEntitlementTable.organizationId),
-        );
-    }
-
-    return and(
-        eq(
-            premiumFeatureEntitlementTable.organizationId,
-            subject.organizationId,
-        ),
-        isNull(premiumFeatureEntitlementTable.userId),
-    );
-}
-
-function getConversationSubjectFilter({
-    subject,
-}: {
-    subject: PremiumEntitlementSubject;
-}) {
-    if (subject.userId !== undefined) {
-        return and(
-            eq(conversationTable.authorId, subject.userId),
-            isNull(conversationTable.organizationId),
-        );
-    }
-
-    return eq(conversationTable.organizationId, subject.organizationId);
-}
-
 export function getPremiumEntitlementSubjectForConversation({
     conversation,
 }: {
     conversation: ConversationEntitlementContext;
 }): PremiumEntitlementSubject {
-    if (conversation.organizationId !== null) {
-        return { organizationId: conversation.organizationId };
-    }
-
-    return { userId: conversation.authorId };
+    return { projectId: conversation.projectId, userId: conversation.userId };
 }
 
 export async function getPremiumEntitlementSubjectForCreate({
@@ -179,23 +144,12 @@ export async function getPremiumEntitlementSubjectForCreate({
     userId: string;
     postAsOrganization?: string;
 }): Promise<PremiumEntitlementSubject> {
-    if (postAsOrganization === undefined || postAsOrganization === "") {
-        return { userId };
-    }
-
-    const organizationId = await authUtilService.isUserPartOfOrganization({
+    const target = await resolveConversationCreateTarget({
         db,
         userId,
-        organizationName: postAsOrganization,
+        postAsOrganizationSlug: postAsOrganization,
     });
-
-    if (organizationId === undefined) {
-        throw httpErrors.forbidden(
-            `User '${userId}' is not part of the organization: '${postAsOrganization}'`,
-        );
-    }
-
-    return { organizationId };
+    return { projectId: target.projectId, userId };
 }
 
 async function getCandidateEntitlements({
@@ -213,17 +167,51 @@ async function getCandidateEntitlements({
         return [];
     }
 
-    const subjectFilter = getEntitlementSubjectFilter({ subject });
+    if (subject.organizationId !== undefined) {
+        return await db
+            .select({
+                feature: premiumFeatureEntitlementTable.feature,
+                expiresAt: premiumFeatureEntitlementTable.expiresAt,
+            })
+            .from(premiumFeatureEntitlementTable)
+            .where(
+                and(
+                    eq(
+                        premiumFeatureEntitlementTable.organizationId,
+                        subject.organizationId,
+                    ),
+                    inArray(premiumFeatureEntitlementTable.feature, features),
+                    lte(premiumFeatureEntitlementTable.startsAt, now),
+                    isNull(premiumFeatureEntitlementTable.revokedAt),
+                ),
+            )
+            .orderBy(desc(premiumFeatureEntitlementTable.expiresAt));
+    }
 
     return await db
         .select({
             feature: premiumFeatureEntitlementTable.feature,
             expiresAt: premiumFeatureEntitlementTable.expiresAt,
         })
-        .from(premiumFeatureEntitlementTable)
+        .from(organizationMembershipTable)
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            eq(
+                projectOrganizationOwnershipTable.organizationId,
+                organizationMembershipTable.organizationId,
+            ),
+        )
+        .innerJoin(
+            premiumFeatureEntitlementTable,
+            eq(
+                premiumFeatureEntitlementTable.organizationId,
+                organizationMembershipTable.organizationId,
+            ),
+        )
         .where(
             and(
-                subjectFilter,
+                eq(organizationMembershipTable.userId, subject.userId),
+                eq(projectOrganizationOwnershipTable.projectId, subject.projectId),
                 inArray(premiumFeatureEntitlementTable.feature, features),
                 lte(premiumFeatureEntitlementTable.startsAt, now),
                 isNull(premiumFeatureEntitlementTable.revokedAt),
@@ -280,18 +268,53 @@ async function refreshPremiumAnalysisForSubject({
     subject: PremiumEntitlementSubject;
     valkey: Valkey | undefined;
 }): Promise<void> {
-    const conversationRows = await db
+    const baseQuery = db
         .select({ conversationId: conversationTable.id })
         .from(conversationTable)
-        .where(
-            and(
-                getConversationSubjectFilter({ subject }),
-                eq(conversationTable.conversationType, "polis"),
-                eq(conversationTable.isImporting, false),
-                isNotNull(conversationTable.currentContentId),
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            eq(
+                projectOrganizationOwnershipTable.projectId,
+                conversationTable.projectId,
             ),
-        )
-        .orderBy(desc(conversationTable.createdAt));
+        );
+
+    const conversationRows =
+        subject.organizationId !== undefined
+            ? await baseQuery
+                  .where(
+                      and(
+                          eq(
+                              projectOrganizationOwnershipTable.organizationId,
+                              subject.organizationId,
+                          ),
+                          eq(conversationTable.conversationType, "polis"),
+                          eq(conversationTable.isImporting, false),
+                          isNotNull(conversationTable.currentContentId),
+                      ),
+                  )
+                  .orderBy(desc(conversationTable.createdAt))
+            : await baseQuery
+                  .innerJoin(
+                      organizationMembershipTable,
+                      eq(
+                          organizationMembershipTable.organizationId,
+                          projectOrganizationOwnershipTable.organizationId,
+                      ),
+                  )
+                  .where(
+                      and(
+                          eq(organizationMembershipTable.userId, subject.userId),
+                          eq(
+                              projectOrganizationOwnershipTable.projectId,
+                              subject.projectId,
+                          ),
+                          eq(conversationTable.conversationType, "polis"),
+                          eq(conversationTable.isImporting, false),
+                          isNotNull(conversationTable.currentContentId),
+                      ),
+                  )
+                  .orderBy(desc(conversationTable.createdAt));
 
     for (const row of conversationRows) {
         const hasActiveVotes = await hasActiveVotesForMathWork({
@@ -487,15 +510,46 @@ async function clearPreferredOpinionGroupCountForSubject({
     db: PostgresJsDatabase;
     subject: PremiumEntitlementSubject;
 }): Promise<void> {
+    const conversationRows =
+        subject.organizationId !== undefined
+            ? await db
+                  .select({ conversationId: conversationTable.id })
+                  .from(conversationTable)
+                  .innerJoin(
+                      projectOrganizationOwnershipTable,
+                      eq(
+                          projectOrganizationOwnershipTable.projectId,
+                          conversationTable.projectId,
+                      ),
+                  )
+                  .where(
+                      and(
+                          eq(
+                              projectOrganizationOwnershipTable.organizationId,
+                              subject.organizationId,
+                          ),
+                          isNotNull(conversationTable.preferredOpinionGroupCount),
+                      ),
+                  )
+            : await db
+                  .select({ conversationId: conversationTable.id })
+                  .from(conversationTable)
+                  .where(
+                      and(
+                          eq(conversationTable.projectId, subject.projectId),
+                          isNotNull(conversationTable.preferredOpinionGroupCount),
+                      ),
+                  );
+
+    const conversationIds = conversationRows.map((row) => row.conversationId);
+    if (conversationIds.length === 0) {
+        return;
+    }
+
     await db
         .update(conversationTable)
         .set({ preferredOpinionGroupCount: null })
-        .where(
-            and(
-                getConversationSubjectFilter({ subject }),
-                isNotNull(conversationTable.preferredOpinionGroupCount),
-            ),
-        );
+        .where(inArray(conversationTable.id, conversationIds));
 }
 
 export async function buildConversationEditPermissions({
@@ -568,7 +622,7 @@ async function resolveEntitlementSubject({
 }: {
     db: PostgresJsDatabase;
     subject: CreatePremiumFeatureEntitlementRequest["subject"];
-}): Promise<PremiumEntitlementSubject> {
+}): Promise<{ organizationId: number }> {
     if (subject.username !== undefined) {
         const users = await db
             .select({ userId: userTable.id })
@@ -581,14 +635,18 @@ async function resolveEntitlementSubject({
             throw httpErrors.notFound("User not found");
         }
 
-        return { userId: user.userId };
+        const organization = await getOrCreatePersonalOrganization({
+            db,
+            userId: user.userId,
+        });
+        return { organizationId: organization.organizationId };
     }
 
     if (subject.organizationName !== undefined) {
         const organizations = await db
             .select({ organizationId: organizationTable.id })
             .from(organizationTable)
-            .where(eq(organizationTable.name, subject.organizationName))
+            .where(eq(organizationTable.slug, subject.organizationName))
             .limit(1);
 
         const organization = organizations.at(0);
@@ -606,7 +664,7 @@ function toEntitlementItem(row: {
     id: number;
     userId: string | null;
     username: string | null;
-    organizationId: number | null;
+    organizationId: number;
     organizationName: string | null;
     feature: PremiumFeature;
     startsAt: Date;
@@ -640,10 +698,10 @@ export async function listPremiumFeatureEntitlements({
     const rows = await db
         .select({
             id: premiumFeatureEntitlementTable.id,
-            userId: premiumFeatureEntitlementTable.userId,
+            userId: organizationTable.autoProvisionedForUserId,
             username: userTable.username,
             organizationId: premiumFeatureEntitlementTable.organizationId,
-            organizationName: organizationTable.name,
+            organizationName: organizationTable.displayName,
             feature: premiumFeatureEntitlementTable.feature,
             startsAt: premiumFeatureEntitlementTable.startsAt,
             expiresAt: premiumFeatureEntitlementTable.expiresAt,
@@ -653,16 +711,16 @@ export async function listPremiumFeatureEntitlements({
             updatedAt: premiumFeatureEntitlementTable.updatedAt,
         })
         .from(premiumFeatureEntitlementTable)
-        .leftJoin(
-            userTable,
-            eq(userTable.id, premiumFeatureEntitlementTable.userId),
-        )
-        .leftJoin(
+        .innerJoin(
             organizationTable,
             eq(
                 organizationTable.id,
                 premiumFeatureEntitlementTable.organizationId,
             ),
+        )
+        .leftJoin(
+            userTable,
+            eq(userTable.id, organizationTable.autoProvisionedForUserId),
         )
         .orderBy(desc(premiumFeatureEntitlementTable.updatedAt));
 
@@ -707,8 +765,7 @@ export async function createPremiumFeatureEntitlement({
     await db.transaction(async (tx) => {
         for (const feature of features) {
             await tx.insert(premiumFeatureEntitlementTable).values({
-                userId: subject.userId ?? null,
-                organizationId: subject.organizationId ?? null,
+                organizationId: subject.organizationId,
                 feature,
                 startsAt,
                 expiresAt,
@@ -765,7 +822,6 @@ export async function updatePremiumFeatureEntitlement({
 }): Promise<void> {
     const existingRows = await db
         .select({
-            userId: premiumFeatureEntitlementTable.userId,
             organizationId: premiumFeatureEntitlementTable.organizationId,
             feature: premiumFeatureEntitlementTable.feature,
         })
@@ -774,13 +830,9 @@ export async function updatePremiumFeatureEntitlement({
         .limit(1);
     const existingEntitlement = existingRows.at(0);
     const subject =
-        existingEntitlement?.userId !== null &&
-        existingEntitlement?.userId !== undefined
-            ? { userId: existingEntitlement.userId }
-            : existingEntitlement?.organizationId !== null &&
-                existingEntitlement?.organizationId !== undefined
-              ? { organizationId: existingEntitlement.organizationId }
-              : undefined;
+        existingEntitlement === undefined
+            ? undefined
+            : { organizationId: existingEntitlement.organizationId };
     const hadPremiumAnalysisAccess =
         existingEntitlement?.feature === PREMIUM_ANALYSIS_FEATURE &&
         subject !== undefined

--- a/services/api/src/service/projectAccess.ts
+++ b/services/api/src/service/projectAccess.ts
@@ -1,0 +1,493 @@
+import { httpErrors } from "@fastify/sensible";
+import { and, eq, gt, isNull, lte, or } from "drizzle-orm";
+import type { PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
+import {
+    conversationTable,
+    organizationMembershipAllProjectCapabilityTable,
+    organizationMembershipCapabilityEnum,
+    organizationMembershipCapabilityTable,
+    organizationMembershipTable,
+    organizationTable,
+    premiumFeatureEntitlementTable,
+    projectOrganizationOwnershipTable,
+    projectTable,
+    userTable,
+} from "@/shared-backend/schema.js";
+import type { PremiumFeature } from "@/shared/types/zod.js";
+import {
+    type AllProjectCapability,
+    getProjectIdsWithCapabilityFromGrants,
+    hasActivePremiumFeatureEntitlement,
+    hasCapabilityForProject,
+} from "@/service/projectAccessLogic.js";
+
+export type OrganizationCapability =
+    (typeof organizationMembershipCapabilityEnum.enumValues)[number];
+
+const baselineOrganizationCapabilities = [
+    "organization_manage_members",
+    "organization_manage_profile",
+    "project_create",
+] satisfies readonly OrganizationCapability[];
+
+const baselineAllProjectCapabilities = [
+    "project_update",
+    "project_delete",
+    "project_manage_owner_organizations",
+    "conversation_create",
+    "conversation_update",
+    "conversation_delete",
+    "conversation_view_private_results",
+    "conversation_export_owner_data",
+    "conversation_moderate",
+    "conversation_manage_integrations",
+] satisfies readonly AllProjectCapability[];
+
+function personalOrganizationSlug(userId: string): string {
+    return `user-${userId.replaceAll("-", "")}`;
+}
+
+function defaultProjectSlug(organizationId: number): string {
+    return `org-${String(organizationId)}-default`;
+}
+
+async function ensureBaselineCapabilities({
+    db,
+    organizationMembershipId,
+}: {
+    db: PostgresDatabase;
+    organizationMembershipId: number;
+}): Promise<void> {
+    await db
+        .insert(organizationMembershipCapabilityTable)
+        .values(
+            baselineOrganizationCapabilities.map((capability) => ({
+                organizationMembershipId,
+                capability,
+            })),
+        )
+        .onConflictDoNothing();
+
+    await db
+        .insert(organizationMembershipAllProjectCapabilityTable)
+        .values(
+            baselineAllProjectCapabilities.map((capability) => ({
+                organizationMembershipId,
+                capability,
+            })),
+        )
+        .onConflictDoNothing();
+}
+
+async function getOrCreateMembership({
+    db,
+    userId,
+    organizationId,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    organizationId: number;
+}): Promise<number> {
+    const existingRows = await db
+        .select({ id: organizationMembershipTable.id })
+        .from(organizationMembershipTable)
+        .where(
+            and(
+                eq(organizationMembershipTable.userId, userId),
+                eq(organizationMembershipTable.organizationId, organizationId),
+            ),
+        )
+        .limit(1);
+    const existing = existingRows.at(0);
+    if (existing !== undefined) {
+        return existing.id;
+    }
+
+    const insertedRows = await db
+        .insert(organizationMembershipTable)
+        .values({ userId, organizationId })
+        .returning({ id: organizationMembershipTable.id });
+    const inserted = insertedRows.at(0);
+    if (inserted === undefined) {
+        throw httpErrors.internalServerError(
+            "Failed to create organization membership",
+        );
+    }
+    return inserted.id;
+}
+
+export async function getOrCreatePersonalOrganization({
+    db,
+    userId,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+}): Promise<{ organizationId: number }> {
+    const existingRows = await db
+        .select({ organizationId: organizationTable.id })
+        .from(organizationTable)
+        .where(eq(organizationTable.autoProvisionedForUserId, userId))
+        .limit(1);
+    const existing = existingRows.at(0);
+    if (existing !== undefined) {
+        const membershipId = await getOrCreateMembership({
+            db,
+            userId,
+            organizationId: existing.organizationId,
+        });
+        await ensureBaselineCapabilities({
+            db,
+            organizationMembershipId: membershipId,
+        });
+        return existing;
+    }
+
+    const userRows = await db
+        .select({ firstName: userTable.firstName })
+        .from(userTable)
+        .where(eq(userTable.id, userId))
+        .limit(1);
+    const user = userRows.at(0);
+    if (user === undefined) {
+        throw httpErrors.notFound("User not found");
+    }
+
+    const insertedRows = await db
+        .insert(organizationTable)
+        .values({
+            slug: personalOrganizationSlug(userId),
+            displayName: user.firstName,
+            directoryVisibility: "unlisted",
+            autoProvisionedForUserId: userId,
+            imagePath: "",
+            isFullImagePath: false,
+        })
+        .returning({ organizationId: organizationTable.id });
+    const inserted = insertedRows.at(0);
+    if (inserted === undefined) {
+        throw httpErrors.internalServerError(
+            "Failed to create personal organization",
+        );
+    }
+
+    const membershipId = await getOrCreateMembership({
+        db,
+        userId,
+        organizationId: inserted.organizationId,
+    });
+    await ensureBaselineCapabilities({
+        db,
+        organizationMembershipId: membershipId,
+    });
+    return inserted;
+}
+
+export async function getOrCreateDefaultProjectForOrganization({
+    db,
+    organizationId,
+}: {
+    db: PostgresDatabase;
+    organizationId: number;
+}): Promise<{ projectId: number }> {
+    const existingRows = await db
+        .select({ projectId: projectTable.id })
+        .from(projectTable)
+        .where(eq(projectTable.autoProvisionedForOrganizationId, organizationId))
+        .limit(1);
+    const existing = existingRows.at(0);
+    if (existing !== undefined) {
+        return existing;
+    }
+
+    const organizationRows = await db
+        .select({ displayName: organizationTable.displayName })
+        .from(organizationTable)
+        .where(eq(organizationTable.id, organizationId))
+        .limit(1);
+    const organization = organizationRows.at(0);
+    if (organization === undefined) {
+        throw httpErrors.notFound("Organization not found");
+    }
+
+    const insertedRows = await db
+        .insert(projectTable)
+        .values({
+            slug: defaultProjectSlug(organizationId),
+            displayName: organization.displayName,
+            directoryVisibility: "unlisted",
+            autoProvisionedForOrganizationId: organizationId,
+        })
+        .returning({ projectId: projectTable.id });
+    const inserted = insertedRows.at(0);
+    if (inserted === undefined) {
+        throw httpErrors.internalServerError("Failed to create default project");
+    }
+
+    await db
+        .insert(projectOrganizationOwnershipTable)
+        .values({ projectId: inserted.projectId, organizationId })
+        .onConflictDoNothing();
+
+    return inserted;
+}
+
+export async function resolveConversationCreateTarget({
+    db,
+    userId,
+    postAsOrganizationSlug,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    postAsOrganizationSlug: string | undefined;
+}): Promise<{ projectId: number; organizationId: number }> {
+    if (postAsOrganizationSlug === undefined || postAsOrganizationSlug === "") {
+        const organization = await getOrCreatePersonalOrganization({ db, userId });
+        const project = await getOrCreateDefaultProjectForOrganization({
+            db,
+            organizationId: organization.organizationId,
+        });
+        const canCreate = await hasProjectCapability({
+            db,
+            userId,
+            projectId: project.projectId,
+            capability: "conversation_create",
+        });
+        if (!canCreate) {
+            throw httpErrors.forbidden("Missing conversation_create capability");
+        }
+        return { ...organization, ...project };
+    }
+
+    const organizationRows = await db
+        .select({ organizationId: organizationTable.id })
+        .from(organizationTable)
+        .innerJoin(
+            organizationMembershipTable,
+            eq(organizationMembershipTable.organizationId, organizationTable.id),
+        )
+        .where(
+            and(
+                eq(organizationTable.slug, postAsOrganizationSlug),
+                eq(organizationMembershipTable.userId, userId),
+            ),
+        )
+        .limit(1);
+    const organization = organizationRows.at(0);
+    if (organization === undefined) {
+        throw httpErrors.forbidden(
+            `User '${userId}' is not part of the organization: '${postAsOrganizationSlug}'`,
+        );
+    }
+
+    const project = await getOrCreateDefaultProjectForOrganization({
+        db,
+        organizationId: organization.organizationId,
+    });
+
+    const canCreate = await hasProjectCapability({
+        db,
+        userId,
+        projectId: project.projectId,
+        capability: "conversation_create",
+    });
+    if (!canCreate) {
+        throw httpErrors.forbidden("Missing conversation_create capability");
+    }
+
+    return { ...organization, ...project };
+}
+
+export async function hasProjectCapability({
+    db,
+    userId,
+    projectId,
+    capability,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    projectId: number;
+    capability: AllProjectCapability;
+}): Promise<boolean> {
+    const rows = await db
+        .select({
+            projectId: projectOrganizationOwnershipTable.projectId,
+            organizationId: organizationMembershipTable.organizationId,
+            capability: organizationMembershipAllProjectCapabilityTable.capability,
+        })
+        .from(organizationMembershipTable)
+        .innerJoin(
+            organizationMembershipAllProjectCapabilityTable,
+            eq(
+                organizationMembershipAllProjectCapabilityTable.organizationMembershipId,
+                organizationMembershipTable.id,
+            ),
+        )
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            eq(
+                projectOrganizationOwnershipTable.organizationId,
+                organizationMembershipTable.organizationId,
+            ),
+        )
+        .where(
+            and(
+                eq(organizationMembershipTable.userId, userId),
+                eq(projectOrganizationOwnershipTable.projectId, projectId),
+                eq(
+                    organizationMembershipAllProjectCapabilityTable.capability,
+                    capability,
+                ),
+            ),
+        )
+        .limit(1);
+
+    return hasCapabilityForProject({
+        capabilityGrants: rows,
+        projectOwnerships: rows,
+        projectId,
+        capability,
+    });
+}
+
+export async function requireProjectCapability({
+    db,
+    userId,
+    projectId,
+    capability,
+    message = "Missing project capability",
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    projectId: number;
+    capability: AllProjectCapability;
+    message?: string;
+}): Promise<void> {
+    const hasCapability = await hasProjectCapability({
+        db,
+        userId,
+        projectId,
+        capability,
+    });
+
+    if (!hasCapability) {
+        throw httpErrors.forbidden(message);
+    }
+}
+
+export async function getProjectIdsWithCapability({
+    db,
+    userId,
+    capability,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    capability: AllProjectCapability;
+}): Promise<number[]> {
+    const rows = await db
+        .select({
+            projectId: projectOrganizationOwnershipTable.projectId,
+            organizationId: organizationMembershipTable.organizationId,
+            capability: organizationMembershipAllProjectCapabilityTable.capability,
+        })
+        .from(organizationMembershipTable)
+        .innerJoin(
+            organizationMembershipAllProjectCapabilityTable,
+            eq(
+                organizationMembershipAllProjectCapabilityTable.organizationMembershipId,
+                organizationMembershipTable.id,
+            ),
+        )
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            eq(
+                projectOrganizationOwnershipTable.organizationId,
+                organizationMembershipTable.organizationId,
+            ),
+        )
+        .where(
+            and(
+                eq(organizationMembershipTable.userId, userId),
+                eq(
+                    organizationMembershipAllProjectCapabilityTable.capability,
+                    capability,
+                ),
+            ),
+        );
+
+    return getProjectIdsWithCapabilityFromGrants({
+        capabilityGrants: rows,
+        projectOwnerships: rows,
+        capability,
+    });
+}
+
+export async function hasConversationCapability({
+    db,
+    userId,
+    conversationId,
+    capability,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    conversationId: number;
+    capability: AllProjectCapability;
+}): Promise<boolean> {
+    const rows = await db
+        .select({ projectId: conversationTable.projectId })
+        .from(conversationTable)
+        .where(eq(conversationTable.id, conversationId))
+        .limit(1);
+    const conversation = rows.at(0);
+    if (conversation === undefined) {
+        throw httpErrors.notFound("Conversation not found");
+    }
+
+    return await hasProjectCapability({
+        db,
+        userId,
+        projectId: conversation.projectId,
+        capability,
+    });
+}
+
+export async function isPremiumFeatureEnabledForProject({
+    db,
+    projectId,
+    feature,
+    now,
+}: {
+    db: PostgresDatabase;
+    projectId: number;
+    feature: PremiumFeature;
+    now: Date;
+}): Promise<boolean> {
+    const rows = await db
+        .select({
+            organizationId: premiumFeatureEntitlementTable.organizationId,
+            feature: premiumFeatureEntitlementTable.feature,
+            expiresAt: premiumFeatureEntitlementTable.expiresAt,
+        })
+        .from(projectOrganizationOwnershipTable)
+        .innerJoin(
+            premiumFeatureEntitlementTable,
+            eq(
+                premiumFeatureEntitlementTable.organizationId,
+                projectOrganizationOwnershipTable.organizationId,
+            ),
+        )
+        .where(
+            and(
+                eq(projectOrganizationOwnershipTable.projectId, projectId),
+                eq(premiumFeatureEntitlementTable.feature, feature),
+                lte(premiumFeatureEntitlementTable.startsAt, now),
+                isNull(premiumFeatureEntitlementTable.revokedAt),
+                or(
+                    isNull(premiumFeatureEntitlementTable.expiresAt),
+                    gt(premiumFeatureEntitlementTable.expiresAt, now),
+                ),
+            ),
+        )
+        .limit(1);
+
+    return hasActivePremiumFeatureEntitlement({ grants: rows, feature, now });
+}

--- a/services/api/src/service/projectAccessLogic.test.ts
+++ b/services/api/src/service/projectAccessLogic.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+    getProjectIdsWithCapabilityFromGrants,
+    hasActivePremiumFeatureEntitlement,
+    hasCapabilityForProject,
+    type OrganizationCapabilityGrant,
+    type ProjectOrganizationOwnershipGrant,
+} from "@/service/projectAccessLogic.js";
+
+describe("hasCapabilityForProject", () => {
+    const capabilityGrants: OrganizationCapabilityGrant[] = [
+        {
+            organizationId: 10,
+            capability: "conversation_update",
+        },
+        {
+            organizationId: 11,
+            capability: "conversation_manage_integrations",
+        },
+        {
+            organizationId: 10,
+            capability: "conversation_delete",
+        },
+    ];
+    const projectOwnerships: ProjectOrganizationOwnershipGrant[] = [
+        { projectId: 1, organizationId: 10 },
+        { projectId: 1, organizationId: 11 },
+        { projectId: 2, organizationId: 12 },
+    ];
+
+    it("allows when any effective project grant has the requested capability", () => {
+        expect(
+            hasCapabilityForProject({
+                capabilityGrants,
+                projectOwnerships,
+                projectId: 1,
+                capability: "conversation_manage_integrations",
+            }),
+        ).toBe(true);
+    });
+
+    it("denies when the capability belongs to an organization that does not own the project", () => {
+        expect(
+            hasCapabilityForProject({
+                capabilityGrants,
+                projectOwnerships,
+                projectId: 2,
+                capability: "conversation_delete",
+            }),
+        ).toBe(false);
+    });
+
+    it("denies when project owner organizations lack the requested capability", () => {
+        expect(
+            hasCapabilityForProject({
+                capabilityGrants,
+                projectOwnerships,
+                projectId: 2,
+                capability: "conversation_update",
+            }),
+        ).toBe(false);
+    });
+});
+
+describe("getProjectIdsWithCapabilityFromGrants", () => {
+    it("returns unique project IDs where the requested capability is effective", () => {
+        expect(
+            getProjectIdsWithCapabilityFromGrants({
+                capabilityGrants: [
+                    {
+                        organizationId: 10,
+                        capability: "conversation_update",
+                    },
+                    {
+                        organizationId: 11,
+                        capability: "conversation_update",
+                    },
+                    {
+                        organizationId: 12,
+                        capability: "conversation_delete",
+                    },
+                    {
+                        organizationId: 13,
+                        capability: "conversation_update",
+                    },
+                    {
+                        organizationId: 14,
+                        capability: "conversation_update",
+                    },
+                ],
+                projectOwnerships: [
+                    { projectId: 1, organizationId: 10 },
+                    { projectId: 1, organizationId: 11 },
+                    { projectId: 2, organizationId: 12 },
+                    { projectId: 3, organizationId: 13 },
+                ],
+                capability: "conversation_update",
+            }),
+        ).toEqual([1, 3]);
+    });
+});
+
+describe("hasActivePremiumFeatureEntitlement", () => {
+    const now = new Date("2026-06-10T12:00:00Z");
+
+    it("allows a non-expiring matching entitlement", () => {
+        expect(
+            hasActivePremiumFeatureEntitlement({
+                grants: [
+                    {
+                        organizationId: 1,
+                        feature: "analysis_variants",
+                        expiresAt: null,
+                    },
+                ],
+                feature: "analysis_variants",
+                now,
+            }),
+        ).toBe(true);
+    });
+
+    it("allows a matching entitlement that expires in the future", () => {
+        expect(
+            hasActivePremiumFeatureEntitlement({
+                grants: [
+                    {
+                        organizationId: 1,
+                        feature: "survey",
+                        expiresAt: new Date("2026-06-11T12:00:00Z"),
+                    },
+                ],
+                feature: "survey",
+                now,
+            }),
+        ).toBe(true);
+    });
+
+    it("denies expired or different-feature entitlements", () => {
+        expect(
+            hasActivePremiumFeatureEntitlement({
+                grants: [
+                    {
+                        organizationId: 1,
+                        feature: "survey",
+                        expiresAt: new Date("2026-06-09T12:00:00Z"),
+                    },
+                    {
+                        organizationId: 1,
+                        feature: "event_ticket",
+                        expiresAt: null,
+                    },
+                ],
+                feature: "survey",
+                now,
+            }),
+        ).toBe(false);
+    });
+});

--- a/services/api/src/service/projectAccessLogic.ts
+++ b/services/api/src/service/projectAccessLogic.ts
@@ -1,0 +1,98 @@
+import { organizationMembershipAllProjectCapabilityEnum } from "@/shared-backend/schema.js";
+import type { PremiumFeature } from "@/shared/types/zod.js";
+
+export type AllProjectCapability =
+    (typeof organizationMembershipAllProjectCapabilityEnum.enumValues)[number];
+
+export interface OrganizationCapabilityGrant {
+    organizationId: number;
+    capability: AllProjectCapability;
+}
+
+export interface ProjectOrganizationOwnershipGrant {
+    projectId: number;
+    organizationId: number;
+}
+
+export interface PremiumEntitlementGrant {
+    organizationId: number;
+    feature: PremiumFeature;
+    expiresAt: Date | null;
+}
+
+export function hasCapabilityForProject({
+    capabilityGrants,
+    projectOwnerships,
+    projectId,
+    capability,
+}: {
+    capabilityGrants: readonly OrganizationCapabilityGrant[];
+    projectOwnerships: readonly ProjectOrganizationOwnershipGrant[];
+    projectId: number;
+    capability: AllProjectCapability;
+}): boolean {
+    const ownerOrganizationIds = new Set<number>();
+    for (const ownership of projectOwnerships) {
+        if (ownership.projectId === projectId) {
+            ownerOrganizationIds.add(ownership.organizationId);
+        }
+    }
+
+    for (const grant of capabilityGrants) {
+        if (
+            grant.capability === capability &&
+            ownerOrganizationIds.has(grant.organizationId)
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export function getProjectIdsWithCapabilityFromGrants({
+    capabilityGrants,
+    projectOwnerships,
+    capability,
+}: {
+    capabilityGrants: readonly OrganizationCapabilityGrant[];
+    projectOwnerships: readonly ProjectOrganizationOwnershipGrant[];
+    capability: AllProjectCapability;
+}): number[] {
+    const organizationIdsWithCapability = new Set<number>();
+    for (const grant of capabilityGrants) {
+        if (grant.capability === capability) {
+            organizationIdsWithCapability.add(grant.organizationId);
+        }
+    }
+
+    const projectIds = new Set<number>();
+    for (const ownership of projectOwnerships) {
+        if (organizationIdsWithCapability.has(ownership.organizationId)) {
+            projectIds.add(ownership.projectId);
+        }
+    }
+
+    return Array.from(projectIds);
+}
+
+export function hasActivePremiumFeatureEntitlement({
+    grants,
+    feature,
+    now,
+}: {
+    grants: readonly PremiumEntitlementGrant[];
+    feature: PremiumFeature;
+    now: Date;
+}): boolean {
+    for (const grant of grants) {
+        if (
+            grant.feature === feature &&
+            (grant.expiresAt === null || grant.expiresAt.getTime() > now.getTime())
+        ) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/services/api/src/service/survey.ts
+++ b/services/api/src/service/survey.ts
@@ -10,7 +10,6 @@ import {
     opinionGroupLineageTable,
     opinionGroupTable,
     opinionTable,
-    organizationTable,
     surveyAggregateOptionTable,
     surveyAggregateQuestionTable,
     surveyAggregateResultTable,
@@ -84,8 +83,8 @@ import {
 import { log } from "@/app.js";
 import {
     getConversationViewAccessLevelForConversation,
-    isConversationOwner,
 } from "@/service/conversationAccess.js";
+import { requireProjectCapability } from "@/service/projectAccess.js";
 import {
     buildSurveyCompletionCounts,
     loadSurveyExportContext,
@@ -103,9 +102,7 @@ import {
 interface ConversationAccessContext {
     conversationId: number;
     slugId: string;
-    authorId: string;
-    organizationId: number | null;
-    organizationName: string | null;
+    projectId: number;
     participationMode: (typeof conversationTable.$inferSelect)["participationMode"];
     conversationType: (typeof conversationTable.$inferSelect)["conversationType"];
     currentContentId: number | null;
@@ -957,9 +954,7 @@ async function getConversationAccessContextBySlugId({
         .select({
             conversationId: conversationTable.id,
             slugId: conversationTable.slugId,
-            authorId: conversationTable.authorId,
-            organizationId: conversationTable.organizationId,
-            organizationName: organizationTable.name,
+            projectId: conversationTable.projectId,
             participationMode: conversationTable.participationMode,
             conversationType: conversationTable.conversationType,
             currentContentId: conversationTable.currentContentId,
@@ -967,10 +962,6 @@ async function getConversationAccessContextBySlugId({
             requiresEventTicket: conversationTable.requiresEventTicket,
         })
         .from(conversationTable)
-        .leftJoin(
-            organizationTable,
-            eq(conversationTable.organizationId, organizationTable.id),
-        )
         .where(eq(conversationTable.slugId, conversationSlugId))
         .limit(1);
 
@@ -2700,8 +2691,7 @@ export async function fetchSurveyAggregatedResults({
     const accessLevel = await getConversationViewAccessLevelForConversation({
         db,
         userId,
-        authorId: conversation.authorId,
-        organizationId: conversation.organizationId,
+        projectId: conversation.projectId,
     });
     const activeSurveyConfig = await getActiveSurveyConfigRecord({
         db,
@@ -2803,12 +2793,11 @@ export async function fetchSurveyCompletionCounts({
     const accessLevel = await getConversationViewAccessLevelForConversation({
         db,
         userId,
-        authorId: conversation.authorId,
-        organizationId: conversation.organizationId,
+        projectId: conversation.projectId,
     });
     if (accessLevel !== "owner") {
         throw httpErrors.forbidden(
-            "Only conversation owners can view survey completion counts",
+            "Missing conversation_update capability",
         );
     }
 
@@ -3291,24 +3280,22 @@ export async function updateSurveyConfigByAuthor({
         db,
         conversationSlugId,
     });
-    const isOwner = await isConversationOwner({
+    await requireProjectCapability({
         db,
         userId,
-        authorId: conversation.authorId,
-        organizationId: conversation.organizationId,
+        projectId: conversation.projectId,
+        capability: "conversation_update",
+        message: "Missing conversation_update capability",
     });
-    if (!isOwner) {
-        throw httpErrors.forbidden(
-            "Only conversation owners can edit the survey",
-        );
-    }
     const existingSurveyConfig = await getActiveSurveyConfigRecord({
         db,
         conversationId: conversation.conversationId,
     });
     await requirePremiumAccess({
         db,
-        subject: getPremiumEntitlementSubjectForConversation({ conversation }),
+        subject: getPremiumEntitlementSubjectForConversation({
+            conversation: { projectId: conversation.projectId, userId },
+        }),
         features: ["survey"],
         mode: existingSurveyConfig === undefined ? "creation" : "edit",
         now,
@@ -3379,17 +3366,13 @@ export async function deleteSurveyConfigByAuthor({
         db,
         conversationSlugId,
     });
-    const isOwner = await isConversationOwner({
+    await requireProjectCapability({
         db,
         userId,
-        authorId: conversation.authorId,
-        organizationId: conversation.organizationId,
+        projectId: conversation.projectId,
+        capability: "conversation_update",
+        message: "Missing conversation_update capability",
     });
-    if (!isOwner) {
-        throw httpErrors.forbidden(
-            "Only conversation owners can delete the survey",
-        );
-    }
     const surveyConfigUpdateEffect = await db.transaction(async (tx) => {
         return await setSurveyConfigForConversation({
             db: tx,

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -4,6 +4,8 @@ import {
     opinionTable,
     opinionModerationTable,
     conversationTable,
+    organizationMembershipTable,
+    projectOrganizationOwnershipTable,
     userTable,
     voteTable,
     eventTicketTable,
@@ -22,7 +24,6 @@ import {
     eq,
     lt,
     or,
-    ne,
     desc,
     inArray,
     isNotNull,
@@ -37,14 +38,12 @@ import {
 import { fetchPostBySlugId } from "./post.js";
 import { createCommentModerationPropertyObject } from "./moderation.js";
 import {
-    getOrganizationIdsByUserId,
     getOrganizationMembershipsByUserId,
 } from "./administrator/organization.js";
-import { getConversationOwnerFilter } from "./conversationAccess.js";
+import { getProjectIdsWithCapability } from "./projectAccess.js";
 import type { ImportPolisResults } from "@/shared/types/polis.js";
 import { generateUUID } from "@/crypto.js";
 import type { UserIdPerParticipantId } from "@/utils/dataStructure.js";
-import { alias } from "drizzle-orm/pg-core";
 
 interface GetAllUserCommentsProps {
     db: PostgresJsDatabase;
@@ -117,9 +116,6 @@ export async function getUserComments({
             authorId: userId,
         });
 
-        // Fetch a list of comment IDs first
-        const conversationAuthorTable = alias(userTable, "conversationAuthor");
-
         const preparedQuery = db
             .select({
                 opinionId: opinionTable.id,
@@ -148,10 +144,6 @@ export async function getUserComments({
                 conversationTable,
                 eq(conversationTable.id, opinionTable.conversationId),
             )
-            .innerJoin(
-                conversationAuthorTable,
-                eq(conversationAuthorTable.id, conversationTable.authorId),
-            )
             .leftJoin(
                 opinionModerationTable,
                 eq(opinionModerationTable.opinionId, opinionTable.id),
@@ -168,12 +160,10 @@ export async function getUserComments({
                               ),
                           ),
                           isNotNull(opinionTable.currentContentId),
-                          eq(conversationAuthorTable.isDeleted, false),
                       )
                     : and(
                           eq(opinionTable.authorId, userId),
                           isNotNull(opinionTable.currentContentId),
-                          eq(conversationAuthorTable.isDeleted, false),
                       ),
             )
             .orderBy(desc(opinionTable.createdAt), desc(opinionTable.id));
@@ -253,44 +243,36 @@ interface GetUserPostProps {
 async function getOwnedActiveConversationCount({
     db,
     userId,
-    organizationIds,
 }: {
     db: PostgresJsDatabase;
     userId: string;
-    organizationIds: number[];
 }): Promise<number> {
-    const authorCountRows = await db
+    const countRows = await db
         .select({ count: count() })
         .from(conversationTable)
-        .innerJoin(userTable, eq(userTable.id, conversationTable.authorId))
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            eq(
+                projectOrganizationOwnershipTable.projectId,
+                conversationTable.projectId,
+            ),
+        )
+        .innerJoin(
+            organizationMembershipTable,
+            eq(
+                organizationMembershipTable.organizationId,
+                projectOrganizationOwnershipTable.organizationId,
+            ),
+        )
         .where(
             and(
-                eq(conversationTable.authorId, userId),
+                eq(organizationMembershipTable.userId, userId),
                 eq(conversationTable.isImporting, false),
                 isNotNull(conversationTable.currentContentId),
-                eq(userTable.isDeleted, false),
             ),
         );
 
-    if (organizationIds.length === 0) {
-        return authorCountRows[0].count;
-    }
-
-    const organizationCountRows = await db
-        .select({ count: count() })
-        .from(conversationTable)
-        .innerJoin(userTable, eq(userTable.id, conversationTable.authorId))
-        .where(
-            and(
-                inArray(conversationTable.organizationId, organizationIds),
-                ne(conversationTable.authorId, userId),
-                eq(conversationTable.isImporting, false),
-                isNotNull(conversationTable.currentContentId),
-                eq(userTable.isDeleted, false),
-            ),
-        );
-
-    return authorCountRows[0].count + organizationCountRows[0].count;
+    return countRows[0].count;
 }
 
 export async function getUserPosts({
@@ -307,19 +289,19 @@ export async function getUserPosts({
             lastSlugId: lastPostSlugId,
             db: db,
         });
-        const organizationIds = await getOrganizationIdsByUserId({
+        const projectIds = await getProjectIdsWithCapability({
             db,
             userId,
+            capability: "conversation_update",
         });
-        const ownershipFilter = getConversationOwnerFilter({
-            userId,
-            organizationIds,
-        });
+        if (projectIds.length === 0) {
+            return new Map();
+        }
 
         const whereClause =
             lastCursor !== undefined
                 ? and(
-                      ownershipFilter,
+                      inArray(conversationTable.projectId, projectIds),
                       eq(conversationTable.isImporting, false),
                       isNotNull(conversationTable.currentContentId),
                       or(
@@ -337,7 +319,7 @@ export async function getUserPosts({
                       ),
                   )
                 : and(
-                      ownershipFilter,
+                      inArray(conversationTable.projectId, projectIds),
                       eq(conversationTable.isImporting, false),
                       isNotNull(conversationTable.currentContentId),
                   );
@@ -448,13 +430,9 @@ export async function getUserProfile({
                     userId,
                     baseImageServiceUrl,
                 });
-            const organizationIds = organizationMemberships.map(
-                (membership) => membership.organizationId,
-            );
             const activePostCount = await getOwnedActiveConversationCount({
                 db,
                 userId,
-                organizationIds,
             });
 
             // Fetch verified event tickets for this user
@@ -550,6 +528,7 @@ export async function bulkInsertUsersFromExternalPolisConvo({
         return {
             id: userId,
             username: `ext_${conversationSlugId}_${String(participantId)}`,
+            firstName: `ext_${conversationSlugId}_${String(participantId)}`,
             isImported: true,
         };
     });

--- a/services/api/src/service/zupass.ts
+++ b/services/api/src/service/zupass.ts
@@ -829,8 +829,10 @@ export async function registerWithZupass({
 }: RegisterWithZupassProps): Promise<void> {
     log.info("[Zupass] Register with Zupass");
     await db.transaction(async (tx) => {
+        const username = await generateUnusedRandomUsername({ db: db });
         await tx.insert(userTable).values({
-            username: await generateUnusedRandomUsername({ db: db }),
+            username,
+            firstName: username,
             id: userId,
         });
         await tx.insert(deviceTable).values({

--- a/services/api/src/shared-backend/schema.ts
+++ b/services/api/src/shared-backend/schema.ts
@@ -861,32 +861,6 @@ export const userTable = pgTable(
     },
 );
 
-/** @service import-worker */
-export const userOrganizationMappingTable = pgTable(
-    "user_organization_mapping",
-    {
-        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-        userId: uuid("user_id")
-            .references(() => userTable.id)
-            .notNull(),
-        organizationId: integer("organization_id")
-            .references(() => organizationTable.id)
-            .notNull(),
-        createdAt: timestamp("created_at", {
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-    },
-    (t) => [
-        unique("unique_user_orgaization_mapping").on(
-            t.userId,
-            t.organizationId,
-        ),
-    ],
-);
-
 export const organizationMembershipTable = pgTable(
     "organization_membership",
     {
@@ -1050,9 +1024,6 @@ export const userDisplayLanguageTable = pgTable(
 /** @service import-worker */
 export const organizationTable = pgTable("organization", {
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-    name: varchar("name", { length: MAX_LENGTH_NAME_CREATOR })
-        .notNull()
-        .unique(),
     slug: varchar("slug", { length: MAX_LENGTH_NAME_CREATOR })
         .notNull()
         .unique(),
@@ -1193,10 +1164,9 @@ export const premiumFeatureEntitlementTable = pgTable(
     "premium_feature_entitlement",
     {
         id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-        userId: uuid("user_id").references(() => userTable.id),
         organizationId: integer("organization_id").references(
             () => organizationTable.id,
-        ),
+        ).notNull(),
         feature: premiumFeatureEnum("feature").notNull(),
         startsAt: timestamp("starts_at", {
             mode: "date",
@@ -1231,17 +1201,6 @@ export const premiumFeatureEntitlementTable = pgTable(
             .notNull(),
     },
     (table) => [
-        check(
-            "premium_feature_entitlement_single_subject_check",
-            sqlOr(
-                sqlAnd(isNotNull(table.userId), isNull(table.organizationId)),
-                sqlAnd(isNull(table.userId), isNotNull(table.organizationId)),
-            ),
-        ),
-        index("premium_feature_entitlement_user_idx").on(
-            table.userId,
-            table.feature,
-        ),
         index("premium_feature_entitlement_org_idx").on(
             table.organizationId,
             table.feature,
@@ -1623,12 +1582,6 @@ export const conversationTable = pgTable(
     {
         id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
         slugId: varchar("slug_id", { length: 8 }).notNull().unique(), // used for permanent URL
-        authorId: uuid("author_id") // "postAs"
-            .notNull()
-            .references(() => userTable.id), // the author of the conversation
-        organizationId: integer("organization_id").references(
-            () => organizationTable.id,
-        ),
         projectId: integer("project_id")
             .references(() => projectTable.id)
             .notNull(),
@@ -1701,24 +1654,6 @@ export const conversationTable = pgTable(
             table.isImporting,
             table.conversationType,
         ),
-        // Composite for user conversation timeline: filters authorId + isImporting, sorts by createdAt/id
-        index("conversation_author_timeline_idx").using(
-            "btree",
-            table.authorId,
-            table.isImporting,
-            sql`${table.createdAt} DESC`,
-            sql`${table.id} DESC`,
-        ),
-        // Composite for organization conversation timeline: filters organizationId + isImporting, sorts by createdAt/id
-        index("conversation_organization_timeline_idx")
-            .using(
-                "btree",
-                table.organizationId,
-                table.isImporting,
-                sql`${table.createdAt} DESC`,
-                sql`${table.id} DESC`,
-            )
-            .where(isNotNull(table.currentContentId)),
         index("conversation_project_id_idx").on(table.projectId),
         index("conversation_project_timeline_idx")
             .using(

--- a/services/api/src/shared-backend/schema.ts
+++ b/services/api/src/shared-backend/schema.ts
@@ -601,6 +601,36 @@ export const premiumFeatureEnum = pgEnum("premium_feature", [
     "analysis_variants",
 ]);
 
+export const directoryVisibilityEnum = pgEnum("directory_visibility", [
+    "listed",
+    "unlisted",
+]);
+
+export const organizationMembershipCapabilityEnum = pgEnum(
+    "organization_membership_capability_enum",
+    [
+        "organization_manage_members",
+        "organization_manage_profile",
+        "project_create",
+    ],
+);
+
+export const organizationMembershipAllProjectCapabilityEnum = pgEnum(
+    "organization_membership_all_project_capability_enum",
+    [
+        "project_update",
+        "project_delete",
+        "project_manage_owner_organizations",
+        "conversation_create",
+        "conversation_update",
+        "conversation_delete",
+        "conversation_view_private_results",
+        "conversation_export_owner_data",
+        "conversation_moderate",
+        "conversation_manage_integrations",
+    ],
+);
+
 export const surveyQuestionTypeEnum = pgEnum("survey_question_type", [
     "choice",
     "free_text",
@@ -802,6 +832,8 @@ export const userTable = pgTable(
         username: varchar("username", { length: MAX_LENGTH_USERNAME })
             .notNull()
             .unique(),
+        firstName: varchar("first_name", { length: MAX_LENGTH_NAME_CREATOR })
+            .notNull(),
         isSiteModerator: boolean("is_site_moderator").notNull().default(false),
         isSiteOrgAdmin: boolean("is_site_org_admin").notNull().default(false),
         isImported: boolean("is_imported").notNull().default(false),
@@ -852,6 +884,38 @@ export const userOrganizationMappingTable = pgTable(
             t.userId,
             t.organizationId,
         ),
+    ],
+);
+
+export const organizationMembershipTable = pgTable(
+    "organization_membership",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        userId: uuid("user_id")
+            .references(() => userTable.id)
+            .notNull(),
+        organizationId: integer("organization_id")
+            .references(() => organizationTable.id)
+            .notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+        updatedAt: timestamp("updated_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (t) => [
+        unique("organization_membership_user_organization_unique").on(
+            t.userId,
+            t.organizationId,
+        ),
+        index("organization_membership_organization_idx").on(t.organizationId),
     ],
 );
 
@@ -989,6 +1053,15 @@ export const organizationTable = pgTable("organization", {
     name: varchar("name", { length: MAX_LENGTH_NAME_CREATOR })
         .notNull()
         .unique(),
+    slug: varchar("slug", { length: MAX_LENGTH_NAME_CREATOR })
+        .notNull()
+        .unique(),
+    displayName: varchar("display_name", { length: MAX_LENGTH_NAME_CREATOR })
+        .notNull(),
+    directoryVisibility: directoryVisibilityEnum("directory_visibility").notNull(),
+    autoProvisionedForUserId: uuid("auto_provisioned_for_user_id")
+        .references(() => userTable.id)
+        .unique(),
     imagePath: text("image_path").notNull(),
     isFullImagePath: boolean("is_full_image_path").notNull(),
     websiteUrl: text("website_url").unique(),
@@ -1009,7 +1082,113 @@ export const organizationTable = pgTable("organization", {
         .notNull(),
 });
 
-/** @service api, shared-analysis-worker */
+/** @service scoring-worker, api, math-updater, import-worker */
+export const projectTable = pgTable("project", {
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    slug: varchar("slug", { length: MAX_LENGTH_NAME_CREATOR })
+        .notNull()
+        .unique(),
+    displayName: varchar("display_name", { length: MAX_LENGTH_NAME_CREATOR })
+        .notNull(),
+    directoryVisibility: directoryVisibilityEnum("directory_visibility").notNull(),
+    autoProvisionedForOrganizationId: integer(
+        "auto_provisioned_for_organization_id",
+    )
+        .references(() => organizationTable.id)
+        .unique(),
+    createdAt: timestamp("created_at", {
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+    updatedAt: timestamp("updated_at", {
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+});
+
+/** @service scoring-worker, api, math-updater, import-worker */
+export const projectOrganizationOwnershipTable = pgTable(
+    "project_organization_ownership",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        projectId: integer("project_id")
+            .references(() => projectTable.id)
+            .notNull(),
+        organizationId: integer("organization_id")
+            .references(() => organizationTable.id)
+            .notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (table) => [
+        unique("project_organization_ownership_project_org_unique").on(
+            table.projectId,
+            table.organizationId,
+        ),
+        index("project_organization_ownership_organization_idx").on(
+            table.organizationId,
+        ),
+    ],
+);
+
+/** @service api */
+export const organizationMembershipCapabilityTable = pgTable(
+    "organization_membership_capability",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        organizationMembershipId: integer("organization_membership_id")
+            .references(() => organizationMembershipTable.id)
+            .notNull(),
+        capability: organizationMembershipCapabilityEnum("capability").notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (table) => [
+        unique("organization_membership_capability_unique").on(
+            table.organizationMembershipId,
+            table.capability,
+        ),
+    ],
+);
+
+/** @service api */
+export const organizationMembershipAllProjectCapabilityTable = pgTable(
+    "organization_membership_all_project_capability",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        organizationMembershipId: integer("organization_membership_id")
+            .references(() => organizationMembershipTable.id)
+            .notNull(),
+        capability:
+            organizationMembershipAllProjectCapabilityEnum("capability").notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (table) => [
+        unique("organization_membership_all_project_capability_unique").on(
+            table.organizationMembershipId,
+            table.capability,
+        ),
+    ],
+);
+
+/** @service api, math-updater */
 export const premiumFeatureEntitlementTable = pgTable(
     "premium_feature_entitlement",
     {
@@ -1450,6 +1629,9 @@ export const conversationTable = pgTable(
         organizationId: integer("organization_id").references(
             () => organizationTable.id,
         ),
+        projectId: integer("project_id")
+            .references(() => projectTable.id)
+            .notNull(),
         currentContentId: integer("current_content_id")
             .references((): AnyPgColumn => conversationContentTable.id)
             .unique(), // null if conversation was deleted
@@ -1532,6 +1714,16 @@ export const conversationTable = pgTable(
             .using(
                 "btree",
                 table.organizationId,
+                table.isImporting,
+                sql`${table.createdAt} DESC`,
+                sql`${table.id} DESC`,
+            )
+            .where(isNotNull(table.currentContentId)),
+        index("conversation_project_id_idx").on(table.projectId),
+        index("conversation_project_timeline_idx")
+            .using(
+                "btree",
+                table.projectId,
                 table.isImporting,
                 sql`${table.createdAt} DESC`,
                 sql`${table.id} DESC`,

--- a/services/api/tests/admissionGuards.test.ts
+++ b/services/api/tests/admissionGuards.test.ts
@@ -228,6 +228,7 @@ describe("Admission guards", () => {
             requestUrlImport({
                 db,
                 userId,
+                projectId: 1,
                 polisUrl: "https://pol.is/123",
                 formData: {
                     participationMode: "guest",

--- a/services/api/tests/authOtpThrottling.test.ts
+++ b/services/api/tests/authOtpThrottling.test.ts
@@ -212,9 +212,11 @@ describe("OTP destination throttling", () => {
 
     async function createGuestDevice(didWrite: string) {
         const userId = crypto.randomUUID();
+        const username = didWrite.replace(/[^a-z0-9]/gi, "").slice(-20);
         await db.insert(userTable).values({
             id: userId,
-            username: didWrite.replace(/[^a-z0-9]/gi, "").slice(-20),
+            username,
+            firstName: username,
         });
         await db.insert(deviceTable).values({
             didWrite,
@@ -297,6 +299,7 @@ describe("OTP destination throttling", () => {
         await db.insert(userTable).values({
             id: conflictingUserId,
             username: "conflictemailuser",
+            firstName: "conflictemailuser",
         });
         await db.insert(emailTable).values({
             email: normalizeEmail(email),
@@ -364,6 +367,7 @@ describe("OTP destination throttling", () => {
         await db.insert(userTable).values({
             id: conflictingUserId,
             username: "conflictphoneuser",
+            firstName: "conflictphoneuser",
         });
         await db.insert(phoneTable).values({
             userId: conflictingUserId,

--- a/services/import-worker/src/import_worker/generated_import_contracts.py
+++ b/services/import-worker/src/import_worker/generated_import_contracts.py
@@ -29,7 +29,6 @@ class ImportFormData(BaseModel):
         extra="forbid",
         validate_by_name=True,
     )
-    post_as_organization: str | None = Field(None, alias="postAsOrganization")
     participation_mode: ParticipationMode = Field(..., alias="participationMode")
     is_indexed: bool = Field(..., alias="isIndexed")
     requires_event_ticket: RequiresEventTicket | None = Field(None, alias="requiresEventTicket")
@@ -56,9 +55,10 @@ class UrlImportRequest(BaseModel):
     )
     import_slug_id: str = Field(..., alias="importSlugId")
     user_id: str = Field(..., alias="userId")
+    actor_user_id: str = Field(..., alias="actorUserId")
+    project_id: int = Field(..., alias="projectId", gt=0)
     form_data: ImportFormData = Field(..., alias="formData")
     did_write: str = Field(..., alias="didWrite")
-    author_id: str = Field(..., alias="authorId")
     type: Literal["url"]
     polis_url: str = Field(..., alias="polisUrl")
 
@@ -91,9 +91,10 @@ class CsvImportRequest(BaseModel):
     )
     import_slug_id: str = Field(..., alias="importSlugId")
     user_id: str = Field(..., alias="userId")
+    actor_user_id: str = Field(..., alias="actorUserId")
+    project_id: int = Field(..., alias="projectId", gt=0)
     form_data: ImportFormData = Field(..., alias="formData")
     did_write: str = Field(..., alias="didWrite")
-    author_id: str = Field(..., alias="authorId")
     type: Literal["csv"]
     files: CsvFiles
 

--- a/services/import-worker/src/import_worker/generated_models.py
+++ b/services/import-worker/src/import_worker/generated_models.py
@@ -110,6 +110,11 @@ class ModerationReasonEnum(StrEnum):
     spam = "spam"
 
 
+class DirectoryVisibility(StrEnum):
+    listed = "listed"
+    unlisted = "unlisted"
+
+
 class VoteEnumAll(StrEnum):
     agree = "agree"
     disagree = "disagree"
@@ -178,8 +183,7 @@ class Conversation(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     slug_id: Mapped[str] = mapped_column(String(8))
-    author_id: Mapped[uuid_pkg.UUID] = mapped_column(Uuid)
-    organization_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    project_id: Mapped[int] = mapped_column(Integer)
     current_content_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     current_ranking_score_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     is_indexed: Mapped[bool] = mapped_column(Boolean, server_default="true")
@@ -336,7 +340,12 @@ class Organization(Base):
     __tablename__ = "organization"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    name: Mapped[str] = mapped_column(String(65))
+    slug: Mapped[str] = mapped_column(String(65))
+    display_name: Mapped[str] = mapped_column(String(65))
+    directory_visibility: Mapped[DirectoryVisibility] = mapped_column(
+        SaEnum(DirectoryVisibility, values_callable=_enum_values, native_enum=False),
+    )
+    auto_provisioned_for_user_id: Mapped[uuid_pkg.UUID | None] = mapped_column(Uuid, nullable=True)
     image_path: Mapped[str] = mapped_column(Text)
     is_full_image_path: Mapped[bool] = mapped_column(Boolean)
     website_url: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -345,13 +354,27 @@ class Organization(Base):
     updated_at: Mapped[datetime] = mapped_column(DateTime)
 
 
-class UserOrganizationMapping(Base):
-    __tablename__ = "user_organization_mapping"
+class ProjectOrganizationOwnership(Base):
+    __tablename__ = "project_organization_ownership"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[uuid_pkg.UUID] = mapped_column(Uuid)
+    project_id: Mapped[int] = mapped_column(Integer)
     organization_id: Mapped[int] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class Project(Base):
+    __tablename__ = "project"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    slug: Mapped[str] = mapped_column(String(65))
+    display_name: Mapped[str] = mapped_column(String(65))
+    directory_visibility: Mapped[DirectoryVisibility] = mapped_column(
+        SaEnum(DirectoryVisibility, values_callable=_enum_values, native_enum=False),
+    )
+    auto_provisioned_for_organization_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    updated_at: Mapped[datetime] = mapped_column(DateTime)
 
 
 class User(Base):
@@ -360,6 +383,7 @@ class User(Base):
     id: Mapped[uuid_pkg.UUID] = mapped_column(Uuid, primary_key=True)
     polis_participant_id: Mapped[int] = mapped_column(Integer)
     username: Mapped[str] = mapped_column(String(20))
+    first_name: Mapped[str] = mapped_column(String(65))
     is_site_moderator: Mapped[bool] = mapped_column(Boolean, server_default="false")
     is_site_org_admin: Mapped[bool] = mapped_column(Boolean, server_default="false")
     is_imported: Mapped[bool] = mapped_column(Boolean, server_default="false")

--- a/services/import-worker/src/import_worker/importer.py
+++ b/services/import-worker/src/import_worker/importer.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol
@@ -26,9 +25,7 @@ from import_worker.generated_models import (
     OpinionContent,
     OpinionGroupSpec,
     OpinionModeration,
-    Organization,
     User,
-    UserOrganizationMapping,
     Vote,
     VoteContent,
 )
@@ -43,6 +40,7 @@ from import_worker.import_models import ImportPolisResults
 from import_worker.polis_url import extract_polis_id_from_url
 
 if TYPE_CHECKING:
+    import uuid
     from collections.abc import Iterable
 
     from sqlalchemy.orm import Session
@@ -198,30 +196,6 @@ def _timestamp_from_polis(value: int | float | None) -> datetime | None:
     return datetime.fromtimestamp(value / 1000, UTC).replace(tzinfo=None)
 
 
-def _get_organization_id(
-    session: Session,
-    *,
-    organization_name: str | None,
-    user_id: uuid.UUID,
-) -> int | None:
-    if organization_name is None or organization_name == "":
-        return None
-
-    row = session.execute(
-        select(Organization.id)
-        .join(UserOrganizationMapping, UserOrganizationMapping.organization_id == Organization.id)
-        .where(
-            and_(
-                Organization.name == organization_name,
-                UserOrganizationMapping.user_id == user_id,
-            ),
-        ),
-    ).first()
-    if row is None:
-        raise ValueError(f"User {user_id} is not part of organization {organization_name}")
-    return row.id
-
-
 def _build_imported_polis_conversation(request: ImportRequest) -> tuple[ImportPolisResults, str]:
     if request.type == "csv":
         return build_import_from_csv(request.files.model_dump(by_alias=True)), "csv"
@@ -278,12 +252,6 @@ def _create_conversation(
     imported: ImportPolisResults,
     polis_url_type: str,
 ) -> ConversationIds:
-    author_id = uuid.UUID(request.author_id)
-    organization_id = _get_organization_id(
-        session,
-        organization_name=request.form_data.post_as_organization,
-        user_id=author_id,
-    )
     conversation_url, report_url = _conversation_urls(
         request=request,
         imported=imported,
@@ -307,9 +275,8 @@ def _create_conversation(
     conversation_row = session.execute(
         sqlalchemy_insert(Conversation)
         .values(
-            author_id=author_id,
             slug_id=conversation_slug_id,
-            organization_id=organization_id,
+            project_id=request.project_id,
             is_indexed=request.form_data.is_indexed,
             participation_mode=request.form_data.participation_mode.value,
             conversation_type="polis",
@@ -350,14 +317,6 @@ def _create_conversation(
         .where(Conversation.id == conversation_id)
         .values(current_content_id=conversation_content_id),
     )
-    session.execute(
-        update(User)
-        .where(User.id == author_id)
-        .values(
-            active_conversation_count=User.active_conversation_count + 1,
-            total_conversation_count=User.total_conversation_count + 1,
-        ),
-    )
     session.commit()
     return ConversationIds(
         conversation_slug_id=conversation_slug_id,
@@ -387,6 +346,7 @@ def _insert_imported_users(
             {
                 "id": user_id_per_participant_id[participant_id],
                 "username": f"ext_{conversation_slug_id}_{participant_id}",
+                "first_name": f"ext_{conversation_slug_id}_{participant_id}",
                 "is_imported": True,
             }
             for participant_id in participant_ids
@@ -900,9 +860,7 @@ def _delete_imported_conversation(
     conversation_id: int,
 ) -> None:
     conversation_row = session.execute(
-        select(Conversation.author_id, Conversation.current_content_id).where(
-            Conversation.id == conversation_id,
-        ),
+        select(Conversation.current_content_id).where(Conversation.id == conversation_id),
     ).first()
     if conversation_row is None or conversation_row.current_content_id is None:
         return
@@ -910,11 +868,6 @@ def _delete_imported_conversation(
         update(Conversation)
         .where(Conversation.id == conversation_id)
         .values(current_content_id=None),
-    )
-    session.execute(
-        update(User)
-        .where(User.id == conversation_row.author_id)
-        .values(active_conversation_count=User.active_conversation_count - 1),
     )
     session.execute(
         update(Opinion)
@@ -949,20 +902,28 @@ def _create_import_notification(
     return notification_slug_id, notification_row.id
 
 
-def _get_import_record(session: Session, *, import_slug_id: str) -> tuple[int, uuid.UUID]:
+def _get_import_user_id(session: Session, *, import_slug_id: str) -> uuid.UUID:
     row = session.execute(
-        select(ConversationImport.id, ConversationImport.user_id).where(
+        select(ConversationImport.user_id).where(
             ConversationImport.slug_id == import_slug_id,
         ),
     ).first()
     if row is None:
         raise RuntimeError(f"Import record not found for {import_slug_id}")
-    return row.id, row.user_id
+    return row.user_id
 
 
 def process_import_request(session: Session, *, request: ImportRequest) -> ImportProcessResult:
     conversation_id: int | None = None
     try:
+        import_user_id = _get_import_user_id(session, import_slug_id=request.import_slug_id)
+        if str(import_user_id) != request.actor_user_id:
+            raise RuntimeError(
+                f"Import actor mismatch for {request.import_slug_id}: "
+                f"payload actor {request.actor_user_id} does not match "
+                f"import owner {import_user_id}",
+            )
+
         imported, polis_url_type = _build_imported_polis_conversation(request)
         conversation_ids = _create_conversation(
             session,
@@ -995,7 +956,6 @@ def process_import_request(session: Session, *, request: ImportRequest) -> Impor
             participant_data=participant_data,
         )
 
-        _import_id, _user_id = _get_import_record(session, import_slug_id=request.import_slug_id)
         session.execute(
             update(ConversationImport)
             .where(ConversationImport.slug_id == request.import_slug_id)

--- a/services/scoring-worker/src/scoring_worker/generated_models.py
+++ b/services/scoring-worker/src/scoring_worker/generated_models.py
@@ -50,6 +50,11 @@ class MaxdiffLifecycleStatus(StrEnum):
     canceled = "canceled"
 
 
+class DirectoryVisibility(StrEnum):
+    listed = "listed"
+    unlisted = "unlisted"
+
+
 class SurveyQuestionType(StrEnum):
     choice = "choice"
     free_text = "free_text"
@@ -66,8 +71,7 @@ class Conversation(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     slug_id: Mapped[str] = mapped_column(String(8))
-    author_id: Mapped[uuid_pkg.UUID] = mapped_column(Uuid)
-    organization_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    project_id: Mapped[int] = mapped_column(Integer)
     current_content_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     current_ranking_score_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     is_indexed: Mapped[bool] = mapped_column(Boolean, server_default="true")
@@ -158,6 +162,29 @@ class MaxdiffUserEntityScore(Base):
     score: Mapped[float] = mapped_column(Float)
     uncertainty_left: Mapped[float] = mapped_column(Float)
     uncertainty_right: Mapped[float] = mapped_column(Float)
+
+
+class ProjectOrganizationOwnership(Base):
+    __tablename__ = "project_organization_ownership"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    project_id: Mapped[int] = mapped_column(Integer)
+    organization_id: Mapped[int] = mapped_column(Integer)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class Project(Base):
+    __tablename__ = "project"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    slug: Mapped[str] = mapped_column(String(65))
+    display_name: Mapped[str] = mapped_column(String(65))
+    directory_visibility: Mapped[DirectoryVisibility] = mapped_column(
+        SaEnum(DirectoryVisibility, values_callable=_enum_values, native_enum=False),
+    )
+    auto_provisioned_for_organization_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    updated_at: Mapped[datetime] = mapped_column(DateTime)
 
 
 class RankingScoreEntity(Base):
@@ -309,6 +336,7 @@ class User(Base):
     id: Mapped[uuid_pkg.UUID] = mapped_column(Uuid, primary_key=True)
     polis_participant_id: Mapped[int] = mapped_column(Integer)
     username: Mapped[str] = mapped_column(String(20))
+    first_name: Mapped[str] = mapped_column(String(65))
     is_site_moderator: Mapped[bool] = mapped_column(Boolean, server_default="false")
     is_site_org_admin: Mapped[bool] = mapped_column(Boolean, server_default="false")
     is_imported: Mapped[bool] = mapped_column(Boolean, server_default="false")

--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/db.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/db.py
@@ -44,6 +44,7 @@ from agora_analysis_worker_shared.generated_models import (
     OpinionModeration,
     OpinionModerationAction,
     PremiumFeatureEntitlement,
+    ProjectOrganizationOwnership,
     RealtimeEventOutbox,
     SurveyAggregateOption,
     SurveyAggregateQuestion,
@@ -1642,51 +1643,17 @@ def _fetch_premium_analysis_conversation_ids(
     if not conversation_ids:
         return set()
 
-    conversation_rows = session.execute(
-        select(Conversation.id, Conversation.author_id, Conversation.organization_id).where(
-            Conversation.id.in_(sorted(set(conversation_ids)))
+    rows = session.execute(
+        select(Conversation.id)
+        .join(
+            ProjectOrganizationOwnership,
+            Conversation.project_id == ProjectOrganizationOwnership.project_id,
         )
-    ).all()
-    if not conversation_rows:
-        return set()
-
-    author_ids = sorted({row.author_id for row in conversation_rows})
-    organization_ids = sorted(
-        {row.organization_id for row in conversation_rows if row.organization_id is not None}
-    )
-    author_entitlement_filter: ColumnElement[bool] | None = None
-    if author_ids:
-        author_entitlement_filter = and_(
-            PremiumFeatureEntitlement.user_id.in_(author_ids),
-            PremiumFeatureEntitlement.organization_id.is_(None),
-        )
-    organization_entitlement_filter: ColumnElement[bool] | None = None
-    if organization_ids:
-        organization_entitlement_filter = and_(
-            PremiumFeatureEntitlement.organization_id.in_(organization_ids),
-            PremiumFeatureEntitlement.user_id.is_(None),
-        )
-
-    subject_entitlement_filter: ColumnElement[bool] | None
-    if author_entitlement_filter is not None and organization_entitlement_filter is not None:
-        subject_entitlement_filter = or_(
-            author_entitlement_filter,
-            organization_entitlement_filter,
-        )
-    elif author_entitlement_filter is not None:
-        subject_entitlement_filter = author_entitlement_filter
-    else:
-        subject_entitlement_filter = organization_entitlement_filter
-
-    if subject_entitlement_filter is None:
-        return set()
-
-    entitlement_rows = session.execute(
-        select(
-            PremiumFeatureEntitlement.user_id,
-            PremiumFeatureEntitlement.organization_id,
-        ).where(
+        .join(
+            PremiumFeatureEntitlement,
             and_(
+                PremiumFeatureEntitlement.organization_id
+                == ProjectOrganizationOwnership.organization_id,
                 PremiumFeatureEntitlement.feature == PREMIUM_ANALYSIS_FEATURE,
                 PremiumFeatureEntitlement.starts_at <= now,
                 PremiumFeatureEntitlement.revoked_at.is_(None),
@@ -1694,21 +1661,13 @@ def _fetch_premium_analysis_conversation_ids(
                     PremiumFeatureEntitlement.expires_at.is_(None),
                     PremiumFeatureEntitlement.expires_at > now,
                 ),
-                subject_entitlement_filter,
-            )
+            ),
         )
+        .where(Conversation.id.in_(sorted(set(conversation_ids))))
+        .distinct()
     ).all()
-    active_author_ids = {row.user_id for row in entitlement_rows if row.user_id is not None}
-    active_organization_ids = {
-        row.organization_id for row in entitlement_rows if row.organization_id is not None
-    }
 
-    return {
-        row.id
-        for row in conversation_rows
-        if row.author_id in active_author_ids
-        or (row.organization_id is not None and row.organization_id in active_organization_ids)
-    }
+    return {row.id for row in rows}
 
 
 def artifact_candidate_ids_by_pair(

--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/generated_models.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/generated_models.py
@@ -150,6 +150,11 @@ class PremiumFeature(StrEnum):
     analysis_variants = "analysis_variants"
 
 
+class DirectoryVisibility(StrEnum):
+    listed = "listed"
+    unlisted = "unlisted"
+
+
 class SurveyQuestionType(StrEnum):
     choice = "choice"
     free_text = "free_text"
@@ -292,8 +297,7 @@ class Conversation(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     slug_id: Mapped[str] = mapped_column(String(8))
-    author_id: Mapped[uuid_pkg.UUID] = mapped_column(Uuid)
-    organization_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    project_id: Mapped[int] = mapped_column(Integer)
     current_content_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     current_ranking_score_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     is_indexed: Mapped[bool] = mapped_column(Boolean, server_default="true")
@@ -677,8 +681,7 @@ class PremiumFeatureEntitlement(Base):
     __tablename__ = "premium_feature_entitlement"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    user_id: Mapped[uuid_pkg.UUID | None] = mapped_column(Uuid, nullable=True)
-    organization_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    organization_id: Mapped[int] = mapped_column(Integer)
     feature: Mapped[PremiumFeature] = mapped_column(
         SaEnum(PremiumFeature, values_callable=_enum_values, native_enum=False),
     )
@@ -688,6 +691,29 @@ class PremiumFeatureEntitlement(Base):
     admin_note: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by_user_id: Mapped[uuid_pkg.UUID | None] = mapped_column(Uuid, nullable=True)
     updated_by_user_id: Mapped[uuid_pkg.UUID | None] = mapped_column(Uuid, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    updated_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class ProjectOrganizationOwnership(Base):
+    __tablename__ = "project_organization_ownership"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    project_id: Mapped[int] = mapped_column(Integer)
+    organization_id: Mapped[int] = mapped_column(Integer)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class Project(Base):
+    __tablename__ = "project"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    slug: Mapped[str] = mapped_column(String(65))
+    display_name: Mapped[str] = mapped_column(String(65))
+    directory_visibility: Mapped[DirectoryVisibility] = mapped_column(
+        SaEnum(DirectoryVisibility, values_callable=_enum_values, native_enum=False),
+    )
+    auto_provisioned_for_organization_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)
 
@@ -888,6 +914,7 @@ class User(Base):
     id: Mapped[uuid_pkg.UUID] = mapped_column(Uuid, primary_key=True)
     polis_participant_id: Mapped[int] = mapped_column(Integer)
     username: Mapped[str] = mapped_column(String(20))
+    first_name: Mapped[str] = mapped_column(String(65))
     is_site_moderator: Mapped[bool] = mapped_column(Boolean, server_default="false")
     is_site_org_admin: Mapped[bool] = mapped_column(Boolean, server_default="false")
     is_imported: Mapped[bool] = mapped_column(Boolean, server_default="false")

--- a/services/shared-backend/scripts/rsync_and_sed.sh
+++ b/services/shared-backend/scripts/rsync_and_sed.sh
@@ -31,7 +31,7 @@ for service in "${TS_BACKEND_SERVICES[@]}"; do
     echo "  → Syncing to $service..."
 
     # Use rsync to copy files
-    rsync -av --delete "$SHARED_BACKEND_DIR/src/" "$TARGET_DIR/"
+    rsync -av --delete --delete-excluded --exclude="*.orig" "$SHARED_BACKEND_DIR/src/" "$TARGET_DIR/"
 
     # Add warning comment to all TypeScript files
     find "$TARGET_DIR" -name "*.ts" -print0 | while read -d $'\0' file; do

--- a/services/shared-backend/src/schema.ts
+++ b/services/shared-backend/src/schema.ts
@@ -600,6 +600,36 @@ export const premiumFeatureEnum = pgEnum("premium_feature", [
     "analysis_variants",
 ]);
 
+export const directoryVisibilityEnum = pgEnum("directory_visibility", [
+    "listed",
+    "unlisted",
+]);
+
+export const organizationMembershipCapabilityEnum = pgEnum(
+    "organization_membership_capability_enum",
+    [
+        "organization_manage_members",
+        "organization_manage_profile",
+        "project_create",
+    ],
+);
+
+export const organizationMembershipAllProjectCapabilityEnum = pgEnum(
+    "organization_membership_all_project_capability_enum",
+    [
+        "project_update",
+        "project_delete",
+        "project_manage_owner_organizations",
+        "conversation_create",
+        "conversation_update",
+        "conversation_delete",
+        "conversation_view_private_results",
+        "conversation_export_owner_data",
+        "conversation_moderate",
+        "conversation_manage_integrations",
+    ],
+);
+
 export const surveyQuestionTypeEnum = pgEnum("survey_question_type", [
     "choice",
     "free_text",
@@ -801,6 +831,8 @@ export const userTable = pgTable(
         username: varchar("username", { length: MAX_LENGTH_USERNAME })
             .notNull()
             .unique(),
+        firstName: varchar("first_name", { length: MAX_LENGTH_NAME_CREATOR })
+            .notNull(),
         isSiteModerator: boolean("is_site_moderator").notNull().default(false),
         isSiteOrgAdmin: boolean("is_site_org_admin").notNull().default(false),
         isImported: boolean("is_imported").notNull().default(false),
@@ -851,6 +883,38 @@ export const userOrganizationMappingTable = pgTable(
             t.userId,
             t.organizationId,
         ),
+    ],
+);
+
+export const organizationMembershipTable = pgTable(
+    "organization_membership",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        userId: uuid("user_id")
+            .references(() => userTable.id)
+            .notNull(),
+        organizationId: integer("organization_id")
+            .references(() => organizationTable.id)
+            .notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+        updatedAt: timestamp("updated_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (t) => [
+        unique("organization_membership_user_organization_unique").on(
+            t.userId,
+            t.organizationId,
+        ),
+        index("organization_membership_organization_idx").on(t.organizationId),
     ],
 );
 
@@ -988,6 +1052,15 @@ export const organizationTable = pgTable("organization", {
     name: varchar("name", { length: MAX_LENGTH_NAME_CREATOR })
         .notNull()
         .unique(),
+    slug: varchar("slug", { length: MAX_LENGTH_NAME_CREATOR })
+        .notNull()
+        .unique(),
+    displayName: varchar("display_name", { length: MAX_LENGTH_NAME_CREATOR })
+        .notNull(),
+    directoryVisibility: directoryVisibilityEnum("directory_visibility").notNull(),
+    autoProvisionedForUserId: uuid("auto_provisioned_for_user_id")
+        .references(() => userTable.id)
+        .unique(),
     imagePath: text("image_path").notNull(),
     isFullImagePath: boolean("is_full_image_path").notNull(),
     websiteUrl: text("website_url").unique(),
@@ -1008,7 +1081,113 @@ export const organizationTable = pgTable("organization", {
         .notNull(),
 });
 
-/** @service api, shared-analysis-worker */
+/** @service scoring-worker, api, math-updater, import-worker */
+export const projectTable = pgTable("project", {
+    id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+    slug: varchar("slug", { length: MAX_LENGTH_NAME_CREATOR })
+        .notNull()
+        .unique(),
+    displayName: varchar("display_name", { length: MAX_LENGTH_NAME_CREATOR })
+        .notNull(),
+    directoryVisibility: directoryVisibilityEnum("directory_visibility").notNull(),
+    autoProvisionedForOrganizationId: integer(
+        "auto_provisioned_for_organization_id",
+    )
+        .references(() => organizationTable.id)
+        .unique(),
+    createdAt: timestamp("created_at", {
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+    updatedAt: timestamp("updated_at", {
+        mode: "date",
+        precision: 0,
+    })
+        .defaultNow()
+        .notNull(),
+});
+
+/** @service scoring-worker, api, math-updater, import-worker */
+export const projectOrganizationOwnershipTable = pgTable(
+    "project_organization_ownership",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        projectId: integer("project_id")
+            .references(() => projectTable.id)
+            .notNull(),
+        organizationId: integer("organization_id")
+            .references(() => organizationTable.id)
+            .notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (table) => [
+        unique("project_organization_ownership_project_org_unique").on(
+            table.projectId,
+            table.organizationId,
+        ),
+        index("project_organization_ownership_organization_idx").on(
+            table.organizationId,
+        ),
+    ],
+);
+
+/** @service api */
+export const organizationMembershipCapabilityTable = pgTable(
+    "organization_membership_capability",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        organizationMembershipId: integer("organization_membership_id")
+            .references(() => organizationMembershipTable.id)
+            .notNull(),
+        capability: organizationMembershipCapabilityEnum("capability").notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (table) => [
+        unique("organization_membership_capability_unique").on(
+            table.organizationMembershipId,
+            table.capability,
+        ),
+    ],
+);
+
+/** @service api */
+export const organizationMembershipAllProjectCapabilityTable = pgTable(
+    "organization_membership_all_project_capability",
+    {
+        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
+        organizationMembershipId: integer("organization_membership_id")
+            .references(() => organizationMembershipTable.id)
+            .notNull(),
+        capability:
+            organizationMembershipAllProjectCapabilityEnum("capability").notNull(),
+        createdAt: timestamp("created_at", {
+            mode: "date",
+            precision: 0,
+        })
+            .defaultNow()
+            .notNull(),
+    },
+    (table) => [
+        unique("organization_membership_all_project_capability_unique").on(
+            table.organizationMembershipId,
+            table.capability,
+        ),
+    ],
+);
+
+/** @service api, math-updater */
 export const premiumFeatureEntitlementTable = pgTable(
     "premium_feature_entitlement",
     {
@@ -1449,6 +1628,9 @@ export const conversationTable = pgTable(
         organizationId: integer("organization_id").references(
             () => organizationTable.id,
         ),
+        projectId: integer("project_id")
+            .references(() => projectTable.id)
+            .notNull(),
         currentContentId: integer("current_content_id")
             .references((): AnyPgColumn => conversationContentTable.id)
             .unique(), // null if conversation was deleted
@@ -1531,6 +1713,16 @@ export const conversationTable = pgTable(
             .using(
                 "btree",
                 table.organizationId,
+                table.isImporting,
+                sql`${table.createdAt} DESC`,
+                sql`${table.id} DESC`,
+            )
+            .where(isNotNull(table.currentContentId)),
+        index("conversation_project_id_idx").on(table.projectId),
+        index("conversation_project_timeline_idx")
+            .using(
+                "btree",
+                table.projectId,
                 table.isImporting,
                 sql`${table.createdAt} DESC`,
                 sql`${table.id} DESC`,

--- a/services/shared-backend/src/schema.ts
+++ b/services/shared-backend/src/schema.ts
@@ -860,32 +860,6 @@ export const userTable = pgTable(
     },
 );
 
-/** @service import-worker */
-export const userOrganizationMappingTable = pgTable(
-    "user_organization_mapping",
-    {
-        id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-        userId: uuid("user_id")
-            .references(() => userTable.id)
-            .notNull(),
-        organizationId: integer("organization_id")
-            .references(() => organizationTable.id)
-            .notNull(),
-        createdAt: timestamp("created_at", {
-            mode: "date",
-            precision: 0,
-        })
-            .defaultNow()
-            .notNull(),
-    },
-    (t) => [
-        unique("unique_user_orgaization_mapping").on(
-            t.userId,
-            t.organizationId,
-        ),
-    ],
-);
-
 export const organizationMembershipTable = pgTable(
     "organization_membership",
     {
@@ -1049,9 +1023,6 @@ export const userDisplayLanguageTable = pgTable(
 /** @service import-worker */
 export const organizationTable = pgTable("organization", {
     id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-    name: varchar("name", { length: MAX_LENGTH_NAME_CREATOR })
-        .notNull()
-        .unique(),
     slug: varchar("slug", { length: MAX_LENGTH_NAME_CREATOR })
         .notNull()
         .unique(),
@@ -1192,10 +1163,9 @@ export const premiumFeatureEntitlementTable = pgTable(
     "premium_feature_entitlement",
     {
         id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
-        userId: uuid("user_id").references(() => userTable.id),
         organizationId: integer("organization_id").references(
             () => organizationTable.id,
-        ),
+        ).notNull(),
         feature: premiumFeatureEnum("feature").notNull(),
         startsAt: timestamp("starts_at", {
             mode: "date",
@@ -1230,17 +1200,6 @@ export const premiumFeatureEntitlementTable = pgTable(
             .notNull(),
     },
     (table) => [
-        check(
-            "premium_feature_entitlement_single_subject_check",
-            sqlOr(
-                sqlAnd(isNotNull(table.userId), isNull(table.organizationId)),
-                sqlAnd(isNull(table.userId), isNotNull(table.organizationId)),
-            ),
-        ),
-        index("premium_feature_entitlement_user_idx").on(
-            table.userId,
-            table.feature,
-        ),
         index("premium_feature_entitlement_org_idx").on(
             table.organizationId,
             table.feature,
@@ -1622,12 +1581,6 @@ export const conversationTable = pgTable(
     {
         id: integer("id").primaryKey().generatedAlwaysAsIdentity(),
         slugId: varchar("slug_id", { length: 8 }).notNull().unique(), // used for permanent URL
-        authorId: uuid("author_id") // "postAs"
-            .notNull()
-            .references(() => userTable.id), // the author of the conversation
-        organizationId: integer("organization_id").references(
-            () => organizationTable.id,
-        ),
         projectId: integer("project_id")
             .references(() => projectTable.id)
             .notNull(),
@@ -1700,24 +1653,6 @@ export const conversationTable = pgTable(
             table.isImporting,
             table.conversationType,
         ),
-        // Composite for user conversation timeline: filters authorId + isImporting, sorts by createdAt/id
-        index("conversation_author_timeline_idx").using(
-            "btree",
-            table.authorId,
-            table.isImporting,
-            sql`${table.createdAt} DESC`,
-            sql`${table.id} DESC`,
-        ),
-        // Composite for organization conversation timeline: filters organizationId + isImporting, sorts by createdAt/id
-        index("conversation_organization_timeline_idx")
-            .using(
-                "btree",
-                table.organizationId,
-                table.isImporting,
-                sql`${table.createdAt} DESC`,
-                sql`${table.id} DESC`,
-            )
-            .where(isNotNull(table.currentContentId)),
         index("conversation_project_id_idx").on(table.projectId),
         index("conversation_project_timeline_idx")
             .using(


### PR DESCRIPTION
## Summary
- replace direct conversation ownership with project-based ownership through organization memberships and capabilities
- add migrations/backfills for projects, memberships, capabilities, organization-owned entitlements, and conversation project IDs
- update API authorization, premium access, notifications, exports, imports, and worker ownership logic
- update import queue payloads to carry authorized project IDs and add pure project access authorization tests

## Tests
- cd services/api && pnpm typecheck
- cd services/api && pnpm lint
- cd services/api && pnpm exec vitest run src/service/projectAccessLogic.test.ts
- cd services/import-worker && uv run --extra dev ruff check
- cd services/import-worker && uv run --extra dev basedpyright
- cd services/import-worker && uv run --extra dev pytest -v
- cd services/python-worker-shared && uv run --extra dev ruff check
- cd services/python-worker-shared && uv run --extra dev basedpyright
- cd services/scoring-worker && make lint
- cd services/scoring-worker && make typecheck

## Not run
- full API integration test suite; the new authorization logic is covered by pure unit tests and should not require a DB-backed test for this pass

## Deploy
- api
- import-worker
- math-updater
- scoring-worker
- agora