### PR TITLE
fix(math-updater): restore analysis generated models

### DIFF
--- a/services/api/src/shared-backend/schema.ts
+++ b/services/api/src/shared-backend/schema.ts
@@ -1081,7 +1081,7 @@ export const projectTable = pgTable("project", {
         .notNull(),
 });
 
-/** @service scoring-worker, api, math-updater, import-worker */
+/** @service scoring-worker, api, math-updater, shared-analysis-worker, import-worker */
 export const projectOrganizationOwnershipTable = pgTable(
     "project_organization_ownership",
     {
@@ -1159,7 +1159,7 @@ export const organizationMembershipAllProjectCapabilityTable = pgTable(
     ],
 );
 
-/** @service api, math-updater */
+/** @service api, math-updater, shared-analysis-worker */
 export const premiumFeatureEntitlementTable = pgTable(
     "premium_feature_entitlement",
     {

--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/generated_models.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/generated_models.py
@@ -144,6 +144,12 @@ class ModerationReasonEnum(StrEnum):
     spam = "spam"
 
 
+class PremiumFeature(StrEnum):
+    survey = "survey"
+    event_ticket = "event_ticket"
+    analysis_variants = "analysis_variants"
+
+
 class SurveyQuestionType(StrEnum):
     choice = "choice"
     free_text = "free_text"
@@ -664,6 +670,33 @@ class Opinion(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime)
     updated_at: Mapped[datetime] = mapped_column(DateTime)
     last_reacted_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class PremiumFeatureEntitlement(Base):
+    __tablename__ = "premium_feature_entitlement"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    organization_id: Mapped[int] = mapped_column(Integer)
+    feature: Mapped[PremiumFeature] = mapped_column(
+        SaEnum(PremiumFeature, values_callable=_enum_values, native_enum=False),
+    )
+    starts_at: Mapped[datetime] = mapped_column(DateTime)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    admin_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by_user_id: Mapped[uuid_pkg.UUID | None] = mapped_column(Uuid, nullable=True)
+    updated_by_user_id: Mapped[uuid_pkg.UUID | None] = mapped_column(Uuid, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
+    updated_at: Mapped[datetime] = mapped_column(DateTime)
+
+
+class ProjectOrganizationOwnership(Base):
+    __tablename__ = "project_organization_ownership"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    project_id: Mapped[int] = mapped_column(Integer)
+    organization_id: Mapped[int] = mapped_column(Integer)
+    created_at: Mapped[datetime] = mapped_column(DateTime)
 
 
 class RealtimeEventOutbox(Base):

--- a/services/shared-analysis-worker/tests/test_ai_description_work.py
+++ b/services/shared-analysis-worker/tests/test_ai_description_work.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
 
 import pytest
 from sqlalchemy import Engine, create_engine, select
@@ -108,8 +107,7 @@ def _insert_non_processable_ai_work_state(
         Conversation(
             id=10,
             slug_id="abc12345",
-            author_id=uuid4(),
-            organization_id=None,
+            project_id=1,
             current_content_id=None,
             current_ranking_score_id=None,
             is_indexed=True,

--- a/services/shared-backend/src/schema.ts
+++ b/services/shared-backend/src/schema.ts
@@ -1080,7 +1080,7 @@ export const projectTable = pgTable("project", {
         .notNull(),
 });
 
-/** @service scoring-worker, api, math-updater, import-worker */
+/** @service scoring-worker, api, math-updater, shared-analysis-worker, import-worker */
 export const projectOrganizationOwnershipTable = pgTable(
     "project_organization_ownership",
     {
@@ -1158,7 +1158,7 @@ export const organizationMembershipAllProjectCapabilityTable = pgTable(
     ],
 );
 
-/** @service api, math-updater */
+/** @service api, math-updater, shared-analysis-worker */
 export const premiumFeatureEntitlementTable = pgTable(
     "premium_feature_entitlement",
     {


### PR DESCRIPTION
## Summary
- include premium entitlement and project ownership tables in shared-analysis-worker model generation
- regenerate the shared-analysis SQLAlchemy models used by premium analysis checks
- update the stale shared-analysis test fixture to use project_id instead of removed conversation ownership columns

## Checks
- cd services/shared-analysis-worker && uv run --extra dev ruff check
- cd services/shared-analysis-worker && uv run --extra dev python -m basedpyright
- cd services/shared-analysis-worker && uv run --extra dev python -m pytest -q
- cd services/math-updater && uv run --extra dev basedpyright
- cd services/api && pnpm typecheck

Deploy: math-updater