### PR TITLE
fix: restore missed translation refactor follow-ups

### DIFF
--- a/services/agora/src/components/features/conversation/ConversationProjectContextPill.i18n.ts
+++ b/services/agora/src/components/features/conversation/ConversationProjectContextPill.i18n.ts
@@ -2,7 +2,7 @@ import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
 
 export interface ConversationProjectContextPillTranslations {
   partOfProject: string;
-  openProjectView: string;
+  openProject: string;
 }
 
 export const conversationProjectContextPillTranslations: Record<
@@ -11,46 +11,46 @@ export const conversationProjectContextPillTranslations: Record<
 > = {
   en: {
     partOfProject: "Part of",
-    openProjectView: "Open project view",
+    openProject: "Open",
   },
   ar: {
     partOfProject: "جزء من",
-    openProjectView: "افتح عرض المشروع",
+    openProject: "افتح",
   },
   es: {
     partOfProject: "Parte de",
-    openProjectView: "Abrir vista del proyecto",
+    openProject: "Abrir",
   },
   fa: {
     partOfProject: "بخشی از",
-    openProjectView: "باز کردن نمای پروژه",
+    openProject: "باز کردن",
   },
   he: {
     partOfProject: "חלק מתוך",
-    openProjectView: "פתח תצוגת פרויקט",
+    openProject: "פתח",
   },
   fr: {
     partOfProject: "Fait partie de",
-    openProjectView: "Ouvrir la vue projet",
+    openProject: "Ouvrir",
   },
   "zh-Hans": {
     partOfProject: "属于",
-    openProjectView: "打开项目视图",
+    openProject: "打开",
   },
   "zh-Hant": {
     partOfProject: "屬於",
-    openProjectView: "開啟專案視圖",
+    openProject: "開啟",
   },
   ja: {
     partOfProject: "所属プロジェクト",
-    openProjectView: "プロジェクト表示を開く",
+    openProject: "開く",
   },
   ky: {
     partOfProject: "Долбоордун бөлүгү",
-    openProjectView: "Долбоор көрүнүшүн ачуу",
+    openProject: "Ачуу",
   },
   ru: {
     partOfProject: "Часть проекта",
-    openProjectView: "Открыть вид проекта",
+    openProject: "Открыть",
   },
 };

--- a/services/agora/src/components/features/conversation/ConversationProjectContextPill.vue
+++ b/services/agora/src/components/features/conversation/ConversationProjectContextPill.vue
@@ -1,39 +1,62 @@
 <template>
-  <SpaLink :to="projectConversationRoute" class="project-context-pill">
+  <span
+    v-if="interactive"
+    class="project-context-pill"
+  >
     <span class="project-context-pill__label">
       {{ t("partOfProject") }}
       <strong class="project-context-pill__title">{{ projectTitle }}</strong>
     </span>
-    <span class="project-context-pill__cta">
-      {{ t("openProjectView") }}
+    <a
+      :href="projectConversationHref"
+      class="project-context-pill__cta"
+      target="_blank"
+      rel="noopener noreferrer"
+      @click.stop
+    >
+      {{ t("openProject") }}
       <q-icon name="mdi-open-in-new" size="0.9rem" aria-hidden="true" />
-    </span>
-  </SpaLink>
+    </a>
+  </span>
+  <span
+    v-else
+    class="project-context-text"
+    @click.stop.prevent
+  >
+    {{ t("partOfProject") }}
+    <strong class="project-context-text__title">{{ projectTitle }}</strong>
+  </span>
 </template>
 
 <script setup lang="ts">
-import SpaLink from "src/components/ui-library/SpaLink.vue";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { computed } from "vue";
-import type { RouteLocationRaw } from "vue-router";
+import { type RouteLocationRaw, useRouter } from "vue-router";
 
 import {
   type ConversationProjectContextPillTranslations,
   conversationProjectContextPillTranslations,
 } from "./ConversationProjectContextPill.i18n";
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   projectSlug: string;
   projectTitle: string;
   conversationSlugId: string;
-}>();
+  interactive?: boolean;
+}>(), {
+  interactive: true,
+});
 
 const { t } = useComponentI18n<ConversationProjectContextPillTranslations>(
   conversationProjectContextPillTranslations
 );
+const router = useRouter();
 const projectConversationRoute = computed<RouteLocationRaw>(() => ({
   path: `/project/${props.projectSlug}/conversation/${props.conversationSlugId}/`,
 }));
+const projectConversationHref = computed(
+  () => router.resolve(projectConversationRoute.value).href
+);
 </script>
 
 <style scoped lang="scss">
