### PR TITLE
fix(agora): show auto-detect status

### DIFF
--- a/services/agora/src/components/newConversation/dialog/ConversationLanguageSettingDialog.vue
+++ b/services/agora/src/components/newConversation/dialog/ConversationLanguageSettingDialog.vue
@@ -17,6 +17,12 @@
             <span class="language-settings-row__value">{{
               primaryLanguageLabel
             }}</span>
+            <span
+              v-if="primaryLanguageDescription !== undefined"
+              class="language-settings-row__description"
+            >
+              {{ primaryLanguageDescription }}
+            </span>
           </span>
           <q-icon :name="forwardIcon" class="language-settings-row__icon" />
         </button>
@@ -255,9 +261,10 @@ const multilingualSetting = defineModel<ConversationMultilingualSetting>(
   { required: true }
 );
 
-const { t, locale } = useComponentI18n<ConversationLanguageSettingDialogTranslations>(
-  conversationLanguageSettingDialogTranslations
-);
+const { t, locale } =
+  useComponentI18n<ConversationLanguageSettingDialogTranslations>(
+    conversationLanguageSettingDialogTranslations
+  );
 const $q = useQuasar();
 
 const currentPage = ref<LanguageDialogPage>("overview");
@@ -278,7 +285,8 @@ function getLocalizedLanguageName(languageCode: string): string | undefined {
   }
 
   try {
-    const canonicalLanguageCode = Intl.getCanonicalLocales(trimmedLanguageCode).at(0);
+    const canonicalLanguageCode =
+      Intl.getCanonicalLocales(trimmedLanguageCode).at(0);
     if (canonicalLanguageCode === undefined) {
       return undefined;
     }
@@ -295,7 +303,8 @@ function getLocalizedLanguageName(languageCode: string): string | undefined {
 const languageOptions = computed<LanguageOption[]>(() =>
   SupportedSpokenLanguageMetadataList.filter(isDisplayLanguageMetadata).map(
     (language) => {
-      const label = getLocalizedLanguageName(language.code) ?? language.englishName;
+      const label =
+        getLocalizedLanguageName(language.code) ?? language.englishName;
       return {
         label,
         caption: language.name,
@@ -410,14 +419,20 @@ function getAutoDetectDescriptionState({
     };
   }
 
-  if (detectedSourceLanguageCode !== null && detectedSourceLanguageCode !== undefined) {
+  if (
+    detectedSourceLanguageCode !== null &&
+    detectedSourceLanguageCode !== undefined
+  ) {
     return {
       kind: "unsupported",
       languageLabel: getLanguageLabel(detectedSourceLanguageCode),
     };
   }
 
-  if (detectedRawLanguageCode !== null && detectedRawLanguageCode !== undefined) {
+  if (
+    detectedRawLanguageCode !== null &&
+    detectedRawLanguageCode !== undefined
+  ) {
     const rawLanguageLabel = getLocalizedLanguageName(detectedRawLanguageCode);
     if (rawLanguageLabel !== undefined) {
       return { kind: "unsupported", languageLabel: rawLanguageLabel };
@@ -455,6 +470,16 @@ const autoDetectOptionDescription = computed(() => {
     language: state.languageLabel,
   });
 });
+const primaryLanguageDescription = computed(() => {
+  if (
+    languageSetting.value.mode !== "auto" ||
+    autoDetectDescriptionState.value.kind === "neutral"
+  ) {
+    return undefined;
+  }
+
+  return autoDetectOptionDescription.value;
+});
 const manualLanguageOptionDescription = computed(() =>
   languageSetting.value.mode === "manual"
     ? getLanguageLabel(languageSetting.value.languageCode)
@@ -488,8 +513,9 @@ function getLanguageLabel(
   }
   return (
     getLocalizedLanguageName(languageCode) ??
-    SupportedSpokenLanguageMetadataList.find((language) => language.code === languageCode)
-      ?.englishName ??
+    SupportedSpokenLanguageMetadataList.find(
+      (language) => language.code === languageCode
+    )?.englishName ??
     languageCode
   );
 }
@@ -660,7 +686,6 @@ watch(
   },
   { deep: true }
 );
-
 </script>
 
 <style scoped lang="scss">

--- a/services/api/src/service/contentTranslation.ts
+++ b/services/api/src/service/contentTranslation.ts
@@ -158,12 +158,14 @@ type TranslationWorkInput =
 async function ensureTranslationWork({
     db,
     input,
+    translationExists,
     now,
     priority,
     log,
 }: {
     db: PostgresDatabase;
     input: TranslationWorkInput;
+    translationExists: boolean;
     now: Date;
     priority: ContentTranslationQueuePriority;
     log: Pick<BaseLogger, "info">;
@@ -205,6 +207,8 @@ async function ensureTranslationWork({
     const existing = existingRows.at(0);
 
     if (existing !== undefined) {
+        const completedTranslationExists =
+            existing.status === "completed" && translationExists;
         const nextPriorityRank = Math.min(
             existing.priorityRank,
             priority,
@@ -212,7 +216,7 @@ async function ensureTranslationWork({
         await db
             .update(contentTranslationWorkTable)
             .set({
-                status: existing.status === "completed" ? "completed" : "pending",
+                status: completedTranslationExists ? "completed" : "pending",
                 priorityRank: nextPriorityRank,
                 leaseOwner: null,
                 leaseToken: null,
@@ -232,13 +236,14 @@ async function ensureTranslationWork({
                 previousStatus: existing.status,
                 previousPriorityRank: existing.priorityRank,
                 nextPriorityRank,
-                shouldQueue: existing.status !== "completed",
+                translationExists,
+                shouldQueue: !completedTranslationExists,
             },
             "[ContentTranslation] Reused translation work row",
         );
         return {
             workId: existing.id,
-            shouldQueue: existing.status !== "completed",
+            shouldQueue: !completedTranslationExists,
         };
     }
 
@@ -315,6 +320,7 @@ async function queueMissingTranslationWork({
     valkey,
     queueScript,
     input,
+    translationExists,
     now,
     log,
     priority,
@@ -323,6 +329,7 @@ async function queueMissingTranslationWork({
     valkey: Valkey | undefined;
     queueScript: Script;
     input: TranslationWorkInput;
+    translationExists: boolean;
     now: Date;
     log: Pick<BaseLogger, "info" | "error">;
     priority: ContentTranslationQueuePriority;
@@ -330,6 +337,7 @@ async function queueMissingTranslationWork({
     const ensuredWork = await ensureTranslationWork({
         db,
         input,
+        translationExists,
         now,
         priority,
         log,
@@ -953,6 +961,7 @@ async function ensureAndQueueEagerTranslationWork({
     valkey,
     queueScript,
     input,
+    translationExists,
     now,
     log,
 }: {
@@ -960,6 +969,7 @@ async function ensureAndQueueEagerTranslationWork({
     valkey: Valkey | undefined;
     queueScript: Script;
     input: TranslationWorkInput;
+    translationExists: boolean;
     now: Date;
     log: Pick<BaseLogger, "info" | "error">;
 }): Promise<void> {
@@ -968,6 +978,7 @@ async function ensureAndQueueEagerTranslationWork({
         valkey,
         queueScript,
         input,
+        translationExists,
         now,
         log,
         priority: CONTENT_TRANSLATION_QUEUE_PRIORITIES.eagerVisible,
@@ -1030,6 +1041,7 @@ export async function scheduleEagerContentTranslationForConversation({
                     sourceContentId: conversationSource.contentId,
                     targetLanguageCode,
                 },
+                translationExists: false,
                 now,
                 log,
             });
@@ -1062,6 +1074,7 @@ export async function scheduleEagerContentTranslationForConversation({
                     ),
                     targetLanguageCode,
                 },
+                translationExists: false,
                 now,
                 log,
             });
@@ -1091,6 +1104,7 @@ export async function scheduleEagerContentTranslationForConversation({
                     sourceContentId: source.contentId,
                     targetLanguageCode,
                 },
+                translationExists: false,
                 now,
                 log,
             });
@@ -1473,6 +1487,7 @@ export async function requestContentTranslation({
                     ),
                     targetLanguageCode,
                 },
+                translationExists,
                 now,
                 log,
                 priority: CONTENT_TRANSLATION_QUEUE_PRIORITIES.userInteractive,
@@ -1522,6 +1537,7 @@ export async function requestContentTranslation({
                     sourceContentId: source.contentId,
                     targetLanguageCode,
                 },
+                translationExists,
                 now,
                 log,
                 priority: CONTENT_TRANSLATION_QUEUE_PRIORITIES.userInteractive,
@@ -1571,6 +1587,7 @@ export async function requestContentTranslation({
                 sourceContentId: source.contentId,
                 targetLanguageCode,
             },
+            translationExists,
             now,
             log,
             priority: CONTENT_TRANSLATION_QUEUE_PRIORITIES.userInteractive,
@@ -1634,6 +1651,7 @@ export async function requestConversationContentTranslation({
                 sourceContentId: source.contentId,
                 targetLanguageCode,
             },
+            translationExists,
             now,
             log,
             priority: CONTENT_TRANSLATION_QUEUE_PRIORITIES.userInteractive,
@@ -1698,6 +1716,7 @@ export async function requestSurveyQuestionContentTranslation({
                 ),
                 targetLanguageCode,
             },
+            translationExists,
             now,
             log,
             priority: CONTENT_TRANSLATION_QUEUE_PRIORITIES.userInteractive,

--- a/services/import-worker/src/import_worker/importer.py
+++ b/services/import-worker/src/import_worker/importer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol
@@ -255,6 +256,10 @@ def now_zero_ms() -> datetime:
     return datetime.now(UTC).replace(microsecond=0, tzinfo=None)
 
 
+def _elapsed_ms(started_at: float) -> float:
+    return (time.perf_counter() - started_at) * 1000
+
+
 def _chunks[T](items: list[T], chunk_size: int) -> Iterable[list[T]]:
     for index in range(0, len(items), chunk_size):
         yield items[index : index + chunk_size]
@@ -286,8 +291,18 @@ def _build_imported_polis_conversation(
     *,
     polis_fetch_timeout_seconds: float,
 ) -> tuple[ImportPolisResults, str]:
+    load_started_at = time.perf_counter()
     if request.type == "csv":
-        return build_import_from_csv(request.files.model_dump(by_alias=True)), "csv"
+        imported = build_import_from_csv(request.files.model_dump(by_alias=True))
+        LOGGER.info(
+            "Loaded import source importSlugId=%s importType=csv comments=%s votes=%s "
+            "durationMs=%.1f",
+            request.import_slug_id,
+            len(imported.comments_data),
+            len(imported.votes_data),
+            _elapsed_ms(load_started_at),
+        )
+        return imported, "csv"
 
     polis_id = extract_polis_id_from_url(request.polis_url)
     loader: PolisLoader
@@ -316,6 +331,15 @@ def _build_imported_polis_conversation(
             "comments_data": loader.comments_data,
             "votes_data": loader.votes_data,
         },
+    )
+    LOGGER.info(
+        "Loaded import source importSlugId=%s importType=url polisUrlType=%s comments=%s "
+        "votes=%s durationMs=%.1f",
+        request.import_slug_id,
+        polis_url_type,
+        len(imported.comments_data),
+        len(imported.votes_data),
+        _elapsed_ms(load_started_at),
     )
     return imported, polis_url_type
 
@@ -1308,6 +1332,7 @@ def process_import_request(
     polis_fetch_timeout_seconds: float,
 ) -> ImportProcessResult:
     conversation_id: int | None = None
+    import_started_at = time.perf_counter()
     try:
         import_user_id = _get_import_user_id(session, import_slug_id=request.import_slug_id)
         if str(import_user_id) != request.actor_user_id:
@@ -1325,6 +1350,7 @@ def process_import_request(
             request=request,
             google_detector=google_detector,
         )
+        phase_started_at = time.perf_counter()
         conversation_ids = _create_conversation(
             session,
             request=request,
@@ -1333,11 +1359,29 @@ def process_import_request(
             google_detector=active_google_detector,
         )
         conversation_id = conversation_ids.conversation_id
+        LOGGER.info(
+            "Created imported conversation importSlugId=%s conversationSlugId=%s "
+            "durationMs=%.1f",
+            request.import_slug_id,
+            conversation_ids.conversation_slug_id,
+            _elapsed_ms(phase_started_at),
+        )
+        phase_started_at = time.perf_counter()
         participant_data = _insert_imported_users(
             session,
             imported=imported,
             conversation_slug_id=conversation_ids.conversation_slug_id,
         )
+        LOGGER.info(
+            "Inserted imported participants importSlugId=%s conversationSlugId=%s "
+            "participants=%s totalParticipants=%s durationMs=%.1f",
+            request.import_slug_id,
+            conversation_ids.conversation_slug_id,
+            participant_data.participant_count,
+            participant_data.total_participant_count,
+            _elapsed_ms(phase_started_at),
+        )
+        phase_started_at = time.perf_counter()
         opinions = _insert_opinions(
             session,
             imported=imported,
@@ -1345,6 +1389,19 @@ def process_import_request(
             participant_data=participant_data,
             google_detector=active_google_detector,
         )
+        LOGGER.info(
+            "Inserted imported statements importSlugId=%s conversationSlugId=%s "
+            "statements=%s totalStatements=%s moderatedStatements=%s hiddenStatements=%s "
+            "durationMs=%.1f",
+            request.import_slug_id,
+            conversation_ids.conversation_slug_id,
+            participant_data.opinion_count,
+            participant_data.total_opinion_count,
+            participant_data.moderated_opinion_count,
+            participant_data.hidden_opinion_count,
+            _elapsed_ms(phase_started_at),
+        )
+        phase_started_at = time.perf_counter()
         _insert_votes(
             session,
             imported=imported,
@@ -1352,17 +1409,47 @@ def process_import_request(
             participant_data=participant_data,
             conversation_slug_id=conversation_ids.conversation_slug_id,
         )
+        LOGGER.info(
+            "Inserted imported votes importSlugId=%s conversationSlugId=%s votes=%s "
+            "totalVotes=%s durationMs=%.1f",
+            request.import_slug_id,
+            conversation_ids.conversation_slug_id,
+            participant_data.vote_count,
+            participant_data.total_vote_count,
+            _elapsed_ms(phase_started_at),
+        )
+        phase_started_at = time.perf_counter()
         content_translation_schedule = _create_content_translation_work(
             session,
             conversation_ids=conversation_ids,
             opinions=opinions,
         )
+        LOGGER.info(
+            "Created imported content translation work importSlugId=%s conversationSlugId=%s "
+            "workCount=%s durationMs=%.1f",
+            request.import_slug_id,
+            conversation_ids.conversation_slug_id,
+            0
+            if content_translation_schedule is None
+            else len(content_translation_schedule.work_ids),
+            _elapsed_ms(phase_started_at),
+        )
+        phase_started_at = time.perf_counter()
         schedule = _update_counts_and_schedule(
             session,
             conversation_id=conversation_ids.conversation_id,
             participant_data=participant_data,
         )
+        LOGGER.info(
+            "Updated imported conversation counts importSlugId=%s conversationSlugId=%s "
+            "shouldEnqueueAnalysis=%s durationMs=%.1f",
+            request.import_slug_id,
+            conversation_ids.conversation_slug_id,
+            schedule.should_enqueue_analysis,
+            _elapsed_ms(phase_started_at),
+        )
 
+        phase_started_at = time.perf_counter()
         session.execute(
             update(ConversationImport)
             .where(ConversationImport.slug_id == request.import_slug_id)
@@ -1372,6 +1459,14 @@ def process_import_request(
             ),
         )
         session.commit()
+        LOGGER.info(
+            "Finalized imported conversation row importSlugId=%s conversationSlugId=%s "
+            "durationMs=%.1f totalDurationMs=%.1f",
+            request.import_slug_id,
+            conversation_ids.conversation_slug_id,
+            _elapsed_ms(phase_started_at),
+            _elapsed_ms(import_started_at),
+        )
         analysis_queue_schedule = (
             AnalysisQueueSchedule(
                 conversation_id=conversation_ids.conversation_id,


### PR DESCRIPTION
## Summary
- Show specific auto-detect status on the Languages overview row.
- Reuse the existing detected, retry, unknown, and unsupported-language copy from the primary-language detail screen.
- Keep the generic auto-detect helper text off the overview.
- Fix eager content translation scheduling after conversation edits so completed work rows only suppress queueing when the actual matching translation exists.
- Requeue stale or missing completed translation work for conversation metadata, survey questions, and seed opinions when languages are added or dynamic translation is enabled.
- Add safe import-worker phase timing logs for source loading and major DB write steps without logging imported content, URLs, or vote payloads.

## Verification
- pnpm exec eslint -c ./eslint.config.js "./src/components/newConversation/dialog/ConversationLanguageSettingDialog.vue"
- pnpm exec prettier --check "src/components/newConversation/dialog/ConversationLanguageSettingDialog.vue"
- cd services/api && pnpm typecheck
- cd services/api && pnpm eslint src/service/contentTranslation.ts
- cd services/api && pnpm lint (fails on existing unrelated lint errors in src/index.ts, src/service/comment.ts, src/service/conversationContent.ts, and src/shared/types/dto.ts)
- cd services/import-worker && uv run ruff check src/import_worker/importer.py
- cd services/import-worker && uv run basedpyright src/import_worker/importer.py

Deploy: agora, api, import-worker