### PR TITLE
fix(import-worker): keep import loop responsive

### DIFF
--- a/services/content-translation-worker/Dockerfile
+++ b/services/content-translation-worker/Dockerfile
@@ -10,7 +10,7 @@ COPY services/content-translation-worker/pyproject.toml services/content-transla
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY services/content-translation-worker/src ./src
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 

--- a/services/import-worker/Dockerfile
+++ b/services/import-worker/Dockerfile
@@ -10,7 +10,7 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 
 COPY src ./src
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --no-editable
 
 FROM python:3.13-slim
 

--- a/services/import-worker/src/import_worker/config.py
+++ b/services/import-worker/src/import_worker/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     max_concurrency: int = Field(default=2, ge=1)
     stale_threshold_ms: int = Field(default=300000, ge=1)
     stale_cleanup_every_n_flushes: int = Field(default=60, ge=1)
+    polis_fetch_timeout_seconds: float = Field(default=30.0, gt=0)
 
     google_cloud_project_id: str | None = Field(
         default=None,

--- a/services/import-worker/src/import_worker/importer.py
+++ b/services/import-worker/src/import_worker/importer.py
@@ -85,11 +85,24 @@ class PolisLoader(Protocol):
 
 
 class RedDwarfPolisLoader:
-    def __init__(self, *, polis_id: str, data_source: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        polis_id: str,
+        request_timeout_seconds: float,
+        data_source: str | None = None,
+    ) -> None:
         if data_source is None:
-            self._loader: Any = Loader(polis_id=polis_id)
+            self._loader: Any = TimeoutRedDwarfLoader(
+                polis_id=polis_id,
+                request_timeout_seconds=request_timeout_seconds,
+            )
         else:
-            self._loader = Loader(polis_id=polis_id, data_source=data_source)
+            self._loader = TimeoutRedDwarfLoader(
+                polis_id=polis_id,
+                data_source=data_source,
+                request_timeout_seconds=request_timeout_seconds,
+            )
 
     @property
     def report_id(self) -> object | None:
@@ -115,6 +128,36 @@ class RedDwarfPolisLoader:
 
     def load_api_data_conversation(self) -> object:
         return self._loader.load_api_data_conversation()
+
+
+class TimeoutRedDwarfLoader(Loader):
+    _request_timeout_seconds: float
+
+    def __init__(
+        self,
+        *,
+        polis_id: str,
+        request_timeout_seconds: float,
+        data_source: str | None = None,
+    ) -> None:
+        self._request_timeout_seconds = request_timeout_seconds
+        loader_init: Any = vars(Loader)["__init__"]
+        if data_source is None:
+            loader_init(self, polis_id=polis_id)
+        else:
+            loader_init(self, polis_id=polis_id, data_source=data_source)
+
+    def init_http_client(self) -> None:
+        super().init_http_client()
+        session: Any = self.session
+        original_request = session.request
+        request_timeout_seconds = self._request_timeout_seconds
+
+        def request_with_timeout(method: str, url: str, **kwargs: Any) -> Any:
+            kwargs.setdefault("timeout", request_timeout_seconds)
+            return original_request(method, url, **kwargs)
+
+        session.request = request_with_timeout
 
 
 LOGGER = logging.getLogger(__name__)
@@ -238,18 +281,29 @@ def _display_language_code_or_none(language_code: str | None) -> str | None:
         return None
 
 
-def _build_imported_polis_conversation(request: ImportRequest) -> tuple[ImportPolisResults, str]:
+def _build_imported_polis_conversation(
+    request: ImportRequest,
+    *,
+    polis_fetch_timeout_seconds: float,
+) -> tuple[ImportPolisResults, str]:
     if request.type == "csv":
         return build_import_from_csv(request.files.model_dump(by_alias=True)), "csv"
 
     polis_id = extract_polis_id_from_url(request.polis_url)
     loader: PolisLoader
     if polis_id.report_id is not None:
-        loader = RedDwarfPolisLoader(polis_id=polis_id.report_id, data_source="csv_export")
+        loader = RedDwarfPolisLoader(
+            polis_id=polis_id.report_id,
+            data_source="csv_export",
+            request_timeout_seconds=polis_fetch_timeout_seconds,
+        )
         loader.load_api_data_conversation()
         polis_url_type = "report"
     elif polis_id.conversation_id is not None:
-        loader = RedDwarfPolisLoader(polis_id=polis_id.conversation_id)
+        loader = RedDwarfPolisLoader(
+            polis_id=polis_id.conversation_id,
+            request_timeout_seconds=polis_fetch_timeout_seconds,
+        )
         polis_url_type = "conversation"
     else:
         raise ValueError("Incorrect Polis URL")
@@ -1251,6 +1305,7 @@ def process_import_request(
     *,
     request: ImportRequest,
     google_detector: GoogleLanguageDetector | None = None,
+    polis_fetch_timeout_seconds: float,
 ) -> ImportProcessResult:
     conversation_id: int | None = None
     try:
@@ -1262,7 +1317,10 @@ def process_import_request(
                 f"import owner {import_user_id}",
             )
 
-        imported, polis_url_type = _build_imported_polis_conversation(request)
+        imported, polis_url_type = _build_imported_polis_conversation(
+            request,
+            polis_fetch_timeout_seconds=polis_fetch_timeout_seconds,
+        )
         active_google_detector = google_detector_for_import(
             request=request,
             google_detector=google_detector,

--- a/services/import-worker/src/import_worker/worker.py
+++ b/services/import-worker/src/import_worker/worker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import signal
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote, urlparse
@@ -219,6 +219,7 @@ def _process_request(
     session_factory: sessionmaker[Session],
     request: ImportRequest,
     google_detector: GoogleLanguageDetector | None,
+    polis_fetch_timeout_seconds: float,
 ) -> ProcessedImport:
     with session_factory() as session:
         try:
@@ -227,6 +228,7 @@ def _process_request(
                 session,
                 request=request,
                 google_detector=google_detector,
+                polis_fetch_timeout_seconds=polis_fetch_timeout_seconds,
             )
             LOGGER.info("Completed %s import %s", request.type, request.import_slug_id)
             return ProcessedImport(result=result, failure_event=None)
@@ -315,10 +317,12 @@ def run_worker(settings: Settings) -> None:
     global _running
 
     LOGGER.info(
-        "Starting import worker (flush_interval_ms=%s, max_batch_size=%s, max_concurrency=%s)",
+        "Starting import worker (flush_interval_ms=%s, max_batch_size=%s, "
+        "max_concurrency=%s, polis_fetch_timeout_seconds=%s)",
         settings.flush_interval_ms,
         settings.max_batch_size,
         settings.max_concurrency,
+        settings.polis_fetch_timeout_seconds,
     )
     should_stop = False
 
@@ -365,14 +369,34 @@ def run_worker(settings: Settings) -> None:
             LOGGER.exception("Initial stale import cleanup failed")
 
     with ThreadPoolExecutor(max_workers=settings.max_concurrency) as executor:
+        pending_futures: dict[Future[ProcessedImport], ImportRequest] = {}
         while not should_stop:
+            completed_futures = [future for future in pending_futures if future.done()]
+            for future in completed_futures:
+                request = pending_futures.pop(future)
+                try:
+                    _push_result_events(vk, processed=future.result())
+                except Exception:
+                    LOGGER.exception(
+                        "Failed to handle import result %s",
+                        request.import_slug_id,
+                    )
+
             if settings.max_batch_size <= 0:
+                time.sleep(settings.flush_interval_ms / 1000)
+                continue
+
+            available_capacity = settings.max_concurrency - len(pending_futures)
+            if available_capacity <= 0:
                 time.sleep(settings.flush_interval_ms / 1000)
                 continue
 
             flush_count += 1
             try:
-                batch = pop_import_requests(vk, count=settings.max_batch_size)
+                batch = pop_import_requests(
+                    vk,
+                    count=min(settings.max_batch_size, available_capacity),
+                )
             except Exception:
                 LOGGER.exception("Import queue poll failed")
                 time.sleep(settings.flush_interval_ms / 1000)
@@ -395,7 +419,10 @@ def run_worker(settings: Settings) -> None:
                 except Exception:
                     LOGGER.exception("Ready import completion failed")
 
-                if flush_count % settings.stale_cleanup_every_n_flushes == 0:
+                if (
+                    not pending_futures
+                    and flush_count % settings.stale_cleanup_every_n_flushes == 0
+                ):
                     try:
                         _push_stale_cleanup_events(
                             vk=vk,
@@ -418,20 +445,15 @@ def run_worker(settings: Settings) -> None:
 
             LOGGER.info("Dequeued %s import requests", len(batch.requests))
 
-            futures = [
-                executor.submit(
+            for request in batch.requests:
+                future = executor.submit(
                     _process_request,
                     session_factory=session_factory,
                     request=request,
                     google_detector=google_detector,
+                    polis_fetch_timeout_seconds=settings.polis_fetch_timeout_seconds,
                 )
-                for request in batch.requests
-            ]
-            for future in as_completed(futures):
-                try:
-                    _push_result_events(vk, processed=future.result())
-                except Exception:
-                    LOGGER.exception("Failed to handle import result")
+                pending_futures[future] = request
 
             try:
                 _push_ready_import_events(vk=vk, session_factory=session_factory)

--- a/services/import-worker/tests/test_config.py
+++ b/services/import-worker/tests/test_config.py
@@ -14,6 +14,7 @@ IMPORT_WORKER_ENV_KEYS = (
     "IMPORT_WORKER_MAX_CONCURRENCY",
     "IMPORT_WORKER_STALE_THRESHOLD_MS",
     "IMPORT_WORKER_STALE_CLEANUP_EVERY_N_FLUSHES",
+    "IMPORT_WORKER_POLIS_FETCH_TIMEOUT_SECONDS",
     "IMPORT_WORKER_GOOGLE_CLOUD_PROJECT_ID",
     "IMPORT_WORKER_GOOGLE_CLOUD_TRANSLATION_ENDPOINT",
     "IMPORT_WORKER_GOOGLE_CLOUD_TRANSLATION_LOCATION",
@@ -118,6 +119,21 @@ def test_settings_reject_zero_batch_size(
             {
                 "connection_string": "postgresql://primary.example/agora",
                 "max_batch_size": 0,
+            },
+            monkeypatch=monkeypatch,
+            tmp_path=tmp_path,
+        )
+
+
+def test_settings_reject_invalid_polis_fetch_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValidationError):
+        build_settings(
+            {
+                "connection_string": "postgresql://primary.example/agora",
+                "polis_fetch_timeout_seconds": 0,
             },
             monkeypatch=monkeypatch,
             tmp_path=tmp_path,


### PR DESCRIPTION
## Summary
- keep the import worker polling loop responsive while imports run in the thread pool
- add a Polis fetch timeout setting so slow upstream requests do not block worker capacity indefinitely
- install uv-managed worker projects non-editably in Docker images so copied runtime virtualenvs contain importable packages

## Verification
- built import-worker image and verified import_worker imports from site-packages inside the runtime image
- built content-translation-worker image and verified content_translation_worker imports from site-packages inside the runtime image
- built math-updater image and verified it imports from site-packages to spot-check other worker packaging

Deploy: import-worker, content-translation-worker