### PR TITLE
fix(agora): refresh translation language state

### DIFF
--- a/services/agora/src/components/post/comments/group/item/TranslatedCommentItem.vue
+++ b/services/agora/src/components/post/comments/group/item/TranslatedCommentItem.vue
@@ -22,8 +22,8 @@ import { storeToRefs } from "pinia";
 import type { OpinionVotingUtilities } from "src/composables/opinion/types";
 import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
 import type {
-  EventSlug,
   DisplayedOpinionItem,
+  EventSlug,
   ParticipationMode,
   SurveyGateSummary,
 } from "src/shared/types/zod";

--- a/services/agora/src/utils/api/comment/comment.ts
+++ b/services/agora/src/utils/api/comment/comment.ts
@@ -6,7 +6,6 @@ import type {
   ApiV1OpinionFetchByConversationPostRequest,
   ApiV1OpinionFetchBySlugIdListPostRequest,
   ApiV1OpinionFetchHiddenByConversationPostRequest,
-  ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem,
 } from "src/api";
 import { DefaultApiAxiosParamCreator, DefaultApiFactory } from "src/api";
 import type {
@@ -29,7 +28,6 @@ import type {
   OpinionItem,
   PolisKey,
 } from "src/shared/types/zod";
-import { zodOpinionItem } from "src/shared/types/zod";
 import { useAuthenticationStore } from "src/stores/authentication";
 
 import { useBackendAuthApi } from "../auth";
@@ -70,20 +68,6 @@ export function useBackendCommentApi() {
     useAuthenticationStore()
   );
   const { updateAuthState } = useBackendAuthApi();
-
-  function createLocalCommentObject(
-    webCommentItemList: ApiV1UserOpinionFetchPost200ResponseInnerOpinionItem[]
-  ): OpinionItem[] {
-    // Use zod to parse and validate - zodDateTimeFlexible handles date conversion automatically
-    const result = zodOpinionItem.array().safeParse(webCommentItemList);
-
-    if (!result.success) {
-      console.error("Failed to parse opinion data with zod:", result.error);
-      return [];
-    }
-
-    return result.data;
-  }
 
   function parseFetchOpinionsResponse(data: unknown): DisplayedOpinionItem[] {
     const result = Dto.fetchOpinionsResponse.safeParse(data);

--- a/services/agora/src/utils/api/contentTranslation/useContentTranslationQueries.ts
+++ b/services/agora/src/utils/api/contentTranslation/useContentTranslationQueries.ts
@@ -99,7 +99,7 @@ export function useConversationDisplayContentCache({
 
   return useQuery<ConversationContentFetchResponse>({
     queryKey,
-    queryFn: async () => {
+    queryFn: () => {
       const cached = queryClient.getQueryData<ConversationContentFetchResponse>(
         queryKey.value
       );

--- a/services/agora/src/utils/api/post/post.ts
+++ b/services/agora/src/utils/api/post/post.ts
@@ -1,5 +1,4 @@
 import type {
-  ApiV1ConversationFetchRecentPost200ResponseConversationDataListInner,
   ApiV1ConversationImportPost200Response,
 } from "src/api";
 import {

--- a/services/agora/src/utils/api/post/useConversationQuery.ts
+++ b/services/agora/src/utils/api/post/useConversationQuery.ts
@@ -97,9 +97,15 @@ export function useConversationQuery({
   const { isGuestOrLoggedIn } = storeToRefs(useAuthenticationStore());
   const { displayLanguage, spokenLanguages } = storeToRefs(useLanguageStore());
   const queryClient = useQueryClient();
+  const sortedSpokenLanguages = computed(() => [...spokenLanguages.value].sort());
 
   return useQuery({
-    queryKey: ["conversation", computed(() => toValue(conversationSlugId))],
+    queryKey: [
+      "conversation",
+      computed(() => toValue(conversationSlugId)),
+      displayLanguage,
+      sortedSpokenLanguages,
+    ],
     queryFn: async () => {
       const slugId = toValue(conversationSlugId);
       const fetchedConversation = await fetchConversationBySlugIdWithDisplayContent({

--- a/services/agora/src/utils/translation/useContentTranslationPreview.ts
+++ b/services/agora/src/utils/translation/useContentTranslationPreview.ts
@@ -126,6 +126,9 @@ function useContentTranslationController({
   );
   const modePreference = ref<ContentTranslationDisplayMode | undefined>(undefined);
   const hasRequestedTranslation = ref(false);
+  const sortedSpokenLanguageKey = computed(() =>
+    [...spokenLanguages.value].sort().join("\u0000")
+  );
   let waitTimeout: ReturnType<typeof setTimeout> | undefined;
 
   const resolvedState = computed(() =>
@@ -244,7 +247,7 @@ function useContentTranslationController({
     hasRequestedTranslation.value = false;
   }
 
-  watch(displayLanguage, () => {
+  watch([displayLanguage, sortedSpokenLanguageKey], () => {
     modePreference.value = undefined;
     hasRequestedTranslation.value = false;
   });

--- a/services/agora/src/utils/translation/useConversationDisplayContent.ts
+++ b/services/agora/src/utils/translation/useConversationDisplayContent.ts
@@ -11,7 +11,7 @@ import {
   useConversationDisplayContentCache,
 } from "src/utils/api/contentTranslation/useContentTranslationQueries";
 import type { MaybeRefOrGetter } from "vue";
-import { computed, ref, toValue } from "vue";
+import { computed, ref, toValue, watch } from "vue";
 
 import {
   type ContentTranslationDisplayMode,
@@ -34,8 +34,11 @@ export function useConversationDisplayContent({
 }: {
   extendedConversation: MaybeRefOrGetter<ExtendedConversation | undefined>;
 }) {
-  const { displayLanguage } = storeToRefs(useLanguageStore());
+  const { displayLanguage, spokenLanguages } = storeToRefs(useLanguageStore());
   const modePreference = ref<ConversationContentMode | undefined>();
+  const sortedSpokenLanguageKey = computed(() =>
+    [...spokenLanguages.value].sort().join("\u0000")
+  );
   const conversationSlugId = computed(
     () => toValue(extendedConversation)?.metadata.conversationSlugId ?? ""
   );
@@ -147,6 +150,10 @@ export function useConversationDisplayContent({
   function setTranslationMode(mode: ContentTranslationDisplayMode): void {
     modePreference.value = mode;
   }
+
+  watch([displayLanguage, sortedSpokenLanguageKey], () => {
+    modePreference.value = undefined;
+  });
 
   return {
     activeDisplayContent,


### PR DESCRIPTION
## Summary
- include display and spoken language preferences in the conversation query key so cached conversation pages refetch language-dependent display content
- reset manual translation mode preferences when spoken languages change
- remove lint-only dead code and unused imports surfaced by the frontend lint run

## Verification
- cd services/agora && pnpm lint
- cd services/agora && pnpm exec vue-tsc --noEmit

Deploy: agora