### PR TITLE
fix(agora): keep content visible during translation

### DIFF
--- a/services/agora/src/composables/useRealtimeSSE.ts
+++ b/services/agora/src/composables/useRealtimeSSE.ts
@@ -1115,6 +1115,7 @@ export function useRealtimeSSE({
         }),
         refetchType: "active",
       });
+      publishContentTranslationUpdated(data);
       return;
     }
     if (data.subject.kind === "survey_question") {

--- a/services/agora/src/utils/api/contentTranslation/useContentTranslationQueries.ts
+++ b/services/agora/src/utils/api/contentTranslation/useContentTranslationQueries.ts
@@ -142,11 +142,13 @@ export function useContentTranslationQuery({
   targetLanguageCode,
   requestMode,
   enabled = true,
+  refetchInterval = false,
 }: {
   subject: MaybeRefOrGetter<ContentTranslationSubject>;
   targetLanguageCode: MaybeRefOrGetter<SupportedDisplayLanguageCodes>;
   requestMode: MaybeRefOrGetter<ContentTranslationRequestMode>;
   enabled?: MaybeRefOrGetter<boolean>;
+  refetchInterval?: MaybeRefOrGetter<number | false>;
 }) {
   const { requestContentTranslation } = useBackendContentTranslationApi();
   const { updateAuthState } = useBackendAuthApi();
@@ -170,6 +172,7 @@ export function useContentTranslationQuery({
       return response;
     },
     enabled: computed(() => toValue(enabled)),
+    refetchInterval: computed(() => toValue(refetchInterval)),
     retry: false,
   });
 }
@@ -180,12 +183,14 @@ export function useConversationContentQuery({
   mode,
   requestMode,
   enabled = true,
+  refetchInterval = false,
 }: {
   conversationSlugId: MaybeRefOrGetter<string>;
   sourceVersion: MaybeRefOrGetter<string | undefined>;
   mode: MaybeRefOrGetter<ConversationContentMode>;
   requestMode: MaybeRefOrGetter<ContentTranslationRequestMode>;
   enabled?: MaybeRefOrGetter<boolean>;
+  refetchInterval?: MaybeRefOrGetter<number | false>;
 }) {
   const { fetchConversationContent } = useBackendContentTranslationApi();
   const { updateAuthState } = useBackendAuthApi();
@@ -212,6 +217,7 @@ export function useConversationContentQuery({
       return response;
     },
     enabled: computed(() => toValue(enabled) && toValue(sourceVersion) !== undefined),
+    refetchInterval: computed(() => toValue(refetchInterval)),
     retry: false,
   });
 }

--- a/services/agora/src/utils/translation/boundedTranslationPolling.ts
+++ b/services/agora/src/utils/translation/boundedTranslationPolling.ts
@@ -1,0 +1,47 @@
+import { computed, onScopeDispose, ref } from "vue";
+
+export function useBoundedTranslationPolling({
+  intervalMs,
+  maxDurationMs,
+  onTimeout,
+}: {
+  intervalMs: number;
+  maxDurationMs: number;
+  onTimeout: () => void;
+}) {
+  const isActive = ref(false);
+  let stopTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  const refetchInterval = computed(() => {
+    if (!isActive.value) {
+      return false;
+    }
+    return intervalMs;
+  });
+
+  function clearStopTimeout(): void {
+    if (stopTimeout !== undefined) {
+      clearTimeout(stopTimeout);
+      stopTimeout = undefined;
+    }
+  }
+
+  function stop(): void {
+    isActive.value = false;
+    clearStopTimeout();
+  }
+
+  function start(): void {
+    stop();
+    isActive.value = true;
+    stopTimeout = setTimeout(() => {
+      stopTimeout = undefined;
+      isActive.value = false;
+      onTimeout();
+    }, maxDurationMs);
+  }
+
+  onScopeDispose(stop);
+
+  return { refetchInterval, start, stop };
+}

--- a/services/agora/src/utils/translation/useContentTranslationPreview.ts
+++ b/services/agora/src/utils/translation/useContentTranslationPreview.ts
@@ -21,18 +21,24 @@ import { useNotify } from "src/utils/ui/notify";
 import type { MaybeRefOrGetter } from "vue";
 import { computed, onScopeDispose, ref, toValue, watch } from "vue";
 
+import { useBoundedTranslationPolling } from "./boundedTranslationPolling";
 import {
   type ContentTranslationDisplayMode,
   getContentTranslationSourceLanguageLabel,
   getLanguageDisplayName,
 } from "./contentTranslation";
-import { subscribeToContentTranslationFailed } from "./contentTranslationEvents";
+import {
+  subscribeToContentTranslationFailed,
+  subscribeToContentTranslationUpdated,
+} from "./contentTranslationEvents";
 import {
   type ContentTranslationPreviewTranslations,
   contentTranslationPreviewTranslations,
 } from "./useContentTranslationPreview.i18n";
 
 const TRANSLATION_WAIT_TIMEOUT_MS = 30_000;
