### PR TITLE
fix(api): install Docker build toolchain

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,6 +1,7 @@
 # ---- Dependencies (production only) ----
 FROM node:24.14.1-alpine AS deps
 WORKDIR /app
+RUN apk add --no-cache python3 make g++
 RUN corepack enable && corepack prepare pnpm@10 --activate
 COPY package.json pnpm-lock.yaml ./
 COPY pnpm-workspace-docker.yaml ./pnpm-workspace.yaml
@@ -10,6 +11,7 @@ RUN pnpm install --frozen-lockfile --prod
 # ---- Build ----
 FROM node:24.14.1-alpine AS build
 WORKDIR /app
+RUN apk add --no-cache python3 make g++
 RUN corepack enable && corepack prepare pnpm@10 --activate
 COPY package.json pnpm-lock.yaml ./
 COPY pnpm-workspace-docker.yaml ./pnpm-workspace.yaml


### PR DESCRIPTION
## Summary
- add Python and compiler tooling to API Docker dependency and build stages
- allow native dependencies such as opencc to compile when linux/amd64 prebuilds are unavailable

## Verification
- Ran `pnpm image:buildx TAG=5.2.1`; original `opencc` install failure was fixed and TypeScript build completed before the command was manually interrupted during the final image ownership step.

Deploy: api