### PR TITLE
fix(workers): preserve partial AI outputs

### DIFF
--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/ai_description_work.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/ai_description_work.py
@@ -60,6 +60,7 @@ from agora_analysis_worker_shared.generated_models import (
 from agora_analysis_worker_shared.generated_shared_types import (
     SUPPORTED_TRANSLATION_TARGET_LANGUAGE_CODES,
 )
+from agora_analysis_worker_shared.provider_errors import is_provider_timeout_error
 
 log = logging.getLogger(__name__)
 POSTGRES_INSERT_BIND_PARAM_LIMIT = 60_000
@@ -3146,7 +3147,7 @@ def process_lineage_description_work_items_batch(
             groups=[request.conversation.groups[0] for request in requests],
             analysis_snapshot_id=first_request.conversation.analysis_snapshot_id,
         )
-        generated = _generate_label_summaries_with_partial_retry(
+        generated = generate_label_summaries_with_partial_retry(
             generate_descriptions=generate_descriptions,
             conversation=conversation,
             attempts=2,
@@ -3245,7 +3246,7 @@ def process_lineage_description_work_items_batch(
     )
 
 
-def _generate_label_summaries_with_partial_retry(
+def generate_label_summaries_with_partial_retry(
     *,
     generate_descriptions: DescriptionGenerator,
     conversation: ConversationDescriptionInput,
@@ -3255,7 +3256,7 @@ def _generate_label_summaries_with_partial_retry(
     generated_mode = "strict"
     group_by_key = {group.group_key: group for group in conversation.groups}
     remaining_group_keys = set(group_by_key)
-    for _attempt in range(attempts):
+    for attempt in range(1, attempts + 1):
         if not remaining_group_keys:
             break
         attempt_conversation = ConversationDescriptionInput(
@@ -3264,7 +3265,30 @@ def _generate_label_summaries_with_partial_retry(
             groups=[group_by_key[group_key] for group_key in sorted(remaining_group_keys)],
             analysis_snapshot_id=conversation.analysis_snapshot_id,
         )
-        generated = generate_descriptions(attempt_conversation)
+        try:
+            generated = generate_descriptions(attempt_conversation)
+        except Exception as error:
+            if is_provider_timeout_error(error):
+                log.warning(
+                    "[AiDescriptionWorkDB] AI label/summary partial retry attempt %d/%d timed out",
+                    attempt,
+                    attempts,
+                    exc_info=True,
+                )
+                if generated_clusters:
+                    break
+                raise
+            log.warning(
+                "[AiDescriptionWorkDB] AI label/summary partial retry attempt %d/%d failed",
+                attempt,
+                attempts,
+                exc_info=True,
+            )
+            if attempt == attempts:
+                if generated_clusters:
+                    break
+                raise
+            continue
         generated_mode = "loose" if generated.mode == "loose" else generated_mode
         for group_key in sorted(remaining_group_keys):
             label_summary = generated.clusters.get(group_key)

--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/bedrock_label_summary.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/bedrock_label_summary.py
@@ -119,7 +119,6 @@ def generate_label_summaries_with_bedrock(
     parsed = parse_bedrock_label_summary_text(
         model_response_text,
         expected_group_keys={group.group_key for group in conversation.groups},
-        allow_partial=True,
     )
     log.info(
         "[DescriptionGenerator] Bedrock label/summary parsed "
@@ -159,7 +158,6 @@ def parse_bedrock_label_summary_response(
     response: object,
     *,
     expected_group_keys: set[str] | None = None,
-    allow_partial: bool = False,
 ) -> ParsedLabelSummaryOutput:
     model_response_text = extract_text_content_from_response(response)
     if model_response_text is None:
@@ -168,7 +166,6 @@ def parse_bedrock_label_summary_response(
     return parse_bedrock_label_summary_text(
         model_response_text,
         expected_group_keys=expected_group_keys,
-        allow_partial=allow_partial,
     )
 
 
@@ -176,7 +173,6 @@ def parse_bedrock_label_summary_text(
     model_response_text: str,
     *,
     expected_group_keys: set[str] | None = None,
-    allow_partial: bool = False,
 ) -> ParsedLabelSummaryOutput:
     last_error: BedrockLabelSummaryError | None = None
     for model_response in iter_llm_output_json_candidates(model_response_text):
@@ -185,7 +181,6 @@ def parse_bedrock_label_summary_text(
                 return parse_label_summary_output_for_groups(
                     model_response,
                     expected_group_keys=expected_group_keys,
-                    allow_partial=allow_partial,
                 )
             return parse_label_summary_output(model_response)
         except BedrockLabelSummaryError as error:
@@ -261,7 +256,6 @@ def parse_label_summary_output_for_groups(
     model_response: dict[str, object],
     *,
     expected_group_keys: set[str],
-    allow_partial: bool = False,
 ) -> ParsedLabelSummaryOutput:
     unexpected_keys = expected_group_keys - CLUSTER_KEYS
     if unexpected_keys:
@@ -277,26 +271,17 @@ def parse_label_summary_output_for_groups(
     for group_key in sorted(expected_group_keys):
         raw_cluster = clusters.get(group_key)
         if not _is_string_key_mapping(raw_cluster):
-            if allow_partial:
-                continue
-            msg = f"missing generated description for group {group_key}"
-            raise BedrockLabelSummaryError(msg)
+            continue
         parsed_cluster = _parse_cluster_value(raw_cluster, strict=True)
         if parsed_cluster is None:
             parsed_cluster = _parse_cluster_value(raw_cluster, strict=False)
             used_loose_mode = parsed_cluster is not None
         if parsed_cluster is None:
-            if allow_partial:
-                continue
-            msg = f"invalid generated description for group {group_key}"
-            raise BedrockLabelSummaryError(msg)
+            continue
         parsed_clusters[group_key] = parsed_cluster
 
     if not parsed_clusters:
         msg = "AI label/summary output did not include any valid expected clusters"
-        raise BedrockLabelSummaryError(msg)
-    if not allow_partial and set(parsed_clusters) != expected_group_keys:
-        msg = "AI label/summary output did not include exactly the expected clusters"
         raise BedrockLabelSummaryError(msg)
     return ParsedLabelSummaryOutput(
         mode="loose" if used_loose_mode else "strict",

--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/description_services.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/description_services.py
@@ -4,10 +4,6 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
-from google.api_core.exceptions import DeadlineExceeded
-from google.api_core.exceptions import RetryError as GoogleRetryError
-
 from agora_analysis_worker_shared.bedrock_label_summary import (
     BedrockLabelSummaryConfig,
     BedrockLabelSummaryError,
@@ -20,6 +16,7 @@ from agora_analysis_worker_shared.description_translation import (
     generate_description_translations_with_bedrock,
     initialize_google_translation_service,
 )
+from agora_analysis_worker_shared.provider_errors import is_provider_timeout_error
 from agora_analysis_worker_shared.simulation_providers import (
     generate_simulated_description_translations,
     generate_simulated_label_summaries,
@@ -113,51 +110,20 @@ def build_description_translator(settings: Settings) -> DescriptionTranslatorBun
 
     if bedrock_config is not None and google_service is not None:
 
-        def translate_with_bedrock_then_google(
+        def translate(
             descriptions: list[DescriptionForTranslation],
             target_language_codes: list[str],
         ) -> list[DescriptionTranslation]:
-            try:
-                bedrock_translations = _generate_bedrock_translations_with_partial_retries(
-                    config=bedrock_config,
-                    descriptions=descriptions,
-                    target_language_codes=target_language_codes,
-                    attempts=2,
-                )
-                return fill_missing_translations_with_google(
-                    google_service=google_service,
-                    descriptions=descriptions,
-                    target_language_codes=target_language_codes,
-                    translations=bedrock_translations,
-                )
-            except Exception as error:
-                if _is_timeout_error(error):
-                    raise
-                log.warning(
-                    "[DescriptionTranslator] Bedrock translation exhausted; falling back to Google",
-                    exc_info=True,
-                )
-                translations = _retry_translation_provider(
-                    provider_name="Google",
-                    attempts=2,
-                    call=lambda: _generate_google_translations(
-                        google_service=google_service,
-                        descriptions=descriptions,
-                        target_language_codes=target_language_codes,
-                    ),
-                )
-                log.info(
-                    "[DescriptionTranslator] Google fallback translation succeeded "
-                    "description_count=%d locale_count=%d output_count=%d",
-                    len(descriptions),
-                    len(target_language_codes),
-                    len(translations),
-                )
-                return translations
+            return translate_with_bedrock_then_google(
+                bedrock_config=bedrock_config,
+                google_service=google_service,
+                descriptions=descriptions,
+                target_language_codes=target_language_codes,
+            )
 
         return DescriptionTranslatorBundle(
             mode="bedrock_with_google_fallback",
-            translate=translate_with_bedrock_then_google,
+            translate=translate,
         )
 
     if bedrock_config is not None:
@@ -166,7 +132,7 @@ def build_description_translator(settings: Settings) -> DescriptionTranslatorBun
             descriptions: list[DescriptionForTranslation],
             target_language_codes: list[str],
         ) -> list[DescriptionTranslation]:
-            return _generate_bedrock_translations_with_partial_retries(
+            return generate_bedrock_translations_with_partial_retries(
                 config=bedrock_config,
                 descriptions=descriptions,
                 target_language_codes=target_language_codes,
@@ -235,7 +201,45 @@ def _generate_google_translations(
     )
 
 
-def _generate_bedrock_translations_with_partial_retries(
+def translate_with_bedrock_then_google(
+    *,
+    bedrock_config: BedrockTranslationConfig,
+    google_service: GoogleTranslationService,
+    descriptions: list[DescriptionForTranslation],
+    target_language_codes: list[str],
+) -> list[DescriptionTranslation]:
+    bedrock_translations: list[DescriptionTranslation] = []
+    try:
+        bedrock_translations = generate_bedrock_translations_with_partial_retries(
+            config=bedrock_config,
+            descriptions=descriptions,
+            target_language_codes=target_language_codes,
+            attempts=2,
+        )
+    except Exception:
+        log.warning(
+            "[DescriptionTranslator] Bedrock translation unavailable; falling back to Google",
+            exc_info=True,
+        )
+
+    translations = fill_missing_translations_with_google(
+        google_service=google_service,
+        descriptions=descriptions,
+        target_language_codes=target_language_codes,
+        translations=bedrock_translations,
+    )
+    if len(translations) > len(bedrock_translations):
+        log.info(
+            "[DescriptionTranslator] Google fallback translation succeeded "
+            "description_count=%d locale_count=%d output_count=%d",
+            len(descriptions),
+            len(target_language_codes),
+            len(translations),
+        )
+    return translations
+
+
+def generate_bedrock_translations_with_partial_retries(
     *,
     config: BedrockTranslationConfig,
     descriptions: list[DescriptionForTranslation],
@@ -268,13 +272,15 @@ def _generate_bedrock_translations_with_partial_retries(
             )
         except Exception as error:
             last_error = error
-            if _is_timeout_error(error):
+            if is_provider_timeout_error(error):
                 log.warning(
                     "[DescriptionTranslator] Bedrock translation attempt %d/%d timed out",
                     attempt,
                     attempts,
                     exc_info=True,
                 )
+                if translations:
+                    return translations
                 raise
             log.warning(
                 "[DescriptionTranslator] Bedrock translation attempt %d/%d failed",
@@ -314,17 +320,31 @@ def fill_missing_translations_with_google(
             target_language_code,
             [description.description_id for description in missing_descriptions],
         )
-        google_translations = _retry_translation_provider(
-            provider_name="Google",
-            attempts=2,
-            call=lambda descriptions_for_locale=missing_descriptions, locale=target_language_code: (
-                _generate_google_translations(
-                    google_service=google_service,
-                    descriptions=descriptions_for_locale,
-                    target_language_codes=[locale],
+        def generate_missing_google_translations(
+            descriptions_for_locale: list[DescriptionForTranslation] = missing_descriptions,
+            locale: str = target_language_code,
+        ) -> list[DescriptionTranslation]:
+            return _generate_google_translations(
+                google_service=google_service,
+                descriptions=descriptions_for_locale,
+                target_language_codes=[locale],
+            )
+
+        try:
+            google_translations = _retry_translation_provider(
+                provider_name="Google",
+                attempts=2,
+                call=generate_missing_google_translations,
+            )
+        except Exception:
+            if translations or missing_translations:
+                log.warning(
+                    "[DescriptionTranslator] Google fallback failed after partial translation; "
+                    "returning partial output",
+                    exc_info=True,
                 )
-            ),
-        )
+                return [*translations, *missing_translations]
+            raise
         missing_translations.extend(google_translations)
         translation_keys.update(
             (translation.description_id, translation.locale)
@@ -382,7 +402,7 @@ def _retry_translation_provider(
             return call()
         except Exception as error:
             last_error = error
-            if _is_timeout_error(error):
+            if is_provider_timeout_error(error):
                 log.warning(
                     "[DescriptionTranslator] %s translation attempt %d/%d timed out",
                     provider_name,
@@ -414,6 +434,15 @@ def _retry_description_provider(
             return call()
         except Exception as error:
             last_error = error
+            if is_provider_timeout_error(error):
+                log.warning(
+                    "[DescriptionGenerator] %s description attempt %d/%d timed out",
+                    provider_name,
+                    attempt,
+                    attempts,
+                    exc_info=True,
+                )
+                raise
             log.warning(
                 "[DescriptionGenerator] %s description attempt %d/%d failed",
                 provider_name,
@@ -423,32 +452,3 @@ def _retry_description_provider(
             )
     msg = f"{provider_name} description generation failed after {attempts} attempt(s)"
     raise BedrockLabelSummaryError(msg) from last_error
-
-
-def _is_timeout_error(error: BaseException) -> bool:
-    seen: set[int] = set()
-    stack: list[BaseException] = [error]
-    while stack:
-        current = stack.pop()
-        current_id = id(current)
-        if current_id in seen:
-            continue
-        seen.add(current_id)
-
-        if isinstance(
-            current,
-            TimeoutError | ConnectTimeoutError | DeadlineExceeded | ReadTimeoutError,
-        ):
-            return True
-
-        if isinstance(current, GoogleRetryError):
-            cause = current.cause
-            if isinstance(cause, BaseException):
-                stack.append(cause)
-
-        if current.__cause__ is not None:
-            stack.append(current.__cause__)
-        if current.__context__ is not None:
-            stack.append(current.__context__)
-
-    return False

--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/description_translation.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/description_translation.py
@@ -298,7 +298,6 @@ def generate_description_translations_with_bedrock(
             model_response_text,
             expected_description_ids={description.description_id for description in descriptions},
             expected_locale=target_language_code,
-            allow_partial=True,
         )
         log.info(
             "[DescriptionTranslator] Bedrock translation parsed "
@@ -345,7 +344,6 @@ def parse_bedrock_translation_response(
     *,
     expected_description_ids: set[int] | None = None,
     expected_locale: str | None = None,
-    allow_partial: bool = False,
 ) -> list[DescriptionTranslation]:
     model_response_text = extract_text_content_from_response(response)
     if model_response_text is None:
@@ -355,7 +353,6 @@ def parse_bedrock_translation_response(
         model_response_text,
         expected_description_ids=expected_description_ids,
         expected_locale=expected_locale,
-        allow_partial=allow_partial,
     )
 
 
@@ -364,7 +361,6 @@ def parse_bedrock_translation_text(
     *,
     expected_description_ids: set[int] | None = None,
     expected_locale: str | None = None,
-    allow_partial: bool = False,
 ) -> list[DescriptionTranslation]:
     last_error: DescriptionTranslationError | None = None
     for model_response in iter_llm_output_json_candidates(model_response_text):
@@ -373,7 +369,6 @@ def parse_bedrock_translation_text(
                 model_response,
                 expected_description_ids=expected_description_ids,
                 expected_locale=expected_locale,
-                allow_partial=allow_partial,
             )
         except DescriptionTranslationError as error:
             last_error = error
@@ -386,7 +381,6 @@ def parse_description_translation_output(
     *,
     expected_description_ids: set[int] | None = None,
     expected_locale: str | None = None,
-    allow_partial: bool = False,
 ) -> list[DescriptionTranslation]:
     raw_translations = model_response.get("translations")
     if not _is_object_sequence(raw_translations):
@@ -404,9 +398,7 @@ def parse_description_translation_output(
                 seen_description_ids=seen_description_ids,
             )
         except DescriptionTranslationError:
-            if allow_partial:
-                continue
-            raise
+            continue
         description_id = translation.description_id
         seen_description_ids.add(description_id)
         translations.append(translation)
@@ -415,13 +407,6 @@ def parse_description_translation_output(
         msg = "Bedrock translation output did not include any valid translations"
         raise DescriptionTranslationError(msg)
 
-    if (
-        not allow_partial
-        and expected_description_ids is not None
-        and seen_description_ids != expected_description_ids
-    ):
-        msg = "Bedrock translation output did not include exactly the expected descriptions"
-        raise DescriptionTranslationError(msg)
     return translations
 
 

--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/provider_errors.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/provider_errors.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from botocore.exceptions import ConnectTimeoutError, ReadTimeoutError
+from google.api_core.exceptions import DeadlineExceeded
+from google.api_core.exceptions import RetryError as GoogleRetryError
+
+
+def is_provider_timeout_error(error: BaseException) -> bool:
+    seen: set[int] = set()
+    stack: list[BaseException] = [error]
+    while stack:
+        current = stack.pop()
+        current_id = id(current)
+        if current_id in seen:
+            continue
+        seen.add(current_id)
+
+        if isinstance(
+            current,
+            TimeoutError | ConnectTimeoutError | DeadlineExceeded | ReadTimeoutError,
+        ):
+            return True
+
+        if isinstance(current, GoogleRetryError):
+            cause = current.cause
+            if isinstance(cause, BaseException):
+                stack.append(cause)
+
+        if current.__cause__ is not None:
+            stack.append(current.__cause__)
+        if current.__context__ is not None:
+            stack.append(current.__context__)
+
+    return False

--- a/services/shared-analysis-worker/tests/test_ai_description_work.py
+++ b/services/shared-analysis-worker/tests/test_ai_description_work.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
 from uuid import uuid4
 
 import pytest
@@ -24,6 +23,7 @@ from agora_analysis_worker_shared.ai_description_work import (
     extend_ai_description_locale_work_leases,
     fetch_claimable_ai_description_work_conversation_ids,
     finalize_first_pass_ai_description_work_batch,
+    generate_label_summaries_with_partial_retry,
     lineage_description_work_demands_for_candidate_requests,
     materialize_requested_description_translation_work,
     materialize_requested_lineage_description_work,
@@ -34,6 +34,10 @@ from agora_analysis_worker_shared.ai_description_work import (
     retry_ai_description_locale_work_item,
     translation_work_demands_for_candidate_requests,
 )
+from agora_analysis_worker_shared.bedrock_label_summary import (
+    LabelSummary,
+    ParsedLabelSummaryOutput,
+)
 from agora_analysis_worker_shared.db import (
     ClaimedWorkItem,
     claim_work_items_batch,
@@ -42,7 +46,12 @@ from agora_analysis_worker_shared.db import (
     fetch_claimable_work_conversation_ids,
     recover_expired_running_work,
 )
-from agora_analysis_worker_shared.description_input import DescriptionOutputError
+from agora_analysis_worker_shared.description_input import (
+    ConversationDescriptionInput,
+    DescriptionOutputError,
+    GroupDescriptionInput,
+    RepresentativeOpinionText,
+)
 from agora_analysis_worker_shared.description_translation import (
     DescriptionForTranslation,
     DescriptionTranslation,
@@ -71,14 +80,11 @@ from agora_analysis_worker_shared.generated_models import (
     OpinionGroupVariant,
     ParticipationMode,
     RealtimeEventOutbox,
+    VoteEnumSimple,
 )
 from agora_analysis_worker_shared.generated_shared_types import (
     SUPPORTED_TRANSLATION_TARGET_LANGUAGE_CODES,
 )
-
-if TYPE_CHECKING:
-    from agora_analysis_worker_shared.bedrock_label_summary import ParsedLabelSummaryOutput
-    from agora_analysis_worker_shared.description_input import ConversationDescriptionInput
 
 NOW = datetime(2026, 5, 21, 12, 0, 0, tzinfo=UTC)
 
@@ -305,6 +311,62 @@ def _translation_claim(
         attempt_count=1,
         lease_token=lease_token,
     )
+
+
+def test_label_summary_partial_retry_stops_after_timeout() -> None:
+    calls: list[list[str]] = []
+
+    def generate_descriptions(
+        conversation: ConversationDescriptionInput,
+    ) -> ParsedLabelSummaryOutput:
+        calls.append([group.group_key for group in conversation.groups])
+        if len(calls) == 1:
+            return ParsedLabelSummaryOutput(
+                mode="strict",
+                clusters={
+                    "0": LabelSummary(
+                        reasoning="ok",
+                        label="Transitists",
+                        summary="Supports transit.",
+                    )
+                },
+            )
+        raise TimeoutError("bedrock timed out")
+
+    result = generate_label_summaries_with_partial_retry(
+        generate_descriptions=generate_descriptions,
+        conversation=ConversationDescriptionInput(
+            conversation_title="Transit funding",
+            conversation_body="How should transit be funded?",
+            groups=[
+                GroupDescriptionInput(
+                    group_key="0",
+                    representative_opinions=[
+                        RepresentativeOpinionText(
+                            opinion_id=10,
+                            stance=VoteEnumSimple.agree,
+                            content="Fund transit",
+                        )
+                    ],
+                ),
+                GroupDescriptionInput(
+                    group_key="1",
+                    representative_opinions=[
+                        RepresentativeOpinionText(
+                            opinion_id=20,
+                            stance=VoteEnumSimple.disagree,
+                            content="Raise fares",
+                        )
+                    ],
+                ),
+            ],
+            analysis_snapshot_id=30,
+        ),
+        attempts=3,
+    )
+
+    assert calls == [["0", "1"], ["1"]]
+    assert list(result.clusters) == ["0"]
 
 
 def _insert_attempted_eager_translation_work(session: Session) -> None:

--- a/services/shared-analysis-worker/tests/test_bedrock_label_summary.py
+++ b/services/shared-analysis-worker/tests/test_bedrock_label_summary.py
@@ -196,26 +196,26 @@ def test_parse_label_summary_output_for_groups_returns_valid_partial_clusters() 
             }
         },
         expected_group_keys={"0", "1"},
-        allow_partial=True,
     )
 
     assert list(parsed.clusters) == ["0"]
 
 
-def test_parse_label_summary_output_for_groups_requires_exact_when_not_partial() -> None:
-    with pytest.raises(BedrockLabelSummaryError):
-        parse_label_summary_output_for_groups(
-            {
-                "clusters": {
-                    "0": {
-                        "reasoning": "ok",
-                        "label": "Transitists",
-                        "summary": "Summary",
-                    }
+def test_parse_label_summary_output_for_groups_keeps_valid_missing_expected() -> None:
+    parsed = parse_label_summary_output_for_groups(
+        {
+            "clusters": {
+                "0": {
+                    "reasoning": "ok",
+                    "label": "Transitists",
+                    "summary": "Summary",
                 }
-            },
-            expected_group_keys={"0", "1"},
-        )
+            }
+        },
+        expected_group_keys={"0", "1"},
+    )
+
+    assert list(parsed.clusters) == ["0"]
 
 
 def test_parse_bedrock_label_summary_text_uses_later_semantic_match() -> None:

--- a/services/shared-analysis-worker/tests/test_description_translation.py
+++ b/services/shared-analysis-worker/tests/test_description_translation.py
@@ -8,6 +8,7 @@ import pytest
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+import agora_analysis_worker_shared.description_services as description_services
 from agora_analysis_worker_shared.description_services import fill_missing_translations_with_google
 from agora_analysis_worker_shared.description_translation import (
     BedrockTranslationConfig,
@@ -244,30 +245,31 @@ def test_parse_description_translation_output_rejects_missing_reasoning() -> Non
         )
 
 
-def test_parse_description_translation_output_rejects_duplicate_ids() -> None:
-    with pytest.raises(DescriptionTranslationError):
-        parse_description_translation_output(
-            {
-                "translations": [
-                    {
-                        "descriptionId": 10,
-                        "locale": "fr",
-                        "reasoning": "First translation.",
-                        "label": "Sceptiques",
-                        "summary": "Ce groupe rejette les affirmations trop optimistes.",
-                    },
-                    {
-                        "descriptionId": 10,
-                        "locale": "fr",
-                        "reasoning": "Duplicate translation.",
-                        "label": "Critiques",
-                        "summary": "Ce groupe rejette les affirmations trop optimistes.",
-                    },
-                ]
-            },
-            expected_description_ids={10},
-            expected_locale="fr",
-        )
+def test_parse_description_translation_output_keeps_first_duplicate_id() -> None:
+    translations = parse_description_translation_output(
+        {
+            "translations": [
+                {
+                    "descriptionId": 10,
+                    "locale": "fr",
+                    "reasoning": "First translation.",
+                    "label": "Sceptiques",
+                    "summary": "Ce groupe rejette les affirmations trop optimistes.",
+                },
+                {
+                    "descriptionId": 10,
+                    "locale": "fr",
+                    "reasoning": "Duplicate translation.",
+                    "label": "Critiques",
+                    "summary": "Ce groupe rejette les affirmations trop optimistes.",
+                },
+            ]
+        },
+        expected_description_ids={10},
+        expected_locale="fr",
+    )
+
+    assert [translation.label for translation in translations] == ["Sceptiques"]
 
 
 def test_parse_bedrock_translation_text_skips_preceding_example_json() -> None:
@@ -331,6 +333,204 @@ def test_partial_bedrock_translation_fills_missing_items_with_google() -> None:
     ]
 
 
+def test_bedrock_timeout_falls_back_to_google_without_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bedrock_calls: list[list[int]] = []
+
+    def raise_timeout(
+        *,
+        config: BedrockTranslationConfig,
+        descriptions: list[DescriptionForTranslation],
+        target_language_codes: list[str],
+    ) -> list[DescriptionTranslation]:
+        del config, target_language_codes
+        bedrock_calls.append([description.description_id for description in descriptions])
+        raise TimeoutError("bedrock timed out")
+
+    monkeypatch.setattr(
+        description_services,
+        "generate_description_translations_with_bedrock",
+        raise_timeout,
+    )
+    google_client = FakeTranslationClient()
+
+    translations = description_services.translate_with_bedrock_then_google(
+        bedrock_config=BedrockTranslationConfig(
+            region="us-east-1",
+            model_id="model",
+            temperature=0.1,
+            top_p=0.9,
+            max_tokens=1024,
+            prompt="Translate",
+            connect_timeout_seconds=2.0,
+            read_timeout_seconds=12.0,
+        ),
+        google_service=GoogleTranslationService(
+            client=google_client,
+            config=GoogleTranslationConfig(
+                project_id="project",
+                location="us-central1",
+                request_timeout_seconds=5.0,
+            ),
+        ),
+        descriptions=[
+            DescriptionForTranslation(
+                description_id=10,
+                label="Transitists",
+                summary="Supports transit.",
+            )
+        ],
+        target_language_codes=["fr"],
+    )
+
+    assert bedrock_calls == [[10]]
+    assert [(translation.description_id, translation.label) for translation in translations] == [
+        (10, "fr:Transitists")
+    ]
+
+
+def test_google_fallback_failure_returns_bedrock_partials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def partial_bedrock(
+        *,
+        config: BedrockTranslationConfig,
+        descriptions: list[DescriptionForTranslation],
+        target_language_codes: list[str],
+    ) -> list[DescriptionTranslation]:
+        del config, descriptions, target_language_codes
+        return [
+            DescriptionTranslation(
+                description_id=10,
+                locale="fr",
+                label="Transitistes",
+                summary="Soutient les transports.",
+            )
+        ]
+
+    def raise_google_timeout(
+        *,
+        google_service: GoogleTranslationService,
+        descriptions: list[DescriptionForTranslation],
+        target_language_codes: list[str],
+    ) -> list[DescriptionTranslation]:
+        del google_service, descriptions, target_language_codes
+        raise TimeoutError("google timed out")
+
+    monkeypatch.setattr(
+        description_services,
+        "generate_description_translations_with_bedrock",
+        partial_bedrock,
+    )
+    monkeypatch.setattr(
+        description_services,
+        "_generate_google_translations",
+        raise_google_timeout,
+    )
+
+    translations = description_services.translate_with_bedrock_then_google(
+        bedrock_config=BedrockTranslationConfig(
+            region="us-east-1",
+            model_id="model",
+            temperature=0.1,
+            top_p=0.9,
+            max_tokens=1024,
+            prompt="Translate",
+            connect_timeout_seconds=2.0,
+            read_timeout_seconds=12.0,
+        ),
+        google_service=GoogleTranslationService(
+            client=FakeTranslationClient(),
+            config=GoogleTranslationConfig(
+                project_id="project",
+                location="us-central1",
+                request_timeout_seconds=5.0,
+            ),
+        ),
+        descriptions=[
+            DescriptionForTranslation(
+                description_id=10,
+                label="Transitists",
+                summary="Supports transit.",
+            ),
+            DescriptionForTranslation(
+                description_id=20,
+                label="Skeptics",
+                summary="Questions cost.",
+            ),
+        ],
+        target_language_codes=["fr"],
+    )
+
+    assert [(translation.description_id, translation.label) for translation in translations] == [
+        (10, "Transitistes")
+    ]
+
+
+def test_bedrock_partial_retry_stops_after_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bedrock_calls: list[list[int]] = []
+
+    def partial_then_timeout(
+        *,
+        config: BedrockTranslationConfig,
+        descriptions: list[DescriptionForTranslation],
+        target_language_codes: list[str],
+    ) -> list[DescriptionTranslation]:
+        del config, target_language_codes
+        bedrock_calls.append([description.description_id for description in descriptions])
+        if len(bedrock_calls) == 1:
+            return [
+                DescriptionTranslation(
+                    description_id=10,
+                    locale="fr",
+                    label="Transitistes",
+                    summary="Soutient les transports.",
+                )
+            ]
+        raise TimeoutError("bedrock timed out")
+
+    monkeypatch.setattr(
+        description_services,
+        "generate_description_translations_with_bedrock",
+        partial_then_timeout,
+    )
+
+    translations = description_services.generate_bedrock_translations_with_partial_retries(
+        config=BedrockTranslationConfig(
+            region="us-east-1",
+            model_id="model",
+            temperature=0.1,
+            top_p=0.9,
+            max_tokens=1024,
+            prompt="Translate",
+            connect_timeout_seconds=2.0,
+            read_timeout_seconds=12.0,
+        ),
+        descriptions=[
+            DescriptionForTranslation(
+                description_id=10,
+                label="Transitists",
+                summary="Supports transit.",
+            ),
+            DescriptionForTranslation(
+                description_id=20,
+                label="Skeptics",
+                summary="Questions cost.",
+            ),
+        ],
+        target_language_codes=["fr"],
+        attempts=3,
+    )
+
+    assert bedrock_calls == [[10, 20], [20]]
+    assert [(translation.description_id, translation.label) for translation in translations] == [
+        (10, "Transitistes")
+    ]
+
+
 def test_parse_bedrock_translation_text_can_return_partial_valid_items() -> None:
     translations = parse_bedrock_translation_text(
         '{"translations":['
@@ -341,7 +541,6 @@ def test_parse_bedrock_translation_text_can_return_partial_valid_items() -> None
         ']}',
         expected_description_ids={10, 20},
         expected_locale="fr",
-        allow_partial=True,
     )
 
     assert [(translation.description_id, translation.label) for translation in translations] == [


### PR DESCRIPTION
## Summary
- preserve valid partial Bedrock translation and label-summary outputs instead of discarding whole batches
- route Bedrock translation timeouts to Google fallback without immediate same-provider retry
- remove strict/partial parser mode in favor of returning valid expected items and retrying missing work

## Tests
- `uv run --with pytest python -m pytest`
- `uv run --with ruff ruff check .`
- `uv run --with basedpyright python -m basedpyright`

Deploy: math-updater, ai-description-retry-worker, description-translation-retry-worker