+const TRANSLATION_COMPLETION_POLL_INTERVAL_MS = 500;
+const TRANSLATION_COMPLETION_POLL_MAX_DURATION_MS = 5_000;
 
 function isRateLimitError(error: unknown): boolean {
   return isAxiosError(error) && error.response?.status === 429;
@@ -153,12 +159,21 @@ function useContentTranslationController({
   const requestMode = computed<ContentTranslationRequestMode>(() =>
     hasRequestedTranslation.value ? "queue_if_missing" : "read_existing"
   );
+  const completionPolling = useBoundedTranslationPolling({
+    intervalMs: TRANSLATION_COMPLETION_POLL_INTERVAL_MS,
+    maxDurationMs: TRANSLATION_COMPLETION_POLL_MAX_DURATION_MS,
+    onTimeout: () => {
+      resetToOriginal();
+      showNotifyMessage(t("translationTimedOut"));
+    },
+  });
 
   const query = useContentTranslationQuery({
     subject,
     targetLanguageCode: displayLanguage,
     requestMode,
     enabled: computed(() => toValue(enabled)),
+    refetchInterval: completionPolling.refetchInterval,
   });
 
   const isLoadingInitialTranslation = computed(() => {
@@ -251,6 +266,7 @@ function useContentTranslationController({
   }
 
   function resetToOriginal(): void {
+    completionPolling.stop();
     modePreference.value = "original";
     hasRequestedTranslation.value = false;
   }
@@ -301,7 +317,7 @@ function useContentTranslationController({
     }
   }
 
-  function isFailedEventForCurrentRequest(
+  function isEventForCurrentRequest(
     data: SSEContentTranslationUpdatedData
   ): boolean {
     return (
@@ -316,7 +332,7 @@ function useContentTranslationController({
 
   const unsubscribeFailedEvents = subscribeToContentTranslationFailed(
     (data) => {
-      if (!isFailedEventForCurrentRequest(data)) {
+      if (!isEventForCurrentRequest(data)) {
         return;
       }
       clearWaitTimeout();
@@ -324,6 +340,21 @@ function useContentTranslationController({
       showNotifyMessage(t("translationFailed"));
     }
   );
+
+  const unsubscribeUpdatedEvents = subscribeToContentTranslationUpdated((data) => {
+    if (!isEventForCurrentRequest(data)) {
+      return;
+    }
+    clearWaitTimeout();
+    void query.refetch();
+    completionPolling.start();
+  });
+
+  watch([translationStatus, translatedVariant], ([status, variant]) => {
+    if (status === "completed" && variant !== undefined) {
+      completionPolling.stop();
+    }
+  });
 
   watch(translationStatus, (status) => {
     if (status === "pending" || status === "running") {
@@ -358,6 +389,8 @@ function useContentTranslationController({
 
   onScopeDispose(() => {
     clearWaitTimeout();
+    completionPolling.stop();
+    unsubscribeUpdatedEvents();
     unsubscribeFailedEvents();
   });
 

--- a/services/agora/src/utils/translation/useConversationDisplayContent.ts
+++ b/services/agora/src/utils/translation/useConversationDisplayContent.ts
@@ -1,4 +1,5 @@
 import { storeToRefs } from "pinia";
+import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import type { ConversationContentFetchResponse } from "src/shared/types/dto";
 import type {
   ExtendedConversationDisplayData,
@@ -11,15 +12,25 @@ import {
   useConversationContentQuery,
   useConversationDisplayContentCache,
 } from "src/utils/api/contentTranslation/useContentTranslationQueries";
+import { useNotify } from "src/utils/ui/notify";
 import type { MaybeRefOrGetter } from "vue";
-import { computed, ref, toValue, watch } from "vue";
+import { computed, onScopeDispose, ref, toValue, watch } from "vue";
 
+import { useBoundedTranslationPolling } from "./boundedTranslationPolling";
 import {
   type ContentTranslationDisplayMode,
   getContentTranslationSourceLanguageLabel,
   getConversationLanguageSettingSourceLanguageCode,
   isSameContentLanguage,
 } from "./contentTranslation";
+import { subscribeToContentTranslationUpdated } from "./contentTranslationEvents";
+import {
+  type ContentTranslationPreviewTranslations,
+  contentTranslationPreviewTranslations,
+} from "./useContentTranslationPreview.i18n";
+
+const TRANSLATION_COMPLETION_POLL_INTERVAL_MS = 500;
+const TRANSLATION_COMPLETION_POLL_MAX_DURATION_MS = 5_000;
 
 export interface ConversationContentTranslationPreview {
   isAvailable: boolean;
@@ -42,6 +53,10 @@ export function useConversationDisplayContent({
   >;
   fallbackPayload?: MaybeRefOrGetter<ExtendedConversationPayload | undefined>;
 }) {
+  const { t } = useComponentI18n<ContentTranslationPreviewTranslations>(
+    contentTranslationPreviewTranslations
+  );
+  const { showNotifyMessage } = useNotify();
   const { displayLanguage, spokenLanguages } = storeToRefs(useLanguageStore());
   const modePreference = ref<ConversationContentMode | undefined>();
   const sortedSpokenLanguageKey = computed(() =>
@@ -63,6 +78,14 @@ export function useConversationDisplayContent({
   const requestedMode = computed<ConversationContentMode>(
     () => modePreference.value ?? "original"
   );
+  const completionPolling = useBoundedTranslationPolling({
+    intervalMs: TRANSLATION_COMPLETION_POLL_INTERVAL_MS,
+    maxDurationMs: TRANSLATION_COMPLETION_POLL_MAX_DURATION_MS,
+    onTimeout: () => {
+      modePreference.value = "original";
+      showNotifyMessage(t("translationTimedOut"));
+    },
+  });
   const requestedContentQuery = useConversationContentQuery({
     conversationSlugId,
     sourceVersion,
@@ -73,22 +96,30 @@ export function useConversationDisplayContent({
     enabled: computed(
       () => modePreference.value !== undefined && toValue(conversationData) !== undefined
     ),
+    refetchInterval: completionPolling.refetchInterval,
   });
 
   const activeDisplayContent = computed<ConversationContentFetchResponse | undefined>(
     () => {
+      const requestedDisplayContent = requestedContentQuery.data.value;
+      const initialDisplayContent = effectiveInitialDisplayContent.value;
       if (
         modePreference.value !== undefined &&
-        requestedContentQuery.data.value !== undefined &&
+        requestedDisplayContent !== undefined &&
         isDisplayContentForMode({
-          displayContent: requestedContentQuery.data.value,
+          displayContent: requestedDisplayContent,
           mode: requestedMode.value,
           isFetching: requestedContentQuery.isFetching.value,
         })
       ) {
-        return requestedContentQuery.data.value;
+        if (
+          requestedDisplayContent.status === "available" ||
+          initialDisplayContent?.status !== "available"
+        ) {
+          return requestedDisplayContent;
+        }
       }
-      return effectiveInitialDisplayContent.value;
+      return initialDisplayContent ?? requestedDisplayContent;
     }
   );
 
@@ -101,7 +132,14 @@ export function useConversationDisplayContent({
       return undefined;
     }
 
-    const translationControl = displayContent.translationControl;
+    const requestedDisplayContent = requestedContentQuery.data.value;
+    const requestedTranslationControl =
+      modePreference.value === "translated" &&
+      requestedDisplayContent?.status !== "available"
+        ? requestedDisplayContent?.translationControl
+        : undefined;
+    const translationControl =
+      requestedTranslationControl ?? displayContent.translationControl;
     if (translationControl === null) {
       return undefined;
     }
@@ -195,6 +233,19 @@ export function useConversationDisplayContent({
     modePreference.value = mode;
   }
 
+  const unsubscribeUpdatedEvents = subscribeToContentTranslationUpdated((data) => {
+    if (
+      modePreference.value !== "translated" ||
+      data.targetLanguageCode !== displayLanguage.value ||
+      data.subject.kind !== "conversation" ||
+      data.subject.conversationSlugId !== conversationSlugId.value
+    ) {
+      return;
+    }
+    void requestedContentQuery.refetch();
+    completionPolling.start();
+  });
+
   function isDisplayContentForMode({
     displayContent,
     mode,
@@ -212,7 +263,25 @@ export function useConversationDisplayContent({
   }
 
   watch([displayLanguage, sortedSpokenLanguageKey], () => {
+    completionPolling.stop();
     modePreference.value = undefined;
+  });
+
+  watch(
+    () => requestedContentQuery.data.value,
+    (displayContent) => {
+      if (
+        displayContent?.status === "available" &&
+        displayContent.mode === "translated"
+      ) {
+        completionPolling.stop();
+      }
+    }
+  );
+
+  onScopeDispose(() => {
+    completionPolling.stop();
+    unsubscribeUpdatedEvents();
   });
 
   return {


### PR DESCRIPTION
## Summary
- keep original conversation content visible while worker translation is pending/materializing
- publish conversation translation completion events to local frontend listeners
- use bounded TanStack Query refetch intervals after completion SSE until translated content is actually present, then stop
- reset to original with the localized timeout notification if translated content still does not materialize

## Verification
- cd services/agora && pnpm exec eslint -c ./eslint.config.js "src/utils/api/contentTranslation/useContentTranslationQueries.ts" "src/utils/translation/boundedTranslationPolling.ts" "src/utils/translation/useConversationDisplayContent.ts" "src/utils/translation/useContentTranslationPreview.ts" "src/composables/useRealtimeSSE.ts"
- cd services/agora && pnpm exec vue-tsc --noEmit

Deploy: agora