@@ -41,10 +64,11 @@ const projectConversationRoute = computed<RouteLocationRaw>(() => ({
   display: inline-flex;
   max-width: 100%;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.45rem;
   border: 1px solid rgba($primary, 0.22);
-  border-radius: 999px;
-  padding: 0.25rem 0.3rem 0.25rem 0.6rem;
+  border-radius: 6px;
+  padding-block: 0.25rem;
+  padding-inline: 0.55rem 0.35rem;
   background: rgba($primary, 0.08);
   color: rgba($ink-darkest, 0.72);
   font-size: 0.78rem;
@@ -58,23 +82,27 @@ const projectConversationRoute = computed<RouteLocationRaw>(() => ({
 }
 
 .project-context-pill:hover,
-.project-context-pill:focus-visible {
+.project-context-pill:focus-within {
   border-color: rgba($primary, 0.42);
   box-shadow: 0 0.35rem 0.9rem rgba($primary, 0.12);
-  outline: none;
   transform: translateY(-1px);
 }
 
 .project-context-pill__label {
   display: inline-flex;
+  flex: 1 1 auto;
   min-width: 0;
   align-items: center;
   gap: 0.25rem;
+  overflow: hidden;
 }
 
 .project-context-pill__title {
+  display: block;
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
-  max-width: min(15rem, 42vw);
+  max-width: min(16rem, 44vw);
   color: $ink-darkest;
   font-weight: var(--font-weight-bold);
   text-overflow: ellipsis;
@@ -86,20 +114,48 @@ const projectConversationRoute = computed<RouteLocationRaw>(() => ({
   flex: 0 0 auto;
   align-items: center;
   gap: 0.25rem;
-  border-radius: 999px;
+  border-radius: 4px;
   padding: 0.25rem 0.45rem;
   background: white;
   color: $primary;
   font-size: 0.72rem;
   font-weight: var(--font-weight-bold);
   box-shadow: inset 0 0 0 1px rgba($primary, 0.16);
+  text-decoration: none;
   white-space: nowrap;
+}
+
+.project-context-pill__cta:focus-visible {
+  outline: 2px solid rgba($primary, 0.36);
+  outline-offset: 2px;
+}
+
+.project-context-text {
+  display: inline;
+  max-width: 100%;
+  color: $color-text-weak;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.25;
+}
+
+.project-context-text__title {
+  color: $ink-darkest;
+  font-weight: var(--font-weight-semibold);
 }
 
 @media (max-width: 420px) {
   .project-context-pill {
-    width: 100%;
-    justify-content: space-between;
+    gap: 0.35rem;
+    padding-inline: 0.45rem 0.25rem;
+  }
+
+  .project-context-pill__title {
+    max-width: min(12rem, 36vw);
+  }
+
+  .project-context-pill__cta {
+    padding: 0.2rem 0.35rem;
   }
 }
 </style>

--- a/services/agora/src/components/features/conversation/ConversationTitle.vue
+++ b/services/agora/src/components/features/conversation/ConversationTitle.vue
@@ -1,31 +1,26 @@
 <template>
   <div class="title-section">
-    <ConversationChip
-      v-if="showChips && isPrivate"
-      :label="t('privateLabel')"
-      background-color="#333"
-    />
-    <ConversationChip
-      v-if="showChips && isMaxDiffConversation"
-      :label="t('prioritizationLabel')"
-      background-color="var(--q-primary)"
-      icon="mdi-sort-numeric-ascending"
-    />
-    <ConversationChip
-      v-if="showChips && externalSourceConfig !== null"
-      label="GitHub"
-      background-color="#24292f"
-      icon="mdi-github"
-    />
-    <ConversationProjectContextPill
-      v-if="showChips && projectContext !== undefined"
-      :project-slug="projectContext.projectSlug"
-      :project-title="displayedProjectTitle"
-      :conversation-slug-id="projectContext.conversationSlugId"
-    />
-    <h1 class="conversation-title" :class="`conversation-title--${size}`">
-      {{ title }}
-    </h1>
+    <div v-if="showProjectContextRow" class="conversation-context-row">
+      <ConversationProjectContextPill
+        v-if="projectContext !== undefined"
+        :project-slug="projectContext.projectSlug"
+        :project-title="displayedProjectTitle"
+        :conversation-slug-id="projectContext.conversationSlugId"
+        :interactive="projectContextInteractive"
+      />
+    </div>
+    <div class="conversation-title-row">
+      <ConversationChip
+        v-for="chip in inlineConversationChips"
+        :key="chip.label"
+        :label="chip.label"
+        :background-color="chip.backgroundColor"
+        :icon="chip.icon"
+      />
+      <h1 class="conversation-title" :class="`conversation-title--${size}`">
+        {{ title }}
+      </h1>
+    </div>
   </div>
 </template>
 
@@ -47,6 +42,12 @@ import {
   conversationTitleTranslations,
 } from "./ConversationTitle.i18n";
 
+interface ConversationTitleChip {
+  label: string;
+  backgroundColor: string;
+  icon: string | undefined;
+}
+
 const props = withDefaults(defineProps<{
   isPrivate: boolean;
   title: string;
@@ -55,8 +56,10 @@ const props = withDefaults(defineProps<{
   externalSourceConfig: ExternalSourceConfig | null;
   projectContext: ConversationProjectContext | undefined;
   projectContextTitleMode: ContentTranslationDisplayMode;
+  projectContextInteractive?: boolean;
   showChips?: boolean;
 }>(), {
+  projectContextInteractive: true,
   showChips: true,
 });
 
@@ -67,6 +70,45 @@ const isMaxDiffConversation = computed(
   () =>
     props.conversationTypeConfig.conversationType === "ranking" &&
     props.conversationTypeConfig.rankingMode === "bws"
+);
+const showProjectContextRow = computed(
+  () => props.showChips && props.projectContext !== undefined
+);
+const conversationChips = computed<ConversationTitleChip[]>(() => {
+  if (!props.showChips) {
+    return [];
+  }
+
+  const chips: ConversationTitleChip[] = [];
+
+  if (props.isPrivate) {
+    chips.push({
+      label: t("privateLabel"),
+      backgroundColor: "#333",
+      icon: undefined,
+    });
+  }
+
+  if (isMaxDiffConversation.value) {
+    chips.push({
+      label: t("prioritizationLabel"),
+      backgroundColor: "var(--q-primary)",
+      icon: "mdi-sort-numeric-ascending",
+    });
+  }
+
+  if (props.externalSourceConfig !== null) {
+    chips.push({
+      label: "GitHub",
+      backgroundColor: "#24292f",
+      icon: "mdi-github",
+    });
+  }
+
+  return chips;
+});
+const inlineConversationChips = computed(() =>
+  conversationChips.value
 );
 const displayedProjectTitle = computed(() => {
   const projectContext = props.projectContext;
@@ -84,9 +126,22 @@ const displayedProjectTitle = computed(() => {
 <style scoped lang="scss">
 .title-section {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.45rem;
+}
+
+.conversation-context-row,
+.conversation-title-row {
+  display: flex;
+  max-width: 100%;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
+}
+
+.conversation-context-row {
+  line-height: 1.2;
 }
 
 .conversation-title {

--- a/services/agora/src/components/post/display/PostContent.vue
+++ b/services/agora/src/components/post/display/PostContent.vue
@@ -35,10 +35,9 @@
           size="medium"
           :conversation-type-config="extendedPostData.metadata"
           :external-source-config="extendedPostData.metadata.externalSourceConfig"
-          :project-context="
-            compactMode ? undefined : extendedPostData.metadata.projectContext
-          "
+          :project-context="extendedPostData.metadata.projectContext"
           :project-context-title-mode="contentTranslation?.mode ?? 'original'"
+          :project-context-interactive="!compactMode"
         />
       </div>
 

--- a/services/agora/src/components/post/maxdiff/MaxDiffCandidateCardContent.vue
+++ b/services/agora/src/components/post/maxdiff/MaxDiffCandidateCardContent.vue
@@ -1,0 +1,121 @@
+<template>
+  <div class="candidate-card-content">
+    <div
+      v-if="translationPreview !== undefined"
+      class="candidate-card-translation-control"
+      @click.stop
+      @keydown.stop
+      @mousedown.stop
+      @pointerdown.stop
+    >
+      <ContentTranslationControl
+        v-model="translationMode"
+        :source-language-label="translationPreview.sourceLanguageLabel"
+        :translation-status="translationPreview.translationStatus"
+      />
+    </div>
+
+    <div ref="contentElement" class="candidate-content-wrapper">
+      <ZKHtmlContent
+        :html-body="displayedTitle"
+        :compact-mode="false"
+        :enable-links="false"
+        content-role="title"
+      />
+      <span v-if="displayedBody" class="candidate-body-inline">
+        — {{ htmlToCountedText(displayedBody) }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import ContentTranslationControl from "src/components/translation/ContentTranslationControl.vue";
+import ZKHtmlContent from "src/components/ui-library/ZKHtmlContent.vue";
+import { htmlToCountedText } from "src/shared/shared";
+import type { MaxDiffCandidateDisplayItem } from "src/utils/maxdiffCandidateDisplay";
+import { useRankingItemDisplayContent } from "src/utils/translation/useRankingItemDisplayContent";
+import { computed, nextTick, useTemplateRef, watch } from "vue";
+
+const props = defineProps<{
+  conversationSlugId: string;
+  item: MaxDiffCandidateDisplayItem | undefined;
+  fallbackText: string;
+}>();
+
+const emit = defineEmits<{
+  contentChanged: [];
+}>();
+
+const contentElement = useTemplateRef<HTMLElement>("contentElement");
+
+const {
+  displayedTitle: translatedDisplayedTitle,
+  displayedBody,
+  translationPreview,
+  setTranslationMode,
+} = useRankingItemDisplayContent({
+  conversationSlugId: computed(() => props.conversationSlugId),
+  itemSlugId: computed(() => props.item?.slugId),
+  displayContent: computed(() => props.item?.displayContent),
+});
+
+const translationMode = computed({
+  get: () => translationPreview.value?.mode ?? "original",
+  set: setTranslationMode,
+});
+
+const displayedTitle = computed(() => {
+  if (props.item === undefined) {
+    return props.fallbackText;
+  }
+
+  return translatedDisplayedTitle.value;
+});
+
+function isTruncated(): boolean {
+  const element = contentElement.value;
+  if (element === null) {
+    return false;
+  }
+
+  return element.scrollHeight > element.clientHeight + 1;
+}
+
+watch([displayedTitle, displayedBody], () => {
+  void nextTick(() => {
+    emit("contentChanged");
+  });
+});
+
+defineExpose({ isTruncated });
+</script>
+
+<style scoped lang="scss">
+.candidate-card-content {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.candidate-card-translation-control {
+  align-self: flex-start;
+}
+
+.candidate-content-wrapper {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
+}
+
+.candidate-body-inline {
+  font-size: 0.85em;
+  color: $color-text-weak;
+}
+</style>

--- a/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.vue
+++ b/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.vue
@@ -119,30 +119,27 @@
 
       <div class="candidates-grid-wrapper">
         <div class="candidates-grid" :class="{ 'candidates-transitioning': isTransitioning }">
-          <button
+          <div
             v-for="slugId in candidates"
             :key="slugId"
             class="candidate-card"
+            role="button"
+            tabindex="0"
             :class="{
               'selected-best': selectedBest === slugId,
               'selected-worst': selectedWorst === slugId,
             }"
             @click="handleCandidateClick(slugId)"
+            @keydown.enter.prevent="handleCandidateClick(slugId)"
+            @keydown.space.prevent="handleCandidateClick(slugId)"
           >
-            <div
-              ref="candidateContentElements"
-              class="candidate-content-wrapper"
-            >
-              <ZKHtmlContent
-                :html-body="candidateItemContentMap.get(slugId) ?? slugId"
-                :compact-mode="false"
-                :enable-links="false"
-                content-role="title"
-              />
-              <span v-if="candidateItemBySlugId.get(slugId)?.body" class="candidate-body-inline">
-                — {{ htmlToCountedText(candidateItemBySlugId.get(slugId)?.body ?? "") }}
-              </span>
-            </div>
+            <MaxDiffCandidateCardContent
+              ref="candidateContentComponents"
+              :conversation-slug-id="conversationSlugId"
+              :item="candidateItemBySlugId.get(slugId)"
+              :fallback-text="slugId"
+              @content-changed="checkTruncation"
+            />
             <div class="candidate-label">
               <span v-if="selectedBest === slugId" class="label-best">
                 {{ t("mostImportant") }}
@@ -151,7 +148,7 @@
                 {{ t("leastImportant") }}
               </span>
             </div>
-          </button>
+          </div>
         </div>
         <div v-if="showTransitionSpinner" class="transition-spinner-overlay">
           <q-spinner-dots color="primary" size="2.5rem" />
@@ -241,12 +238,10 @@ import AnalysisActionButton from "src/components/post/analysis/common/AnalysisAc
 import ErrorRetryBlock from "src/components/ui/ErrorRetryBlock.vue";
 import PageLoadingSpinner from "src/components/ui/PageLoadingSpinner.vue";
 import ZKBottomDialogContainer from "src/components/ui-library/ZKBottomDialogContainer.vue";
-import ZKHtmlContent from "src/components/ui-library/ZKHtmlContent.vue";
 import { useConversationLoginIntentions } from "src/composables/auth/useConversationLoginIntentions";
 import type { RegisterChildRefreshHandler } from "src/composables/conversation/useConversationParentState";
 import { useParticipationGate } from "src/composables/conversation/useParticipationGate";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
-import { htmlToCountedText } from "src/shared/shared";
 import type {
   ExtendedConversationDisplayData,
   MaxDiffComparison,
@@ -273,6 +268,7 @@ import { getRankingItemDisplayText } from "src/utils/translation/useRankingItemD
 import { useNotify } from "src/utils/ui/notify";
 import { computed, inject, nextTick, onActivated, onBeforeUnmount, onDeactivated, ref, triggerRef, watch } from "vue";
 
+import MaxDiffCandidateCardContent from "./MaxDiffCandidateCardContent.vue";
 import MaxDiffStatementDialog from "./MaxDiffStatementDialog.vue";
 import {
   type MaxDiffVotingTabTranslations,
@@ -407,14 +403,6 @@ const itemBySlugId = computed(() => {
 
 const candidateItems = ref<MaxDiffCandidateDisplayItem[]>([]);
 
-const candidateItemContentMap = computed(() => {
-  const map = new Map<string, string>();
-  for (const item of candidateItems.value) {
-    map.set(item.slugId, item.title);
-  }
-  return map;
-});
-
 const candidateItemBySlugId = computed(() => {
   const map = new Map<string, MaxDiffCandidateDisplayItem>();
   for (const item of candidateItems.value) {
@@ -537,14 +525,16 @@ function openVotingDialog(slugId: string): void {
 
 // Truncation detection for candidate cards
 const truncatedCards = ref(new Set<string>());
-const candidateContentElements = ref<HTMLElement[]>([]);
+const candidateContentComponents = ref<
+  Array<{ isTruncated: () => boolean }>
+>([]);
 
 function checkTruncation(): void {
   const newSet = new Set<string>();
-  for (const [index, el] of candidateContentElements.value.entries()) {
+  for (const [index, component] of candidateContentComponents.value.entries()) {
     const slugId = candidates.value[index];
     if (slugId === undefined) continue;
-    if (el.scrollHeight > el.clientHeight + 1) {
+    if (component.isTruncated()) {
       newSet.add(slugId);
     }
   }

--- a/services/agora/src/composables/conversation/usePublishConversationDraft.ts
+++ b/services/agora/src/composables/conversation/usePublishConversationDraft.ts
@@ -4,7 +4,11 @@ import {
   type CreateConversationTranslations,
   createConversationTranslations,
 } from "src/pages/conversation/new/create/index.i18n";
-import { type CreateNewConversationResponse,Dto } from "src/shared/types/dto";
+import {
+  type CreateNewConversationRequest,
+  type CreateNewConversationResponse,
+  Dto,
+} from "src/shared/types/dto";
 import type { SurveyConfig } from "src/shared/types/zod";
 import { useNavigationStore } from "src/stores/navigation";
 import { useNewPostDraftsStore } from "src/stores/newConversationDrafts";
@@ -30,6 +34,87 @@ type CreateConversationFailureReason = Extract<
   { success: false }
 >["reason"];
 
+type BuildCreateConversationRequestResult =
+  | {
+      success: true;
+      request: CreateNewConversationRequest;
+    }
+  | {
+      success: false;
+    };
+
+function buildBaseCreateConversationRequest({
+  conversationDraft,
+}: {
+  conversationDraft: ConversationDraft;
+}) {
+  return {
+    conversationTitle: conversationDraft.title,
+    conversationBody:
+      conversationDraft.content === "" ? undefined : conversationDraft.content,
+    conversationBodyPlainText: conversationDraft.contentPlainText,
+    projectSlug: conversationDraft.selectedProjectSlug,
+    languageSettingsSource:
+      conversationDraft.selectedProjectSlug !== undefined &&
+      conversationDraft.inheritProjectLanguages
+        ? "project_inherited"
+        : "conversation_override",
+    multilingualSetting: conversationDraft.multilingualSetting,
+    postAsOrganization: conversationDraft.postAs.postAsOrganization
+      ? conversationDraft.postAs.organizationName
+      : "",
+    isIndexed: !conversationDraft.isPrivate,
+    participationMode: conversationDraft.participationMode,
+    seedOpinionList: conversationDraft.seedOpinions,
+    requiresEventTicket: conversationDraft.requiresEventTicket,
+  };
+}
+
+function buildCreateConversationRequest({
+  conversationDraft,
+  surveyConfig,
+}: {
+  conversationDraft: ConversationDraft;
+  surveyConfig: SurveyConfig | null;
+}): BuildCreateConversationRequestResult {
+  const baseCreateRequest = buildBaseCreateConversationRequest({
+    conversationDraft,
+  });
+
+  if (conversationDraft.conversationType === "ranking") {
+    return {
+      success: true,
+      request: Dto.createNewConversationRequest.parse({
+        ...baseCreateRequest,
+        conversationType: conversationDraft.conversationType,
+        rankingMode: conversationDraft.rankingMode,
+        externalSourceConfig: conversationDraft.externalSourceConfig,
+      }),
+    };
+  }
+
+  const normalizedSurveyConfigResult = buildSurveyConfigForSave({
+    surveyConfig,
+  });
+
+  if (!normalizedSurveyConfigResult.success) {
+    return {
+      success: false,
+    };
+  }
+
+  return {
+    success: true,
+    request: Dto.createNewConversationRequest.parse({
+      ...baseCreateRequest,
+      conversationType: conversationDraft.conversationType,
+      aiLabelingEnabled: conversationDraft.aiLabelingEnabled,
+      preferredOpinionGroupCount: conversationDraft.preferredOpinionGroupCount,
+      surveyConfig: normalizedSurveyConfigResult.surveyConfig,
+    }),
+  };
+}
+
 export function usePublishConversationDraft() {
   const router = useRouter();
   const navigationStore = useNavigationStore();
@@ -51,45 +136,19 @@ export function usePublishConversationDraft() {
     onInvalidSurvey,
     beforeSuccessNavigation,
   }: PublishConversationDraftParams): Promise<boolean> {
-    const normalizedSurveyConfigResult = buildSurveyConfigForSave({
-      surveyConfig,
-    });
-    if (!normalizedSurveyConfigResult.success) {
-      showNotifyMessage(invalidSurveyMessage);
-      onInvalidSurvey?.();
-      return false;
-    }
-
     try {
-      const createRequest = Dto.createNewConversationRequest.parse({
-        conversationTitle: conversationDraft.title,
-        conversationBody:
-          conversationDraft.content === "" ? undefined : conversationDraft.content,
-        conversationBodyPlainText: conversationDraft.contentPlainText,
-        projectSlug: conversationDraft.selectedProjectSlug,
-        languageSettingsSource:
-          conversationDraft.selectedProjectSlug !== undefined &&
-          conversationDraft.inheritProjectLanguages
-            ? "project_inherited"
-            : "conversation_override",
-        multilingualSetting: conversationDraft.multilingualSetting,
-        postAsOrganization: conversationDraft.postAs.postAsOrganization
-          ? conversationDraft.postAs.organizationName
-          : "",
-        isIndexed: !conversationDraft.isPrivate,
-        participationMode: conversationDraft.participationMode,
-        conversationType: conversationDraft.conversationType,
-        ...(conversationDraft.conversationType === "ranking"
-          ? { rankingMode: conversationDraft.rankingMode }
-          : {}),
-        seedOpinionList: conversationDraft.seedOpinions,
-        requiresEventTicket: conversationDraft.requiresEventTicket,
-        aiLabelingEnabled: conversationDraft.aiLabelingEnabled,
-        preferredOpinionGroupCount: conversationDraft.preferredOpinionGroupCount,
-        externalSourceConfig: conversationDraft.externalSourceConfig,
-        surveyConfig: normalizedSurveyConfigResult.surveyConfig,
+      const createRequestResult = buildCreateConversationRequest({
+        conversationDraft,
+        surveyConfig,
       });
-      const response = await createNewPost(createRequest);
+
+      if (!createRequestResult.success) {
+        showNotifyMessage(invalidSurveyMessage);
+        onInvalidSurvey?.();
+        return false;
+      }
+
+      const response = await createNewPost(createRequestResult.request);
 
       if (response.status !== "success") {
         handleAxiosErrorStatusCodes({
@@ -115,7 +174,10 @@ export function usePublishConversationDraft() {
         return false;
       }
 
-      if (conversationDraft.externalSourceConfig !== null) {
+      if (
+        conversationDraft.conversationType === "ranking" &&
+        conversationDraft.externalSourceConfig !== null
+      ) {
         await syncMaxDiff({
           conversationSlugId: response.data.conversationSlugId,
         });
@@ -132,7 +194,8 @@ export function usePublishConversationDraft() {
       });
 
       return true;
-    } catch {
+    } catch (error) {
+      console.error("Failed to publish conversation draft", error);
       showNotifyMessage(defaultErrorMessage);
       return false;
     }

--- a/services/agora/src/pages/user-profile.vue
+++ b/services/agora/src/pages/user-profile.vue
@@ -75,6 +75,7 @@ import {
 } from "src/composables/ui/useLocalizedDateTime";
 import { isNetworkOffline } from "src/composables/useNetworkStatus";
 import { useAuthenticationStore } from "src/stores/authentication";
+import { useLanguageStore } from "src/stores/language";
 import { useUserStore } from "src/stores/user";
 import { onActivated, ref, watch } from "vue";
 import { useRoute } from "vue-router";
@@ -91,6 +92,7 @@ const { isActive } = usePageLayout({ enableFooter: false, reducedWidth: true, ad
 const { loadUserProfile } = useUserStore();
 const authStore = useAuthenticationStore();
 const { isGuest, isAuthInitialized } = storeToRefs(authStore);
+const { displayLanguage } = storeToRefs(useLanguageStore());
 
 interface CustomTab {
   route: "/user-profile/conversations/" | "/user-profile/opinions/";
@@ -141,6 +143,12 @@ onActivated(() => {
 watch(isAuthInitialized, (initialized) => {
   if (initialized && !hasLoadedOnce.value) {
     void initialize();
+  }
+});
+
+watch(displayLanguage, () => {
+  if (hasLoadedOnce.value && isAuthInitialized.value) {
+    void loadUserProfile();
   }
 });
 

--- a/services/agora/src/utils/api/post/useFeedQuery.ts
+++ b/services/agora/src/utils/api/post/useFeedQuery.ts
@@ -5,6 +5,7 @@ import {
 import { storeToRefs } from "pinia";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { useHomeFeedStore } from "src/stores/homeFeed";
+import { useLanguageStore } from "src/stores/language";
 import { computed, type MaybeRefOrGetter, toValue } from "vue";
 
 import { useBackendPostApi } from "./post";
@@ -17,9 +18,14 @@ export function useFeedQuery({
   const { fetchRecentPost } = useBackendPostApi();
   const { isGuestOrLoggedIn } = storeToRefs(useAuthenticationStore());
   const { currentHomeFeedTab } = storeToRefs(useHomeFeedStore());
+  const { displayLanguage } = storeToRefs(useLanguageStore());
 
   return useQuery({
-    queryKey: ["feed", computed(() => currentHomeFeedTab.value)],
+    queryKey: [
+      "feed",
+      computed(() => currentHomeFeedTab.value),
+      computed(() => displayLanguage.value),
+    ],
     queryFn: async () => {
       const response = await fetchRecentPost({
         loadPersonalizedData: isGuestOrLoggedIn.value,

--- a/services/api/scripts/backfill-rich-text-plain-text.ts
+++ b/services/api/scripts/backfill-rich-text-plain-text.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env npx tsx
 
-import { and, asc, eq, isNotNull, isNull } from "drizzle-orm";
+import { and, asc, eq, gt, isNotNull, isNull } from "drizzle-orm";
 import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { pathToFileURL } from "node:url";
 import { createPostgresClient } from "../src/shared-backend/db.js";
 import { sharedConfigSchema } from "../src/shared-backend/config.js";
+import {
+    initializeGoogleCloudCredentials,
+    type GoogleCloudCredentials,
+} from "../src/shared-backend/googleCloudAuth.js";
 import {
     conversationContentTable,
     conversationContentTranslationTable,
@@ -17,13 +21,38 @@ import {
     surveyAnswerTable,
 } from "../src/shared-backend/schema.js";
 import { htmlToCountedText } from "../src/shared-app-api/html.js";
+import {
+    contentLanguageMetadataUpdateValues,
+    resolveContentLanguageMetadata,
+} from "../src/service/contentLanguageMetadata.js";
 
 const BATCH_SIZE = 500;
+const REQUIRED_ENV_EXAMPLE = [
+    "CONNECTION_STRING=postgres://...",
+    "",
+    "GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/google-service-account.json",
+    "GOOGLE_CLOUD_TRANSLATION_LOCATION=us-central1",
+    "GOOGLE_CLOUD_TRANSLATION_ENDPOINT=translate.googleapis.com",
+].join("\n");
+const REQUIRED_ENV_KEYS = [
+    "CONNECTION_STRING",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_TRANSLATION_LOCATION",
+    "GOOGLE_CLOUD_TRANSLATION_ENDPOINT",
+] as const;
 
-// One-time migration helper for the rich-text/plain-text split.
+// One-time migration helper for the rich-text/plain-text split and legacy
+// ranking-item language metadata.
 // Run manually with `pnpm backfill:rich-text-plain-text` after V0079.1 has
-// copied legacy ranking rows into ranking_item* tables and before V0081 adds
-// strict body/plain-text pair constraints. Keep this script until every
+// copied legacy ranking rows into ranking_item* tables and before V0080 adds
+// strict body/plain-text pair constraints / V0081 drops maxdiff_* tables.
+// Required env:
+// CONNECTION_STRING=postgres://...
+//
+// GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/google-service-account.json
+// GOOGLE_CLOUD_TRANSLATION_LOCATION=us-central1
+// GOOGLE_CLOUD_TRANSLATION_ENDPOINT=translate.googleapis.com
+// Keep this script until every
 // deployed environment has successfully applied V0081; remove it after that
 // migration is no longer pending anywhere.
 //
@@ -53,6 +82,12 @@ interface BackfillTarget {
     updatePlainText: (db: Db, row: BackfillRow) => Promise<void>;
 }
 
+interface RankingItemLanguageBackfillRow {
+    id: number;
+    title: string;
+    bodyPlainText: string | null;
+}
+
 function rowsWithHtml(rows: { id: number; html: string | null }[]): BackfillRow[] {
     return rows.flatMap((row) =>
         row.html === null ? [] : [{ id: row.id, html: row.html }],
@@ -60,6 +95,10 @@ function rowsWithHtml(rows: { id: number; html: string | null }[]): BackfillRow[
 }
 
 const noopClearStalePlainText = (): Promise<number> => Promise.resolve(0);
+
+function isNonEmptyString(value: string | undefined): boolean {
+    return value !== undefined && value.trim().length > 0;
+}
 
 const targets: BackfillTarget[] = [
     {
@@ -434,6 +473,37 @@ const targets: BackfillTarget[] = [
     },
 ];
 
+function requireBackfillEnv({ env }: { env: NodeJS.ProcessEnv }): void {
+    const missingKeys = REQUIRED_ENV_KEYS.filter((key) => !isNonEmptyString(env[key]));
+
+    if (missingKeys.length === 0) {
+        return;
+    }
+
+    throw new Error(
+        [
+            "[RichTextPlainTextBackfill] Missing required env var(s):",
+            missingKeys.map((key) => `- ${key}`).join("\n"),
+            "",
+            "Expected env block:",
+            REQUIRED_ENV_EXAMPLE,
+        ].join("\n"),
+    );
+}
+
+function buildRankingItemLanguageDetectionCorpus({
+    title,
+    bodyPlainText,
+}: {
+    title: string;
+    bodyPlainText: string | null;
+}): string {
+    return [title, bodyPlainText]
+        .map((text) => text?.trim() ?? "")
+        .filter((text) => text.length > 0)
+        .join("\n\n");
+}
+
 async function backfillTarget({
     db,
     target,
@@ -467,8 +537,80 @@ async function backfillTarget({
     }
 }
 
+async function backfillRankingItemLanguageMetadata({
+    db,
+    googleCloudCredentials,
+}: {
+    db: Db;
+    googleCloudCredentials: GoogleCloudCredentials;
+}): Promise<number> {
+    let processedCount = 0;
+    let lastSeenId = 0;
+    for (;;) {
+        const rows: RankingItemLanguageBackfillRow[] = await db
+            .select({
+                id: rankingItemContentTable.id,
+                title: rankingItemContentTable.title,
+                bodyPlainText: rankingItemContentTable.bodyPlainText,
+            })
+            .from(rankingItemContentTable)
+            .where(
+                and(
+                    gt(rankingItemContentTable.id, lastSeenId),
+                    isNull(rankingItemContentTable.sourceLanguageProvider),
+                    isNull(rankingItemContentTable.sourceRawLanguageCode),
+                ),
+            )
+            .orderBy(asc(rankingItemContentTable.id))
+            .limit(BATCH_SIZE);
+
+        if (rows.length === 0) {
+            return processedCount;
+        }
+
+        for (const row of rows) {
+            lastSeenId = row.id;
+            const corpus = buildRankingItemLanguageDetectionCorpus({
+                title: row.title,
+                bodyPlainText: row.bodyPlainText,
+            });
+            const sourceLanguageMetadata = await resolveContentLanguageMetadata({
+                text: corpus,
+                googleText: corpus,
+                googleCloudCredentials,
+                useGoogleLanguageDetection: true,
+            });
+
+            await db
+                .update(rankingItemContentTable)
+                .set(contentLanguageMetadataUpdateValues(sourceLanguageMetadata))
+                .where(
+                    and(
+                        eq(rankingItemContentTable.id, row.id),
+                        isNull(rankingItemContentTable.sourceLanguageProvider),
+                        isNull(rankingItemContentTable.sourceRawLanguageCode),
+                    ),
+                );
+        }
+
+        processedCount += rows.length;
+        log.info(
+            `[RichTextPlainTextBackfill] ranking item language metadata: processed ${String(processedCount)} row(s)`,
+        );
+    }
+}
+
 async function main(): Promise<void> {
+    requireBackfillEnv({ env: process.env });
     const config = sharedConfigSchema.parse(process.env);
+    const googleCloudCredentials = await initializeGoogleCloudCredentials({
+        googleCloudServiceAccountAwsSecretKey: undefined,
+        awsSecretRegion: undefined,
+        googleApplicationCredentialsPath: config.GOOGLE_APPLICATION_CREDENTIALS,
+        googleCloudTranslationLocation: config.GOOGLE_CLOUD_TRANSLATION_LOCATION,
+        googleCloudTranslationEndpoint: config.GOOGLE_CLOUD_TRANSLATION_ENDPOINT,
+        log,
+    });
     const client = await createPostgresClient(config, log);
     const db = drizzle(client);
 
@@ -479,6 +621,14 @@ async function main(): Promise<void> {
                 `[RichTextPlainTextBackfill] ${target.label}: completed with ${String(updatedCount)} row(s) updated`,
             );
         }
+        const processedLanguageMetadataCount =
+            await backfillRankingItemLanguageMetadata({
+                db,
+                googleCloudCredentials,
+            });
+        log.info(
+            `[RichTextPlainTextBackfill] ranking item language metadata: completed with ${String(processedLanguageMetadataCount)} row(s) processed`,
+        );
     } finally {
         await client.end({ timeout: 5 });
     }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -1833,6 +1833,7 @@ server.after(() => {
                     : undefined,
                 baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
                 sortAlgorithm: request.body.sortAlgorithm,
+                currentDisplayLanguage: getRequestDisplayLanguage({ request }),
             });
         },
     });
@@ -2414,6 +2415,7 @@ server.after(() => {
                 userId: deviceStatus.userId,
                 lastPostSlugId: request.body.lastConversationSlugId,
                 baseImageServiceUrl: config.IMAGES_SERVICE_BASE_URL,
+                currentDisplayLanguage: getRequestDisplayLanguage({ request }),
                 limit: 10,
             });
             return Array.from(conversationsMap.values());

--- a/services/api/src/service/common.ts
+++ b/services/api/src/service/common.ts
@@ -13,6 +13,7 @@ import {
     projectOrganizationOwnershipTable,
 } from "@/shared-backend/schema.js";
 import { toUnionUndefined } from "@/shared/shared.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 import type {
     ConversationMetadata,
     ExtendedConversationPayload,
@@ -53,6 +54,7 @@ import {
     DEFAULT_CONVERSATION_MULTILINGUAL_SETTING,
     getConversationMultilingualSettingsByConversationId,
 } from "./conversationMultilingual.js";
+import { fetchConversationProjectContexts } from "./projectPage.js";
 
 function requireJoinedRankingMode({
     conversationId,
@@ -262,6 +264,7 @@ export function useCommonPost() {
         removeMutedAuthors: boolean;
         baseImageServiceUrl: string;
         sortAlgorithm: FeedSortAlgorithm;
+        currentDisplayLanguage: SupportedDisplayLanguageCodes;
     }
 
     async function fetchPostItems({
@@ -274,6 +277,7 @@ export function useCommonPost() {
         removeMutedAuthors,
         baseImageServiceUrl,
         sortAlgorithm,
+        currentDisplayLanguage,
     }: FetchPostItemsProps): Promise<ExtendedConversationPerSlugId> {
         let postItems;
 
@@ -417,20 +421,27 @@ export function useCommonPost() {
             postItems = await postItemsQuery;
         }
 
-        const latestViewSnapshotCountsByConversationId =
-            await fetchLatestConversationViewSnapshotCountsByConversationId({
+        const conversationIds = postItems.map((postItem) => postItem.conversationId);
+        const conversationSlugIds = postItems.map((postItem) => postItem.slugId);
+        const [
+            latestViewSnapshotCountsByConversationId,
+            multilingualSettingsByConversationId,
+            projectContextsBySlugId,
+        ] = await Promise.all([
+            fetchLatestConversationViewSnapshotCountsByConversationId({
                 db,
-                conversationIds: postItems.map(
-                    (postItem) => postItem.conversationId,
-                ),
-            });
-        const multilingualSettingsByConversationId =
-            await getConversationMultilingualSettingsByConversationId({
+                conversationIds,
+            }),
+            getConversationMultilingualSettingsByConversationId({
                 db,
-                conversationIds: postItems.map(
-                    (postItem) => postItem.conversationId,
-                ),
-            });
+                conversationIds,
+            }),
+            fetchConversationProjectContexts({
+                db,
+                conversationSlugIds,
+                currentDisplayLanguage,
+            }),
+        ]);
 
         if (sortAlgorithm == "following") {
             postItems.sort((post1, post2) => {
@@ -557,6 +568,7 @@ export function useCommonPost() {
                     );
                     return parsed.success ? parsed.data : null;
                 })(),
+                projectContext: projectContextsBySlugId.get(postItem.slugId),
                 importInfo:
                     postItem.importUrl !== null ||
                     postItem.importConversationUrl !== null ||

--- a/services/api/src/service/feed.ts
+++ b/services/api/src/service/feed.ts
@@ -6,6 +6,7 @@ import type {
     ExtendedConversationPerSlugId,
     FeedSortAlgorithm,
 } from "@/shared/types/zod.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 import { and, desc, eq, isNotNull, SQL } from "drizzle-orm";
 import { type PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
 import { useCommonPost } from "./common.js";
@@ -57,6 +58,7 @@ interface FetchFeedProps {
     personalizationUserId?: string;
     baseImageServiceUrl: string;
     sortAlgorithm: FeedSortAlgorithm;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }
 
 export async function fetchFeed({
@@ -64,6 +66,7 @@ export async function fetchFeed({
     personalizationUserId,
     baseImageServiceUrl,
     sortAlgorithm,
+    currentDisplayLanguage,
 }: FetchFeedProps): Promise<FetchFeedResponse> {
     const targetFetchLimit = 1000;
 
@@ -86,6 +89,7 @@ export async function fetchFeed({
         removeMutedAuthors: true,
         baseImageServiceUrl,
         sortAlgorithm,
+        currentDisplayLanguage,
     });
 
     const topSlugIdList = Array.from(conversations.keys()).slice(

--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -73,7 +73,6 @@ import {
     type RankingItemContentSource,
     type SurveyQuestionContentSource,
 } from "./contentTranslation.js";
-import { fetchConversationProjectContext } from "./projectPage.js";
 
 const MAX_CONVERSATION_SEED_ITEMS = 50;
 
@@ -527,6 +526,7 @@ export async function fetchPostBySlugId({
         removeMutedAuthors: false,
         baseImageServiceUrl,
         sortAlgorithm: "new",
+        currentDisplayLanguage: currentDisplayLanguage ?? "en",
     });
 
     if (postData.size === 0) {
@@ -547,27 +547,14 @@ export async function fetchPostBySlugId({
         db,
         conversationSlugId,
     });
-    const [surveyGate, projectContext] = await Promise.all([
-        getSurveyGateSummary({
-            db,
-            conversationId,
-            participantId: personalizedUserId,
-        }),
-        currentDisplayLanguage === undefined
-            ? Promise.resolve(undefined)
-            : fetchConversationProjectContext({
-                  db,
-                  conversationSlugId,
-                  currentDisplayLanguage,
-              }),
-    ]);
+    const surveyGate = await getSurveyGateSummary({
+        db,
+        conversationId,
+        participantId: personalizedUserId,
+    });
 
     return {
         ...firstPost,
-        metadata: {
-            ...firstPost.metadata,
-            projectContext,
-        },
         interaction: {
             ...firstPost.interaction,
             surveyGate,

--- a/services/api/src/service/projectPage.ts
+++ b/services/api/src/service/projectPage.ts
@@ -107,6 +107,10 @@ interface ProjectBaseRow {
     sourceLanguageConfidence: number | null;
 }
 
+interface ConversationProjectBaseRow extends ProjectBaseRow {
+    conversationSlugId: string;
+}
+
 interface ConversationDisplayCounts {
     conversationId: number;
     opinionCount: number;
@@ -171,6 +175,10 @@ interface ProjectActivityContentTranslationRow {
     translatedBody: string | null;
     translatedBodyPlainText: string | null;
     sourceLanguageCode: SupportedSpokenLanguageCodes | null;
+}
+
+interface ProjectContentTranslationRow extends ProjectContentTranslationResolutionRow {
+    projectContentId: number;
 }
 
 function optionalText(value: string | null): string | undefined {
@@ -311,15 +319,21 @@ async function fetchProjectBaseBySlug({
     return project;
 }
 
-async function fetchProjectBaseByConversationSlug({
+async function fetchProjectBasesByConversationSlug({
     db,
-    conversationSlugId,
+    conversationSlugIds,
 }: {
     db: PostgresJsDatabase;
-    conversationSlugId: string;
-}): Promise<ProjectBaseRow | undefined> {
-    const rows = await db
+    conversationSlugIds: readonly string[];
+}): Promise<ConversationProjectBaseRow[]> {
+    const uniqueConversationSlugIds = Array.from(new Set(conversationSlugIds));
+    if (uniqueConversationSlugIds.length === 0) {
+        return [];
+    }
+
+    return await db
         .select({
+            conversationSlugId: conversationTable.slugId,
             projectId: projectTable.id,
             projectContentId: projectContentTable.id,
             projectContentPublicId: projectContentTable.publicId,
@@ -343,16 +357,13 @@ async function fetchProjectBaseByConversationSlug({
         )
         .where(
             and(
-                eq(conversationTable.slugId, conversationSlugId),
+                inArray(conversationTable.slugId, uniqueConversationSlugIds),
                 eq(projectTable.directoryVisibility, "listed"),
                 isNull(projectTable.autoProvisionedForOrganizationId),
                 isNull(projectTable.deletedAt),
                 isNull(projectContentTable.deletedAt),
             ),
-        )
-        .limit(1);
-
-    return rows.at(0);
+        );
 }
 
 async function fetchProjectTargetLanguages({
@@ -362,16 +373,48 @@ async function fetchProjectTargetLanguages({
     db: PostgresJsDatabase;
     projectId: number;
 }): Promise<SupportedDisplayLanguageCodes[]> {
+    const languagesByProjectId = await fetchProjectTargetLanguagesByProjectId({
+        db,
+        projectIds: [projectId],
+    });
+    return languagesByProjectId.get(projectId) ?? [];
+}
+
+async function fetchProjectTargetLanguagesByProjectId({
+    db,
+    projectIds,
+}: {
+    db: PostgresJsDatabase;
+    projectIds: readonly number[];
+}): Promise<Map<number, SupportedDisplayLanguageCodes[]>> {
+    const uniqueProjectIds = Array.from(new Set(projectIds));
+    if (uniqueProjectIds.length === 0) {
+        return new Map();
+    }
+
     const rows = await db
-        .select({ languageCode: projectTranslationTargetLanguageTable.languageCode })
+        .select({
+            projectId: projectTranslationTargetLanguageTable.projectId,
+            languageCode: projectTranslationTargetLanguageTable.languageCode,
+        })
         .from(projectTranslationTargetLanguageTable)
         .where(
             and(
-                eq(projectTranslationTargetLanguageTable.projectId, projectId),
+                inArray(projectTranslationTargetLanguageTable.projectId, uniqueProjectIds),
                 isNull(projectTranslationTargetLanguageTable.deletedAt),
             ),
         );
-    return rows.map((row) => row.languageCode);
+
+    const languagesByProjectId = new Map<
+        number,
+        SupportedDisplayLanguageCodes[]
+    >();
+    for (const row of rows) {
+        const languages = languagesByProjectId.get(row.projectId) ?? [];
+        languages.push(row.languageCode);
+        languagesByProjectId.set(row.projectId, languages);
+    }
+    return languagesByProjectId;
 }
 
 function buildProjectPageLanguageOptions({
@@ -678,6 +721,58 @@ async function fetchResolvedProjectContent({
         additionalLanguageCodes,
         translationStatus,
     });
+}
+
+async function fetchProjectContentTranslationsByContentId({
+    db,
+    projectContentIds,
+}: {
+    db: PostgresJsDatabase;
+    projectContentIds: readonly number[];
+}): Promise<Map<number, ProjectContentTranslationResolutionRow[]>> {
+    const uniqueProjectContentIds = Array.from(new Set(projectContentIds));
+    if (uniqueProjectContentIds.length === 0) {
+        return new Map();
+    }
+
+    const rows: ProjectContentTranslationRow[] = await db
+        .select({
+            projectContentId: projectContentTranslationTable.projectContentId,
+            languageCode: projectContentTranslationTable.displayLanguageCode,
+            title: projectContentTranslationTable.translatedTitle,
+            subtitle: projectContentTranslationTable.translatedSubtitle,
+            body: projectContentTranslationTable.translatedBody,
+            sourceKind: projectContentTranslationTable.sourceKind,
+            sourceLanguageCode: projectContentTranslationTable.sourceLanguageCode,
+        })
+        .from(projectContentTranslationTable)
+        .where(
+            and(
+                inArray(
+                    projectContentTranslationTable.projectContentId,
+                    uniqueProjectContentIds,
+                ),
+                isNull(projectContentTranslationTable.deletedAt),
+            ),
+        );
+
+    const rowsByContentId = new Map<
+        number,
+        ProjectContentTranslationResolutionRow[]
+    >();
+    for (const row of rows) {
+        const projectRows = rowsByContentId.get(row.projectContentId) ?? [];
+        projectRows.push({
+            languageCode: row.languageCode,
+            title: row.title,
+            subtitle: row.subtitle,
+            body: row.body,
+            sourceKind: row.sourceKind,
+            sourceLanguageCode: row.sourceLanguageCode,
+        });
+        rowsByContentId.set(row.projectContentId, projectRows);
+    }
+    return rowsByContentId;
 }
 
 export function toProjectDisplayContent({
@@ -1909,42 +2004,71 @@ export async function fetchConversationProjectContext({
     conversationSlugId: string;
     currentDisplayLanguage: SupportedDisplayLanguageCodes;
 }): Promise<ConversationProjectContext | undefined> {
-    const project = await fetchProjectBaseByConversationSlug({
+    const projectContexts = await fetchConversationProjectContexts({
         db,
-        conversationSlugId,
+        conversationSlugIds: [conversationSlugId],
+        currentDisplayLanguage,
     });
-    if (project === undefined) {
-        return undefined;
+    return projectContexts.get(conversationSlugId);
+}
+
+export async function fetchConversationProjectContexts({
+    db,
+    conversationSlugIds,
+    currentDisplayLanguage,
+}: {
+    db: PostgresJsDatabase;
+    conversationSlugIds: readonly string[];
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
+}): Promise<Map<string, ConversationProjectContext>> {
+    const projects = await fetchProjectBasesByConversationSlug({
+        db,
+        conversationSlugIds,
+    });
+    if (projects.length === 0) {
+        return new Map();
     }
 
-    const defaultLanguageCode = getProjectDefaultDisplayLanguage({
-        sourceLanguageCode: project.sourceLanguageCode,
-    });
-    const additionalLanguageCodes = await fetchProjectTargetLanguages({
-        db,
-        projectId: project.projectId,
-    });
-    const { preferredContentLanguage } = resolvePreferredContentLanguage({
-        displayLanguage: currentDisplayLanguage,
-        defaultContentLanguage: defaultLanguageCode,
-        configuredContentLanguages: additionalLanguageCodes,
-    });
-    const content = await fetchResolvedProjectContent({
-        db,
-        project,
-        languageCandidateSet: getLanguageCandidateSet({
-            effectiveLanguageCode: preferredContentLanguage,
-            defaultLanguageCode,
-        }),
-        effectiveLanguageCode: preferredContentLanguage,
-        additionalLanguageCodes,
-        includeTranslationStatus: false,
-    });
+    const [additionalLanguagesByProjectId, translationsByContentId] =
+        await Promise.all([
+            fetchProjectTargetLanguagesByProjectId({
+                db,
+                projectIds: projects.map((project) => project.projectId),
+            }),
+            fetchProjectContentTranslationsByContentId({
+                db,
+                projectContentIds: projects.map(
+                    (project) => project.projectContentId,
+                ),
+            }),
+        ]);
 
-    return {
-        projectSlug: project.projectSlug,
-        originalProjectTitle: content.originalTitle,
-        translatedProjectTitle: content.translatedTitle,
-        conversationSlugId,
-    };
+    const contexts = new Map<string, ConversationProjectContext>();
+    for (const project of projects) {
+        const defaultLanguageCode = getProjectDefaultDisplayLanguage({
+            sourceLanguageCode: project.sourceLanguageCode,
+        });
+        const additionalLanguageCodes =
+            additionalLanguagesByProjectId.get(project.projectId) ?? [];
+        const { preferredContentLanguage } = resolvePreferredContentLanguage({
+            displayLanguage: currentDisplayLanguage,
+            defaultContentLanguage: defaultLanguageCode,
+            configuredContentLanguages: additionalLanguageCodes,
+        });
+        const content = resolveProjectContentForDisplay({
+            project,
+            translationRows:
+                translationsByContentId.get(project.projectContentId) ?? [],
+            effectiveLanguageCode: preferredContentLanguage,
+            additionalLanguageCodes,
+        });
+
+        contexts.set(project.conversationSlugId, {
+            projectSlug: project.projectSlug,
+            originalProjectTitle: content.originalTitle,
+            translatedProjectTitle: content.translatedTitle,
+            conversationSlugId: project.conversationSlugId,
+        });
+    }
+    return contexts;
 }

--- a/services/api/src/service/user.ts
+++ b/services/api/src/service/user.ts
@@ -11,6 +11,7 @@ import {
     eventTicketTable,
 } from "@/shared-backend/schema.js";
 import type { GetUserProfileResponse } from "@/shared/types/dto.js";
+import type { SupportedDisplayLanguageCodes } from "@/shared/languages.js";
 import type {
     OpinionItem,
     ExtendedOpinion,
@@ -247,6 +248,7 @@ interface GetUserPostProps {
     userId: string;
     lastPostSlugId?: string;
     baseImageServiceUrl: string;
+    currentDisplayLanguage: SupportedDisplayLanguageCodes;
     limit?: number;
 }
 
@@ -294,6 +296,7 @@ export async function getUserPosts({
     userId,
     lastPostSlugId,
     baseImageServiceUrl,
+    currentDisplayLanguage,
     limit,
 }: GetUserPostProps): Promise<ExtendedConversationPerSlugId> {
     try {
@@ -349,6 +352,7 @@ export async function getUserPosts({
                 removeMutedAuthors: false,
                 baseImageServiceUrl,
                 sortAlgorithm: "new",
+                currentDisplayLanguage,
             });
 
         return conversations;

--- a/services/api/src/shared-backend/analysisScheduler.ts
+++ b/services/api/src/shared-backend/analysisScheduler.ts
@@ -139,7 +139,7 @@ export async function scheduleAnalysisUpdate({
             .where(eq(conversationTable.id, conversationId))
             // FK checks from analysis workers take KEY SHARE on conversation.
             // NO KEY UPDATE still serializes schedulers without blocking them.
-            .for("no key update");
+            .for("no key update", { of: conversationTable });
 
         if (conversations.length === 0) {
             throw new Error(


### PR DESCRIPTION
## Summary\n- restore the one-off ranking item language metadata backfill that was missed from #1142\n- restore the scoped analysis scheduler lock fix\n- restore project context / MaxDiff candidate display polish that was present on the local #1142 branch but not in the squash merge\n\n## Verification\n- cd services/api && pnpm typecheck\n- cd services/agora && pnpm lint\n\nDeploy: agora, api