### PR TITLE
fix(agora): stabilize language preferences

### DIFF
--- a/services/agora/src/components/project/ProjectConversationView.vue
+++ b/services/agora/src/components/project/ProjectConversationView.vue
@@ -535,7 +535,9 @@ function t(
 
 <style scoped lang="scss">
 .project-conversation-view {
+  box-sizing: border-box;
   min-height: 100dvh;
+  overflow-x: hidden;
   background:
     radial-gradient(
       circle at 1px 1px,
@@ -545,6 +547,12 @@ function t(
     $app-background-color;
   background-size: 24px 24px;
   color: $ink-darker;
+}
+
+.project-conversation-view *,
+.project-conversation-view *::before,
+.project-conversation-view *::after {
+  box-sizing: inherit;
 }
 
 main {
@@ -669,6 +677,7 @@ main {
 
 .project-conversation-view__content-grid {
   display: grid;
+  width: 100%;
   grid-template-columns: minmax(0, 1fr) minmax(18rem, 22rem);
   grid-template-areas:
     "title ."
@@ -696,6 +705,7 @@ main {
   position: relative;
   z-index: 1;
   grid-area: title;
+  min-width: 0;
   isolation: isolate;
   display: flex;
   flex-direction: column;
@@ -724,6 +734,7 @@ main {
 .project-conversation-view__title-block {
   display: flex;
   flex-direction: column;
+  min-width: 0;
   gap: 0.85rem;
 }
 
@@ -743,6 +754,10 @@ main {
 
 .project-conversation-view__title-row :deep(.title-section) {
   min-width: 0;
+}
+
+.project-conversation-view__title-row :deep(.conversation-title) {
+  overflow-wrap: anywhere;
 }
 
 .project-conversation-view__translated-title {
@@ -766,7 +781,9 @@ main {
 }
 
 .project-conversation-view__breadcrumb-link {
+  display: block;
   overflow: hidden;
+  flex: 1 1 auto;
   min-width: 0;
   max-width: min(28rem, 100%);
   color: $primary-dark;
@@ -948,7 +965,7 @@ main {
   }
 
   .project-conversation-view__content-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
       "title"
       "stream"
@@ -1007,6 +1024,7 @@ main {
   }
 
   .project-conversation-view__title-row {
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.45rem;
   }
 

--- a/services/agora/src/stores/language.ts
+++ b/services/agora/src/stores/language.ts
@@ -199,13 +199,13 @@ export const useLanguageStore = defineStore("language", () => {
   }): Promise<boolean> {
     const originalLanguage = displayLanguage.value;
     try {
-      await updateLocale(newLanguage);
-
       if (authStore.isGuestOrLoggedIn) {
         await saveDisplayLanguageToBackend({
           newDisplayLanguage: newLanguage,
         });
       }
+
+      await updateLocale(newLanguage);
 
       return true;
     } catch (err) {

--- a/services/agora/src/utils/api/post/useConversationQuery.ts
+++ b/services/agora/src/utils/api/post/useConversationQuery.ts
@@ -108,6 +108,8 @@ export function useConversationQuery({
     ],
     queryFn: async () => {
       const slugId = toValue(conversationSlugId);
+      const targetLanguageCode = displayLanguage.value;
+      const requestedSpokenLanguages = [...spokenLanguages.value];
       const fetchedConversation = await fetchConversationBySlugIdWithDisplayContent({
         postSlugId: slugId,
         loadPersonalizedData: isGuestOrLoggedIn.value,
@@ -119,8 +121,8 @@ export function useConversationQuery({
       queryClient.setQueryData<ConversationContentFetchResponse>(
         getConversationDisplayContentQueryKey({
           conversationSlugId: slugId,
-          targetLanguageCode: displayLanguage.value,
-          spokenLanguages: spokenLanguages.value,
+          targetLanguageCode,
+          spokenLanguages: requestedSpokenLanguages,
         }),
         fetchedConversation.displayContent
       );
@@ -130,8 +132,8 @@ export function useConversationQuery({
             conversationSlugId: slugId,
             contentId: fetchedConversation.displayContent.contentId,
             mode: fetchedConversation.displayContent.mode,
-            targetLanguageCode: displayLanguage.value,
-            spokenLanguages: spokenLanguages.value,
+            targetLanguageCode,
+            spokenLanguages: requestedSpokenLanguages,
           }),
           fetchedConversation.displayContent
         );

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1592,6 +1592,9 @@ server.after(() => {
                     twilioServiceSid: config.TWILIO_SERVICE_SID,
                     peppers: config.PEPPERS,
                     sessionLifetimeDays: config.SESSION_LIFETIME_DAYS,
+                    currentDisplayLanguage: getRequestDisplayLanguage({
+                        request,
+                    }),
                 });
             }
             return await doVerifyPhoneOtp();
@@ -1694,6 +1697,9 @@ server.after(() => {
                     code: request.body.code,
                     email: request.body.email,
                     sessionLifetimeDays: config.SESSION_LIFETIME_DAYS,
+                    currentDisplayLanguage: getRequestDisplayLanguage({
+                        request,
+                    }),
                 });
             }
             return await doVerifyEmailOtp();
@@ -2307,6 +2313,7 @@ server.after(() => {
                 votingAction: request.body.chosenOption,
                 userAgent: request.headers["user-agent"] ?? "Unknown device",
                 now: now,
+                currentDisplayLanguage: getRequestDisplayLanguage({ request }),
                 returnIsUserClustered: request.body.returnIsUserClustered,
             });
             reply.send(castVoteResponse);
@@ -2333,6 +2340,7 @@ server.after(() => {
                 didWrite,
                 userAgent: request.headers["user-agent"] ?? "Unknown device",
                 now,
+                currentDisplayLanguage: getRequestDisplayLanguage({ request }),
             });
             if (!participationCheck.success) {
                 return participationCheck;
@@ -2640,6 +2648,7 @@ server.after(() => {
                 didWrite: didWrite,
                 userAgent: request.headers["user-agent"] ?? "Unknown device",
                 now: now,
+                currentDisplayLanguage: getRequestDisplayLanguage({ request }),
                 isSeed: false,
                 googleCloudCredentials,
                 voteBuffer: voteBuffer,
@@ -2663,7 +2672,7 @@ server.after(() => {
             const headerDisplayLanguage = getRequestDisplayLanguage({
                 request,
             });
-            const languagePreferences = deviceStatus.isLoggedIn
+            const languagePreferences = deviceStatus.isKnown
                 ? await getLanguagePreferences({
                       db,
                       userId: deviceStatus.userId,
@@ -2854,7 +2863,7 @@ server.after(() => {
             const headerDisplayLanguage = getRequestDisplayLanguage({
                 request,
             });
-            const languagePreferences = deviceStatus.isLoggedIn
+            const languagePreferences = deviceStatus.isKnown
                 ? await getLanguagePreferences({
                       db,
                       userId: deviceStatus.userId,
@@ -3646,7 +3655,7 @@ server.after(() => {
             const headerDisplayLanguage = getRequestDisplayLanguage({
                 request,
             });
-            const languagePreferences = deviceStatus.isLoggedIn
+            const languagePreferences = deviceStatus.isKnown
                 ? await getLanguagePreferences({
                       db,
                       userId: deviceStatus.userId,
@@ -3806,7 +3815,7 @@ server.after(() => {
             const headerDisplayLanguage = getRequestDisplayLanguage({
                 request,
             });
-            const languagePreferences = deviceStatus.isLoggedIn
+            const languagePreferences = deviceStatus.isKnown
                 ? await getLanguagePreferences({
                       db,
                       userId: deviceStatus.userId,
@@ -3941,6 +3950,7 @@ server.after(() => {
                 didWrite,
                 userAgent: request.headers["user-agent"] ?? "Unknown device",
                 now: nowZeroMs(),
+                currentDisplayLanguage: getRequestDisplayLanguage({ request }),
                 valkey: queueValkeyRef.current,
             });
         },
@@ -3962,6 +3972,7 @@ server.after(() => {
                 didWrite,
                 userAgent: request.headers["user-agent"] ?? "Unknown device",
                 now: nowZeroMs(),
+                currentDisplayLanguage: getRequestDisplayLanguage({ request }),
                 valkey: queueValkeyRef.current,
             });
         },
@@ -4132,6 +4143,9 @@ server.after(() => {
                     axiosVerificatorSvc,
                     userAgent,
                     sessionLifetimeDays: config.SESSION_LIFETIME_DAYS,
+                    currentDisplayLanguage: getRequestDisplayLanguage({
+                        request,
+                    }),
                 });
             return verificationStatusAndNullifier;
         },
@@ -4158,6 +4172,7 @@ server.after(() => {
                 userAgent: request.headers["user-agent"] ?? "Unknown device",
                 now,
                 sessionLifetimeDays: config.SESSION_LIFETIME_DAYS,
+                currentDisplayLanguage: getRequestDisplayLanguage({ request }),
             });
         },
     });
@@ -5258,6 +5273,9 @@ server.after(() => {
                 didWrite,
                 now,
             });
+            const headerDisplayLanguage = getRequestDisplayLanguage({
+                request,
+            });
             const requesterUserId = deviceStatus.isKnown
                 ? deviceStatus.userId
                 : (
@@ -5266,23 +5284,16 @@ server.after(() => {
                           didWrite,
                           now,
                           userAgent,
+                          currentDisplayLanguage: headerDisplayLanguage,
                       })
                   ).userId;
-            const headerDisplayLanguage = getRequestDisplayLanguage({
-                request,
+            const languagePreferences = await getLanguagePreferences({
+                db,
+                userId: requesterUserId,
+                request: {
+                    currentDisplayLanguage: headerDisplayLanguage,
+                },
             });
-            const languagePreferences = deviceStatus.isLoggedIn
-                ? await getLanguagePreferences({
-                      db,
-                      userId: deviceStatus.userId,
-                      request: {
-                          currentDisplayLanguage: headerDisplayLanguage,
-                      },
-                  })
-                : {
-                      displayLanguage: headerDisplayLanguage,
-                      spokenLanguages: [headerDisplayLanguage],
-                  };
 
             const preferredContentTranslation =
                 await getPreferredContentTranslationAvailabilityForConversation({
@@ -5404,6 +5415,9 @@ server.after(() => {
                           didWrite,
                           now,
                           userAgent,
+                          currentDisplayLanguage: getRequestDisplayLanguage({
+                              request,
+                          }),
                       })
                   ).userId;
 

--- a/services/api/src/service/auth.ts
+++ b/services/api/src/service/auth.ts
@@ -23,6 +23,7 @@ import {
     phoneTable,
     userTable,
     userDisplayLanguageTable,
+    userSpokenLanguagesTable,
 } from "@/shared-backend/schema.js";
 import { nowZeroMs } from "@/shared/util.js";
 import type {
@@ -237,6 +238,7 @@ async function finalizePhoneOtpSuccess({
     resultOtp,
     now,
     sessionLifetimeDays,
+    currentDisplayLanguage,
 }: {
     db: PostgresDatabase;
     authResult: Exclude<AuthResult, { type: "associated_with_another_user" }>;
@@ -251,6 +253,7 @@ async function finalizePhoneOtpSuccess({
     };
     now: Date;
     sessionLifetimeDays: number;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }): Promise<VerifyOtp200> {
     return await db.transaction(async (tx) => {
         const verifyResult = await registerOrLoginWithPhoneNumber({
@@ -265,6 +268,7 @@ async function finalizePhoneOtpSuccess({
             userAgent: resultOtp.userAgent,
             now,
             sessionLifetimeDays,
+            currentDisplayLanguage,
         });
         await resetPhoneOtpDestinationState({
             db: tx,
@@ -285,6 +289,7 @@ async function finalizeEmailOtpSuccess({
     now,
     sessionLifetimeDays,
     emailReachability,
+    currentDisplayLanguage,
 }: {
     db: PostgresDatabase;
     authResult: Exclude<AuthResult, { type: "associated_with_another_user" }>;
@@ -295,6 +300,7 @@ async function finalizeEmailOtpSuccess({
     now: Date;
     sessionLifetimeDays: number;
     emailReachability: ReacherIsReachable | null;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }): Promise<VerifyOtp200> {
     return await db.transaction(async (tx) => {
         const verifyResult = await registerOrLoginWithEmail({
@@ -306,6 +312,7 @@ async function finalizeEmailOtpSuccess({
             now,
             sessionLifetimeDays,
             emailReachability,
+            currentDisplayLanguage,
         });
         await resetEmailOtpDestinationState({
             db: tx,
@@ -328,11 +335,13 @@ interface VerifyOtpProps {
     peppers: string[];
     sessionLifetimeDays: number;
     now: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 interface RegisterWithPhoneNumberProps {
     db: PostgresDatabase;
     didWrite: string;
+    now: Date;
     lastTwoDigits: number;
     countryCallingCode: string;
     phoneCountryCode?: CountryCode;
@@ -341,6 +350,7 @@ interface RegisterWithPhoneNumberProps {
     userAgent: string;
     userId: string;
     sessionExpiry: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 interface RegisterWithoutVerificationProps {
@@ -348,17 +358,20 @@ interface RegisterWithoutVerificationProps {
     didWrite: string;
     now: Date;
     userAgent: string;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 interface RegisterWithZKPProps {
     db: PostgresDatabase;
     didWrite: string;
+    now: Date;
     citizenship: string;
     nullifier: string;
     sex: string;
     userAgent: string;
     userId: string;
     sessionExpiry: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 interface LoginProps {
@@ -383,6 +396,69 @@ interface LoginNewDeviceWithZKPProps {
     userAgent: string;
     userId: string;
     sessionExpiry: Date;
+}
+
+async function insertInitialLanguagePreferencesForNewUser({
+    db,
+    userId,
+    currentDisplayLanguage,
+    now,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
+    now: Date;
+}): Promise<void> {
+    await db
+        .insert(userDisplayLanguageTable)
+        .values({
+            userId,
+            languageCode: currentDisplayLanguage,
+            createdAt: now,
+            updatedAt: now,
+        });
+
+    await db
+        .insert(userSpokenLanguagesTable)
+        .values({
+            userId,
+            languageCode: currentDisplayLanguage,
+            createdAt: now,
+        });
+}
+
+export async function createUserWithInitialLanguagePreferencesIfMissing({
+    db,
+    userId,
+    currentDisplayLanguage,
+    now,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
+    now: Date;
+}): Promise<boolean> {
+    const username = await generateUnusedRandomUsername({ db });
+    const insertedUser = await db
+        .insert(userTable)
+        .values({
+            username,
+            id: userId,
+        })
+        .onConflictDoNothing({ target: userTable.id })
+        .returning({ id: userTable.id });
+
+    if (insertedUser.length === 0) {
+        return false;
+    }
+
+    await insertInitialLanguagePreferencesForNewUser({
+        db,
+        userId,
+        currentDisplayLanguage,
+        now,
+    });
+    return true;
 }
 
 interface GetPhoneAuthenticationTypeByNumber {
@@ -471,6 +547,7 @@ interface RegisterOrLoginWithPhoneNumberBaseProps {
     userAgent: string;
     now: Date;
     sessionLifetimeDays: number;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 type RegisterOrLoginWithPhoneNumberProps =
@@ -565,7 +642,9 @@ async function registerOrLoginWithPhoneNumber(
                 pepperVersion: pepperVersion,
                 userAgent: userAgent,
                 userId: props.userId,
+                now,
                 sessionExpiry: loginSessionExpiry,
+                currentDisplayLanguage: props.currentDisplayLanguage,
             });
             return {
                 success: true,
@@ -640,6 +719,7 @@ export async function verifyPhoneOtp({
     twilioServiceSid,
     peppers,
     sessionLifetimeDays,
+    currentDisplayLanguage,
     now: providedNow,
 }: VerifyOtpProps): Promise<VerifyOtp200> {
     if (
@@ -806,6 +886,7 @@ export async function verifyPhoneOtp({
                     resultOtp: resultOtp[0],
                     now,
                     sessionLifetimeDays,
+                    currentDisplayLanguage,
                 });
             default:
                 log.error(
@@ -827,6 +908,7 @@ export async function verifyPhoneOtp({
             resultOtp: resultOtp[0],
             now,
             sessionLifetimeDays,
+            currentDisplayLanguage,
         });
     } else {
         await updateCodeGuessAttemptAmount(
@@ -885,6 +967,7 @@ export async function updateCodeGuessAttemptAmount(
 export async function registerWithPhoneNumber({
     db,
     didWrite,
+    now,
     lastTwoDigits,
     phoneCountryCode,
     countryCallingCode,
@@ -893,29 +976,22 @@ export async function registerWithPhoneNumber({
     userAgent,
     userId,
     sessionExpiry,
+    currentDisplayLanguage,
 }: RegisterWithPhoneNumberProps): Promise<void> {
     log.info("Register with phone number");
     await db.transaction(async (tx) => {
         // Note: OTP expiration happens at registerOrLoginWithPhoneNumber entry point
         // to prevent race conditions across all auth paths
 
-        // Check if user already exists (credential upgrade case: user logged in
-        // with another credential and is adding phone)
-        const existingUser = await tx
-            .select({ id: userTable.id })
-            .from(userTable)
-            .where(eq(userTable.id, userId))
-            .limit(1);
+        const wasUserCreated =
+            await createUserWithInitialLanguagePreferencesIfMissing({
+                db: tx,
+                userId,
+                currentDisplayLanguage,
+                now,
+            });
 
-        if (existingUser.length === 0) {
-            // New user registration
-            const username = await generateUnusedRandomUsername({
-                db: db,
-            });
-            await tx.insert(userTable).values({
-                username,
-                id: userId,
-            });
+        if (wasUserCreated) {
             await tx.insert(deviceTable).values({
                 userId: userId,
                 didWrite: didWrite,
@@ -928,7 +1004,7 @@ export async function registerWithPhoneNumber({
                 .update(deviceTable)
                 .set({
                     sessionExpiry: sessionExpiry,
-                    updatedAt: nowZeroMs(),
+                    updatedAt: now,
                 })
                 .where(eq(deviceTable.didWrite, didWrite));
         }
@@ -954,6 +1030,7 @@ export async function createGuestUser({
     didWrite,
     now,
     userAgent,
+    currentDisplayLanguage,
 }: RegisterWithoutVerificationProps): Promise<{
     userId: string;
     wasUserJustCreated: boolean;
@@ -981,6 +1058,12 @@ export async function createGuestUser({
                 // might happen when a user clicks multiple times on votes for the first time
                 tx.rollback(); // will throw
             }
+            await insertInitialLanguagePreferencesForNewUser({
+                db: tx,
+                userId,
+                currentDisplayLanguage,
+                now,
+            });
             return { userId: userId, wasUserJustCreated: true };
         });
     } catch (e) {
@@ -1007,30 +1090,26 @@ export async function createGuestUser({
 export async function registerWithZKP({
     db,
     didWrite,
+    now,
     citizenship,
     nullifier,
     sex,
     userAgent,
     userId,
     sessionExpiry,
+    currentDisplayLanguage,
 }: RegisterWithZKPProps): Promise<void> {
     log.info("Register with ZKP");
     await db.transaction(async (tx) => {
-        // Check if user already exists (credential upgrade case: user logged in
-        // with another credential and is adding Rarimo)
-        const existingUser = await tx
-            .select({ id: userTable.id })
-            .from(userTable)
-            .where(eq(userTable.id, userId))
-            .limit(1);
-
-        if (existingUser.length === 0) {
-            // New user registration
-            const username = await generateUnusedRandomUsername({ db: db });
-            await tx.insert(userTable).values({
-                username,
-                id: userId,
+        const wasUserCreated =
+            await createUserWithInitialLanguagePreferencesIfMissing({
+                db: tx,
+                userId,
+                currentDisplayLanguage,
+                now,
             });
+
+        if (wasUserCreated) {
             await tx.insert(deviceTable).values({
                 userId: userId,
                 didWrite: didWrite,
@@ -1043,7 +1122,7 @@ export async function registerWithZKP({
                 .update(deviceTable)
                 .set({
                     sessionExpiry: sessionExpiry,
-                    updatedAt: nowZeroMs(),
+                    updatedAt: now,
                 })
                 .where(eq(deviceTable.didWrite, didWrite));
         }
@@ -2841,22 +2920,26 @@ async function updateEmailCodeGuessAttemptAmount({
 interface RegisterWithEmailProps {
     db: PostgresDatabase;
     didWrite: string;
+    now: Date;
     email: string;
     userAgent: string;
     userId: string;
     sessionExpiry: Date;
     emailReachability: ReacherIsReachable | null;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 // WARN: we assume the OTP was verified AND EXPIRED at registerOrLoginWithEmail entry point
 async function registerWithEmail({
     db,
     didWrite,
+    now,
     email,
     userAgent,
     userId,
     sessionExpiry,
     emailReachability,
+    currentDisplayLanguage,
 }: RegisterWithEmailProps): Promise<void> {
     const canonicalEmail = normalizeEmail(email);
 
@@ -2865,23 +2948,15 @@ async function registerWithEmail({
         // Note: OTP expiration happens at registerOrLoginWithEmail entry point
         // to prevent race conditions across all auth paths
 
-        // Check if user already exists (credential upgrade case: user logged in
-        // with another credential and is adding email)
-        const existingUser = await tx
-            .select({ id: userTable.id })
-            .from(userTable)
-            .where(eq(userTable.id, userId))
-            .limit(1);
+        const wasUserCreated =
+            await createUserWithInitialLanguagePreferencesIfMissing({
+                db: tx,
+                userId,
+                currentDisplayLanguage,
+                now,
+            });
 
-        if (existingUser.length === 0) {
-            // New user registration
-            const username = await generateUnusedRandomUsername({
-                db: db,
-            });
-            await tx.insert(userTable).values({
-                username,
-                id: userId,
-            });
+        if (wasUserCreated) {
             await tx.insert(deviceTable).values({
                 userId: userId,
                 didWrite: didWrite,
@@ -2894,7 +2969,7 @@ async function registerWithEmail({
                 .update(deviceTable)
                 .set({
                     sessionExpiry: sessionExpiry,
-                    updatedAt: nowZeroMs(),
+                    updatedAt: now,
                 })
                 .where(eq(deviceTable.didWrite, didWrite));
         }
@@ -2916,6 +2991,7 @@ interface RegisterOrLoginWithEmailBaseProps {
     now: Date;
     sessionLifetimeDays: number;
     emailReachability: ReacherIsReachable | null;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 type RegisterOrLoginWithEmailProps =
@@ -2996,8 +3072,10 @@ async function registerOrLoginWithEmail(
                 email,
                 userAgent,
                 userId: props.userId,
+                now,
                 sessionExpiry: loginSessionExpiry,
                 emailReachability,
+                currentDisplayLanguage: props.currentDisplayLanguage,
             });
             return {
                 success: true,
@@ -3069,6 +3147,7 @@ interface VerifyEmailOtpProps {
     email: string;
     sessionLifetimeDays: number;
     now: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 export async function verifyEmailOtp({
@@ -3078,6 +3157,7 @@ export async function verifyEmailOtp({
     code,
     email,
     sessionLifetimeDays,
+    currentDisplayLanguage,
     now: providedNow,
 }: VerifyEmailOtpProps): Promise<VerifyOtp200> {
     const now = providedNow;
@@ -3190,6 +3270,7 @@ export async function verifyEmailOtp({
             now,
             sessionLifetimeDays,
             emailReachability: resultOtp[0].emailReachability,
+            currentDisplayLanguage,
         });
     } else {
         await updateEmailCodeGuessAttemptAmount({

--- a/services/api/src/service/authUtil.ts
+++ b/services/api/src/service/authUtil.ts
@@ -20,6 +20,7 @@ import type {
     DeviceLoginStatusExtended,
     ParticipationMode,
 } from "@/shared/types/zod.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 
 // Internal type extending the API type with sessionExpiry for the isKnown=true case.
 // sessionExpiry is internal-only — NOT exposed in the check-login-status API response.
@@ -114,6 +115,7 @@ interface GetOrRegisterUserIdFromDeviceStatusProps {
     participationMode: ParticipationMode;
     userAgent: string;
     now: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 export async function getOrRegisterUserIdFromDeviceStatus({
@@ -122,6 +124,7 @@ export async function getOrRegisterUserIdFromDeviceStatus({
     participationMode,
     userAgent,
     now,
+    currentDisplayLanguage,
 }: GetOrRegisterUserIdFromDeviceStatusProps): Promise<string> {
     const deviceStatus = await getDeviceStatus({
         db,
@@ -158,6 +161,7 @@ export async function getOrRegisterUserIdFromDeviceStatus({
             didWrite,
             now,
             userAgent,
+            currentDisplayLanguage,
         });
         return userId;
     });

--- a/services/api/src/service/comment.ts
+++ b/services/api/src/service/comment.ts
@@ -2682,7 +2682,7 @@ async function getPostIdFromPostSlugId(
     return postId;
 }
 
-interface PostNewOpinionProps {
+interface PostNewOpinionBaseProps {
     db: PostgresJsDatabase;
     tx?: PostgresJsDatabase;
     commentBody: string;
@@ -2697,7 +2697,11 @@ interface PostNewOpinionProps {
     voteBuffer?: VoteBuffer;
     realtimeSSEManager?: RealtimeSSEManager;
     onCreatedOpinionSource?: (source: OpinionContentSource) => void;
-    conversationMetadata?: {
+}
+
+interface PostNewOpinionWithConversationMetadataProps {
+    currentDisplayLanguage?: never;
+    conversationMetadata: {
         conversationId: number;
         conversationContentId: number;
         conversationAuthorId: string;
@@ -2709,23 +2713,36 @@ interface PostNewOpinionProps {
     };
 }
 
-export async function postNewOpinion({
-    db,
-    tx,
-    commentBody,
-    opinionPlainText,
-    conversationSlugId,
-    didWrite,
-    userAgent,
-    now,
-    isSeed,
-    googleCloudCredentials,
-    useGoogleLanguageDetection,
-    voteBuffer,
-    realtimeSSEManager,
-    onCreatedOpinionSource,
-    conversationMetadata,
-}: PostNewOpinionProps): Promise<CreateCommentResponse> {
+interface PostNewOpinionWithParticipationCheckProps {
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
+    conversationMetadata?: undefined;
+}
+
+type PostNewOpinionProps = PostNewOpinionBaseProps &
+    (
+        | PostNewOpinionWithConversationMetadataProps
+        | PostNewOpinionWithParticipationCheckProps
+    );
+
+export async function postNewOpinion(
+    props: PostNewOpinionProps,
+): Promise<CreateCommentResponse> {
+    const {
+        db,
+        tx,
+        opinionPlainText,
+        conversationSlugId,
+        didWrite,
+        userAgent,
+        now,
+        isSeed,
+        googleCloudCredentials,
+        useGoogleLanguageDetection,
+        voteBuffer,
+        realtimeSSEManager,
+        onCreatedOpinionSource,
+    } = props;
+    let { commentBody } = props;
     interface ParticipationContext {
         success: true;
         conversationId: number;
@@ -2765,13 +2782,13 @@ export async function postNewOpinion({
     const participationContext:
         | ParticipationContext
         | Extract<CreateCommentResponse, { success: false }> =
-        conversationMetadata !== undefined
+        props.conversationMetadata !== undefined
             ? {
                   success: true,
-                  conversationId: conversationMetadata.conversationId,
+                  conversationId: props.conversationMetadata.conversationId,
                   conversationContentId:
-                      conversationMetadata.conversationContentId,
-                  participantId: conversationMetadata.conversationAuthorId,
+                      props.conversationMetadata.conversationContentId,
+                  participantId: props.conversationMetadata.conversationAuthorId,
               }
             : await (async () => {
                   const participationCheck =
@@ -2781,6 +2798,8 @@ export async function postNewOpinion({
                           didWrite,
                           userAgent,
                           now,
+                          currentDisplayLanguage:
+                              props.currentDisplayLanguage,
                       });
                   if (!participationCheck.success) {
                       return participationCheck;
@@ -2875,7 +2894,7 @@ export async function postNewOpinion({
             .where(eq(userTable.id, participationContext.participantId));
 
         const participantUsername =
-            conversationMetadata?.conversationAuthorUsername ??
+            props.conversationMetadata?.conversationAuthorUsername ??
             (await (async (): Promise<string> => {
                 const participantRows = await transactionDb
                     .select({ username: userTable.username })

--- a/services/api/src/service/participationGate.ts
+++ b/services/api/src/service/participationGate.ts
@@ -8,6 +8,7 @@ import type {
     ParticipationMode,
     SurveyGateStatus,
 } from "@/shared/types/zod.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 import { useCommonPost } from "./common.js";
 import * as authUtilService from "./authUtil.js";
 import * as zupassService from "./zupass.js";
@@ -197,6 +198,7 @@ export async function checkConversationParticipation({
     didWrite,
     userAgent,
     now,
+    currentDisplayLanguage,
     requireCompletedSurvey = true,
     skipLockCheck = false,
     skipClosedCheck = false,
@@ -206,6 +208,7 @@ export async function checkConversationParticipation({
     didWrite: string;
     userAgent: string;
     now: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
     requireCompletedSurvey?: boolean;
     skipLockCheck?: boolean;
     skipClosedCheck?: boolean;
@@ -310,6 +313,7 @@ export async function checkConversationParticipation({
                     participationMode: metadata.participationMode,
                     userAgent,
                     now,
+                    currentDisplayLanguage,
                 });
         } else {
             throw httpErrors.unauthorized(

--- a/services/api/src/service/participationGateFlow.test.ts
+++ b/services/api/src/service/participationGateFlow.test.ts
@@ -106,6 +106,7 @@ function createParams(
         didWrite: "did:test:1",
         userAgent: "Vitest",
         now: new Date("2026-01-01T00:00:00.000Z"),
+        currentDisplayLanguage: "en",
         ...overrides,
     };
 }

--- a/services/api/src/service/rarimo.ts
+++ b/services/api/src/service/rarimo.ts
@@ -11,6 +11,7 @@ import {
     zodZKProof,
     zodStatusResponse,
 } from "@/shared/types/zod.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 import { type AxiosInstance } from "axios";
 import { type PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
 import { and, eq } from "drizzle-orm";
@@ -115,6 +116,7 @@ interface VerifyUserStatusProps {
     axiosVerificatorSvc: AxiosInstance;
     userAgent: string;
     sessionLifetimeDays: number;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 export async function isLoggedInOrExistsAndAssociatedWithNoNullifier({
@@ -279,6 +281,7 @@ export async function verifyUserStatusAndAuthenticate({
     axiosVerificatorSvc,
     userAgent,
     sessionLifetimeDays,
+    currentDisplayLanguage,
 }: VerifyUserStatusProps): Promise<VerifyUserStatusAndAuthenticate200> {
     const now = nowZeroMs();
     // TODO: move this check to verifyUCAN directly in the controller:
@@ -378,7 +381,9 @@ export async function verifyUserStatusAndAuthenticate({
                     sex: sex,
                     userAgent,
                     userId: authResult.userId,
+                    now,
                     sessionExpiry: loginSessionExpiry,
+                    currentDisplayLanguage,
                 });
                 break;
             case "login_known_device":

--- a/services/api/src/service/survey.test.ts
+++ b/services/api/src/service/survey.test.ts
@@ -264,6 +264,7 @@ describe("saveSurveyAnswer", () => {
             didWrite: "did:test:1",
             userAgent: "Vitest",
             now: new Date("2026-01-01T00:00:00.000Z"),
+            currentDisplayLanguage: "en",
         });
 
         expect(result).toEqual({
@@ -276,6 +277,7 @@ describe("saveSurveyAnswer", () => {
             didWrite: "did:test:1",
             userAgent: "Vitest",
             now: new Date("2026-01-01T00:00:00.000Z"),
+            currentDisplayLanguage: "en",
             requireCompletedSurvey: false,
         });
         expect(transactionMock).not.toHaveBeenCalled();
@@ -302,6 +304,7 @@ describe("withdrawSurveyResponse", () => {
             didWrite: "did:test:2",
             userAgent: "Vitest",
             now: new Date("2026-01-02T00:00:00.000Z"),
+            currentDisplayLanguage: "es",
         });
 
         expect(result).toEqual({
@@ -314,6 +317,7 @@ describe("withdrawSurveyResponse", () => {
             didWrite: "did:test:2",
             userAgent: "Vitest",
             now: new Date("2026-01-02T00:00:00.000Z"),
+            currentDisplayLanguage: "es",
             requireCompletedSurvey: false,
         });
         expect(transactionMock).not.toHaveBeenCalled();

--- a/services/api/src/service/survey.ts
+++ b/services/api/src/service/survey.ts
@@ -2499,6 +2499,7 @@ export async function saveSurveyAnswer({
     didWrite,
     userAgent,
     now,
+    currentDisplayLanguage,
     valkey,
 }: {
     db: PostgresJsDatabase;
@@ -2508,6 +2509,7 @@ export async function saveSurveyAnswer({
     didWrite: string;
     userAgent: string;
     now: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
     valkey?: Valkey;
 }): Promise<
     | {
@@ -2526,6 +2528,7 @@ export async function saveSurveyAnswer({
         didWrite,
         userAgent,
         now,
+        currentDisplayLanguage,
         requireCompletedSurvey: false,
     });
     if (!participationCheck.success) {
@@ -2829,6 +2832,7 @@ export async function withdrawSurveyResponse({
     didWrite,
     userAgent,
     now,
+    currentDisplayLanguage,
     valkey,
 }: {
     db: PostgresJsDatabase;
@@ -2836,6 +2840,7 @@ export async function withdrawSurveyResponse({
     didWrite: string;
     userAgent: string;
     now: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
     valkey?: Valkey;
 }): Promise<
     | {
@@ -2853,6 +2858,7 @@ export async function withdrawSurveyResponse({
         didWrite,
         userAgent,
         now,
+        currentDisplayLanguage,
         requireCompletedSurvey: false,
     });
     if (!participationCheck.success) {

--- a/services/api/src/service/voting.ts
+++ b/services/api/src/service/voting.ts
@@ -10,6 +10,7 @@ import type {
 } from "@/shared/types/dto.js";
 import type { ImportPolisResults } from "@/shared/types/polis.js";
 import type { VotingAction, VotingOption } from "@/shared/types/zod.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 import { nowZeroMs } from "@/shared/util.js";
 import type {
     OpinionContentIdPerOpinionId,
@@ -75,6 +76,7 @@ interface CastVoteForOpinionSlugIdProps {
     votingAction: VotingAction;
     userAgent: string;
     now: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
     returnIsUserClustered?: boolean;
 }
 
@@ -470,6 +472,7 @@ export async function castVoteForOpinionSlugId({
     votingAction,
     userAgent,
     now,
+    currentDisplayLanguage,
     returnIsUserClustered,
 }: CastVoteForOpinionSlugIdProps): Promise<CastVoteResponse> {
     const { conversationSlugId, conversationId } =
@@ -483,6 +486,7 @@ export async function castVoteForOpinionSlugId({
         didWrite,
         userAgent,
         now,
+        currentDisplayLanguage,
     });
     if (!participationCheck.success) {
         return participationCheck;

--- a/services/api/src/service/zupass.ts
+++ b/services/api/src/service/zupass.ts
@@ -10,6 +10,7 @@ import type {
     EventSlug,
     DeviceLoginStatusExtended,
 } from "@/shared/types/zod.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 import { type PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
 import { and, eq } from "drizzle-orm";
 import { determineAuthType } from "./auth/core/stateHelpers.js";
@@ -20,8 +21,8 @@ import type { JSONBoundConfig, JSONRevealedClaims } from "@pcd/gpc";
 import { log } from "@/app.js";
 import { getZupassEventId, getZupassSignerPublicKey } from "./zupassConfig.js";
 import * as authUtilService from "./authUtil.js";
-import { generateUnusedRandomUsername } from "./account.js";
 import { mergeGuestIntoVerifiedUser } from "./merge.js";
+import { createUserWithInitialLanguagePreferencesIfMissing } from "./auth.js";
 
 // Dynamic import wrapper for gpcVerify to work around broken ESM in @pcd/gpc
 async function gpcVerify(
@@ -42,6 +43,7 @@ interface VerifyEventTicketProps {
     userAgent: string;
     now: Date;
     sessionLifetimeDays: number;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 /**
@@ -58,6 +60,7 @@ export async function verifyEventTicket({
     userAgent,
     now,
     sessionLifetimeDays,
+    currentDisplayLanguage,
 }: VerifyEventTicketProps): Promise<VerifyEventTicket200> {
     try {
         // Step 0: Parse and validate proof data structure
@@ -491,6 +494,8 @@ export async function verifyEventTicket({
                             userAgent,
                             userId: authResult.userId,
                             sessionExpiry,
+                            currentDisplayLanguage,
+                            now,
                         });
                         log.info(
                             { userId: authResult.userId, nullifier, eventSlug },
@@ -797,6 +802,8 @@ interface RegisterWithZupassProps {
     userAgent: string;
     userId: string;
     sessionExpiry: Date;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
+    now: Date;
 }
 
 interface LoginNewDeviceWithZupassProps {
@@ -826,20 +833,35 @@ export async function registerWithZupass({
     userAgent,
     userId,
     sessionExpiry,
+    currentDisplayLanguage,
+    now,
 }: RegisterWithZupassProps): Promise<void> {
     log.info("[Zupass] Register with Zupass");
     await db.transaction(async (tx) => {
-        const username = await generateUnusedRandomUsername({ db: db });
-        await tx.insert(userTable).values({
-            username,
-            id: userId,
-        });
-        await tx.insert(deviceTable).values({
-            userId: userId,
-            didWrite: didWrite,
-            userAgent: userAgent,
-            sessionExpiry: sessionExpiry,
-        });
+        const wasUserCreated =
+            await createUserWithInitialLanguagePreferencesIfMissing({
+                db: tx,
+                userId,
+                currentDisplayLanguage,
+                now,
+            });
+
+        if (wasUserCreated) {
+            await tx.insert(deviceTable).values({
+                userId: userId,
+                didWrite: didWrite,
+                userAgent: userAgent,
+                sessionExpiry: sessionExpiry,
+            });
+        } else {
+            await tx
+                .update(deviceTable)
+                .set({
+                    sessionExpiry,
+                    updatedAt: now,
+                })
+                .where(eq(deviceTable.didWrite, didWrite));
+        }
         await tx.insert(eventTicketTable).values({
             userId: userId,
             provider: "zupass",

--- a/services/api/tests/authOtpThrottling.test.ts
+++ b/services/api/tests/authOtpThrottling.test.ts
@@ -36,6 +36,7 @@ const {
     otpPhoneDestinationStateTable,
     phoneTable,
     userTable,
+    userDisplayLanguageTable,
 } = schema;
 
 const SESSION_EXPIRY = new Date("2100-01-01T00:00:00.000Z");
@@ -110,6 +111,15 @@ describe("OTP destination throttling", () => {
             sessionExpiry: SESSION_EXPIRY,
         });
         return { userId };
+    }
+
+    async function expectNoDisplayLanguagePreferences(userId: string) {
+        const displayLanguages = await db
+            .select()
+            .from(userDisplayLanguageTable)
+            .where(eq(userDisplayLanguageTable.userId, userId));
+
+        expect(displayLanguages).toHaveLength(0);
     }
 
     function getWrongCode(actualCode: number): number {
@@ -201,6 +211,7 @@ describe("OTP destination throttling", () => {
             email,
             sessionLifetimeDays: 90,
             now: currentNow,
+            currentDisplayLanguage: "en",
         });
 
         expect(verifyResponse).toEqual({
@@ -272,6 +283,7 @@ describe("OTP destination throttling", () => {
             peppers: [process.env.PEPPERS!],
             sessionLifetimeDays: 90,
             now: currentNow,
+            currentDisplayLanguage: "en",
         });
 
         expect(verifyResponse).toEqual({
@@ -317,6 +329,7 @@ describe("OTP destination throttling", () => {
             email,
             sessionLifetimeDays: 90,
             now: currentNow,
+            currentDisplayLanguage: "en",
         });
 
         expect(wrongGuess.success).toBe(false);
@@ -507,6 +520,7 @@ describe("OTP destination throttling", () => {
                 email,
                 sessionLifetimeDays: 90,
                 now: currentNow,
+                currentDisplayLanguage: "en",
             });
         }
 
@@ -575,6 +589,7 @@ describe("OTP destination throttling", () => {
             email,
             sessionLifetimeDays: 90,
             now: currentNow,
+            currentDisplayLanguage: "en",
         });
 
         expect(successResponse.success).toBe(true);
@@ -588,6 +603,7 @@ describe("OTP destination throttling", () => {
             .where(eq(emailTable.userId, successResponse.userId));
 
         expect(storedEmail.email).toBe(normalizeEmail(email));
+        await expectNoDisplayLanguagePreferences(successResponse.userId);
 
         const [destinationState] = await db
             .select()
@@ -640,6 +656,7 @@ describe("OTP destination throttling", () => {
             peppers: [process.env.PEPPERS!],
             sessionLifetimeDays: 90,
             now: currentNow,
+            currentDisplayLanguage: "en",
         });
 
         expect(wrongGuess.success).toBe(false);
@@ -788,6 +805,7 @@ describe("OTP destination throttling", () => {
                 peppers: [process.env.PEPPERS!],
                 sessionLifetimeDays: 90,
                 now: currentNow,
+                currentDisplayLanguage: "en",
             });
         }
 
@@ -864,9 +882,14 @@ describe("OTP destination throttling", () => {
             peppers: [process.env.PEPPERS!],
             sessionLifetimeDays: 90,
             now: currentNow,
+            currentDisplayLanguage: "en",
         });
 
         expect(successResponse.success).toBe(true);
+        if (!successResponse.success) {
+            throw new Error("Expected successful phone verification");
+        }
+        await expectNoDisplayLanguagePreferences(successResponse.userId);
 
         const [destinationState] = await db
             .select()


### PR DESCRIPTION
## Summary
- persist initial language preferences only for newly-created guest or registered users
- use saved preferences for known guest devices instead of falling back to Accept-Language
- avoid frontend display-content cache races during language switches
- prevent project conversation mobile horizontal overflow

## Tests
- cd services/api && pnpm typecheck
- cd services/api && pnpm exec eslint src/index.ts src/service/auth.ts src/service/authUtil.ts src/service/participationGate.ts src/service/voting.ts src/service/comment.ts src/service/survey.ts src/service/rarimo.ts src/service/zupass.ts src/service/participationGateFlow.test.ts src/service/survey.test.ts
- cd services/api && pnpm test -- participationGateFlow.test.ts survey.test.ts authOtpThrottling.test.ts
- cd services/agora && pnpm exec eslint src/stores/language.ts src/utils/api/post/useConversationQuery.ts src/components/project/ProjectConversationView.vue
- cd services/agora && pnpm exec vue-tsc --noEmit
- git diff --check