### PR TITLE
fix: complete content translation live refresh

### DIFF
--- a/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.vue
+++ b/services/agora/src/components/post/maxdiff/MaxDiffVotingTab.vue
@@ -137,7 +137,7 @@
               ref="candidateContentComponents"
               :conversation-slug-id="conversationSlugId"
               :item="candidateItemBySlugId.get(slugId)"
-              :fallback-text="slugId"
+              fallback-text=""
               @content-changed="checkTruncation"
             />
             <div class="candidate-label">
@@ -616,7 +616,7 @@ watch(
 );
 
 // Detect truncated candidate cards after DOM updates
-watch(candidates, () => {
+watch([candidates, itemBySlugId], () => {
   updateCandidateItemSnapshot();
   void nextTick(checkTruncation);
 });

--- a/services/agora/src/utils/maxdiffCandidateDisplay.test.ts
+++ b/services/agora/src/utils/maxdiffCandidateDisplay.test.ts
@@ -70,21 +70,12 @@ describe("createMaxDiffCandidateDisplaySnapshot", () => {
     }
   });
 
-  it("creates a safe slug fallback when a candidate item is missing", () => {
+  it("omits missing candidate items from the display snapshot", () => {
     const snapshot = createMaxDiffCandidateDisplaySnapshot({
       candidateSlugIds: ["missing"],
       itemBySlugId: new Map(),
     });
 
-    expect(snapshot).toHaveLength(1);
-    expect(snapshot[0]).toMatchObject({
-      slugId: "missing",
-      title: "missing",
-      body: null,
-      externalUrl: null,
-    });
-    expect(snapshot[0]?.displayContent.sourceVersion).toBe(
-      "00000000-0000-4000-8000-000000000000"
-    );
+    expect(snapshot).toEqual([]);
   });
 });

--- a/services/agora/src/utils/maxdiffCandidateDisplay.ts
+++ b/services/agora/src/utils/maxdiffCandidateDisplay.ts
@@ -37,27 +37,17 @@ export function createMaxDiffCandidateDisplaySnapshot({
   candidateSlugIds: readonly string[];
   itemBySlugId: ReadonlyMap<string, MaxDiffCandidateDisplayItem>;
 }): MaxDiffCandidateDisplayItem[] {
-  return candidateSlugIds.map((slugId) => {
+  const snapshot: MaxDiffCandidateDisplayItem[] = [];
+  for (const slugId of candidateSlugIds) {
     const item = itemBySlugId.get(slugId);
-    if (item !== undefined) {
-      return {
-        ...item,
-        displayContent: cloneRankingItemDisplayedContent(item.displayContent),
-      };
+    if (item === undefined) {
+      continue;
     }
 
-    return {
-      slugId,
-      title: slugId,
-      body: null,
-      displayContent: {
-        sourceVersion: "00000000-0000-4000-8000-000000000000",
-        status: "available",
-        mode: "original",
-        content: { title: slugId },
-        translationControl: null,
-      },
-      externalUrl: null,
-    };
-  });
+    snapshot.push({
+      ...item,
+      displayContent: cloneRankingItemDisplayedContent(item.displayContent),
+    });
+  }
+  return snapshot;
 }

--- a/services/agora/src/utils/translation/useContentTranslationPreview.ts
+++ b/services/agora/src/utils/translation/useContentTranslationPreview.ts
@@ -36,9 +36,8 @@ import {
   contentTranslationPreviewTranslations,
 } from "./useContentTranslationPreview.i18n";
 
-const TRANSLATION_WAIT_TIMEOUT_MS = 30_000;
-const TRANSLATION_COMPLETION_POLL_INTERVAL_MS = 500;
-const TRANSLATION_COMPLETION_POLL_MAX_DURATION_MS = 5_000;
+const TRANSLATION_POLL_INTERVAL_MS = 500;
+const TRANSLATION_POLL_MAX_DURATION_MS = 30_000;
 
 function isRateLimitError(error: unknown): boolean {
   return isAxiosError(error) && error.response?.status === 429;
@@ -154,14 +153,13 @@ function useContentTranslationController({
   const sortedSpokenLanguageKey = computed(() =>
     [...spokenLanguages.value].sort().join("\u0000")
   );
-  let waitTimeout: ReturnType<typeof setTimeout> | undefined;
 
   const requestMode = computed<ContentTranslationRequestMode>(() =>
     hasRequestedTranslation.value ? "queue_if_missing" : "read_existing"
   );
-  const completionPolling = useBoundedTranslationPolling({
-    intervalMs: TRANSLATION_COMPLETION_POLL_INTERVAL_MS,
-    maxDurationMs: TRANSLATION_COMPLETION_POLL_MAX_DURATION_MS,
+  const translationPolling = useBoundedTranslationPolling({
+    intervalMs: TRANSLATION_POLL_INTERVAL_MS,
+    maxDurationMs: TRANSLATION_POLL_MAX_DURATION_MS,
     onTimeout: () => {
       resetToOriginal();
       showNotifyMessage(t("translationTimedOut"));
@@ -173,7 +171,7 @@ function useContentTranslationController({
     targetLanguageCode: displayLanguage,
     requestMode,
     enabled: computed(() => toValue(enabled)),
-    refetchInterval: completionPolling.refetchInterval,
+    refetchInterval: translationPolling.refetchInterval,
   });
 
   const isLoadingInitialTranslation = computed(() => {
@@ -257,16 +255,16 @@ function useContentTranslationController({
         translatedVariant.value === undefined
       ) {
         hasRequestedTranslation.value = true;
+        translationPolling.start();
         await query.refetch();
       }
       return;
     }
-    modePreference.value = nextMode;
-    hasRequestedTranslation.value = false;
+    resetToOriginal();
   }
 
   function resetToOriginal(): void {
-    completionPolling.stop();
+    translationPolling.stop();
     modePreference.value = "original";
     hasRequestedTranslation.value = false;
   }
@@ -310,13 +308,6 @@ function useContentTranslationController({
     );
   }
 
-  function clearWaitTimeout(): void {
-    if (waitTimeout !== undefined) {
-      clearTimeout(waitTimeout);
-      waitTimeout = undefined;
-    }
-  }
-
   function isEventForCurrentRequest(
     data: SSEContentTranslationUpdatedData
   ): boolean {
@@ -335,7 +326,6 @@ function useContentTranslationController({
       if (!isEventForCurrentRequest(data)) {
         return;
       }
-      clearWaitTimeout();
       resetToOriginal();
       showNotifyMessage(t("translationFailed"));
     }
@@ -345,28 +335,17 @@ function useContentTranslationController({
     if (!isEventForCurrentRequest(data)) {
       return;
     }
-    clearWaitTimeout();
     void query.refetch();
-    completionPolling.start();
+    translationPolling.start();
   });
 
   watch([translationStatus, translatedVariant], ([status, variant]) => {
     if (status === "completed" && variant !== undefined) {
-      completionPolling.stop();
+      translationPolling.stop();
     }
   });
 
   watch(translationStatus, (status) => {
-    if (status === "pending" || status === "running") {
-      clearWaitTimeout();
-      waitTimeout = setTimeout(() => {
-        resetToOriginal();
-        showNotifyMessage(t("translationTimedOut"));
-      }, TRANSLATION_WAIT_TIMEOUT_MS);
-      return;
-    }
-
-    clearWaitTimeout();
     if (status === "failed") {
       resetToOriginal();
       showQueryFailureToast();
@@ -388,8 +367,7 @@ function useContentTranslationController({
   );
 
   onScopeDispose(() => {
-    clearWaitTimeout();
-    completionPolling.stop();
+    translationPolling.stop();
     unsubscribeUpdatedEvents();
     unsubscribeFailedEvents();
   });

--- a/services/content-translation-worker/src/content_translation_worker/db.py
+++ b/services/content-translation-worker/src/content_translation_worker/db.py
@@ -894,6 +894,7 @@ def process_claimed_work(
 class ConversationSource:
     conversation_slug_id: str
     content_id: int
+    public_id: uuid.UUID
     title: str
     body: str | None
     source_language_code: str | None
@@ -907,6 +908,7 @@ class OpinionSource:
     conversation_slug_id: str
     opinion_slug_id: str
     content_id: int
+    public_id: uuid.UUID
     content: str
     source_language_code: str | None
     source_raw_language_code: str | None
@@ -930,6 +932,7 @@ class SurveyQuestionSource:
     conversation_slug_id: str
     question_slug_id: str
     content_id: int
+    public_id: uuid.UUID
     question_text: str
     source_language_code: str | None
     source_raw_language_code: str | None
@@ -1016,6 +1019,7 @@ def _fetch_conversation_source(
         select(
             Conversation.slug_id,
             ConversationContent.id,
+            ConversationContent.public_id,
             ConversationContent.title,
             ConversationContent.body,
             ConversationContent.source_language_code,
@@ -1037,6 +1041,7 @@ def _fetch_conversation_source(
     return ConversationSource(
         conversation_slug_id=row.slug_id,
         content_id=row.id,
+        public_id=row.public_id,
         title=row.title,
         body=row.body,
         source_language_code=row.source_language_code,
@@ -1056,6 +1061,7 @@ def _fetch_opinion_source(
             Conversation.slug_id.label("conversation_slug_id"),
             Opinion.slug_id.label("opinion_slug_id"),
             OpinionContent.id,
+            OpinionContent.public_id,
             OpinionContent.content,
             OpinionContent.source_language_code,
             OpinionContent.source_raw_language_code,
@@ -1078,6 +1084,7 @@ def _fetch_opinion_source(
         conversation_slug_id=row.conversation_slug_id,
         opinion_slug_id=row.opinion_slug_id,
         content_id=row.id,
+        public_id=row.public_id,
         content=row.content,
         source_language_code=row.source_language_code,
         source_raw_language_code=row.source_raw_language_code,
@@ -1097,6 +1104,7 @@ def _fetch_survey_question_source(
             Conversation.slug_id.label("conversation_slug_id"),
             SurveyQuestion.slug_id.label("question_slug_id"),
             SurveyQuestionContent.id,
+            SurveyQuestionContent.public_id,
             SurveyQuestionContent.question_text,
             SurveyQuestionContent.source_language_code,
             SurveyQuestionContent.source_raw_language_code,
@@ -1142,6 +1150,7 @@ def _fetch_survey_question_source(
         conversation_slug_id=row.conversation_slug_id,
         question_slug_id=row.question_slug_id,
         content_id=row.id,
+        public_id=row.public_id,
         question_text=row.question_text,
         source_language_code=row.source_language_code,
         source_raw_language_code=row.source_raw_language_code,
@@ -1997,7 +2006,7 @@ def _insert_conversation_translation_event(
         conversation_slug_id=source.conversation_slug_id,
         target_language_code=target_language_code,
         status=status,
-        source_version=f"conversation_content:{source.content_id}",
+        source_version=source.public_id,
     )
 
 
@@ -2018,7 +2027,7 @@ def _insert_opinion_translation_event(
         conversation_slug_id=source.conversation_slug_id,
         target_language_code=target_language_code,
         status=status,
-        source_version=f"opinion_content:{source.content_id}",
+        source_version=source.public_id,
     )
 
 
@@ -2029,7 +2038,6 @@ def _insert_survey_question_translation_event(
     target_language_code: str,
     status: Literal["completed", "failed"],
 ) -> None:
-    option_content_ids = ",".join(str(option.content_id) for option in source.options)
     _insert_translation_event(
         session,
         subject={
@@ -2040,9 +2048,7 @@ def _insert_survey_question_translation_event(
         conversation_slug_id=source.conversation_slug_id,
         target_language_code=target_language_code,
         status=status,
-        source_version=(
-            f"survey_question_content:{source.content_id}:option_content:{option_content_ids}"
-        ),
+        source_version=source.public_id,
     )
 
 
@@ -2063,7 +2069,7 @@ def _insert_ranking_item_translation_event(
         conversation_slug_id=source.conversation_slug_id,
         target_language_code=target_language_code,
         status=status,
-        source_version=str(source.public_id),
+        source_version=source.public_id,
     )
 
 
@@ -2150,7 +2156,7 @@ def _insert_translation_event(
     conversation_slug_id: str,
     target_language_code: str,
     status: Literal["completed", "failed"],
-    source_version: str,
+    source_version: uuid.UUID,
 ) -> None:
     timestamp_ms = int(datetime.now(UTC).timestamp() * 1000)
     event_data = build_content_translation_event_data(

--- a/services/content-translation-worker/src/content_translation_worker/events.py
+++ b/services/content-translation-worker/src/content_translation_worker/events.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    import uuid
 
 
 @dataclass(frozen=True)
@@ -16,7 +19,7 @@ def build_content_translation_event_data(
     conversation_slug_id: str,
     target_language_code: str,
     status: Literal["completed", "failed"],
-    source_version: str,
+    source_version: uuid.UUID,
     timestamp_ms: int,
 ) -> ContentTranslationEventData:
     return ContentTranslationEventData(
@@ -24,7 +27,7 @@ def build_content_translation_event_data(
             "subject": subject,
             "targetLanguageCode": target_language_code,
             "status": status,
-            "sourceVersion": source_version,
+            "sourceVersion": str(source_version),
             "timestamp": timestamp_ms,
         },
         topic=f"translation:conversation:{conversation_slug_id}:target:{target_language_code}",

--- a/services/content-translation-worker/tests/test_events.py
+++ b/services/content-translation-worker/tests/test_events.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import uuid
+
 from content_translation_worker.events import build_content_translation_event_data
 
 
 def test_build_content_translation_event_data() -> None:
+    source_version = uuid.UUID("798ef559-29c0-4972-a701-969d977c2ee0")
     event_data = build_content_translation_event_data(
         subject={"kind": "conversation", "conversationSlugId": "conv1234"},
         conversation_slug_id="conv1234",
         target_language_code="fr",
         status="completed",
-        source_version="conversation_content:10",
+        source_version=source_version,
         timestamp_ms=123456,
     )
 
@@ -17,13 +20,14 @@ def test_build_content_translation_event_data() -> None:
         "subject": {"kind": "conversation", "conversationSlugId": "conv1234"},
         "targetLanguageCode": "fr",
         "status": "completed",
-        "sourceVersion": "conversation_content:10",
+        "sourceVersion": str(source_version),
         "timestamp": 123456,
     }
     assert event_data.topic == "translation:conversation:conv1234:target:fr"
 
 
 def test_build_survey_question_content_translation_event_data() -> None:
+    source_version = uuid.UUID("ac01f173-f623-4f34-b10b-5266d2caa42e")
     event_data = build_content_translation_event_data(
         subject={
             "kind": "survey_question",
@@ -33,7 +37,7 @@ def test_build_survey_question_content_translation_event_data() -> None:
         conversation_slug_id="conv1234",
         target_language_code="fr",
         status="failed",
-        source_version="survey_question_content:10:option_content:21,22",
+        source_version=source_version,
         timestamp_ms=123456,
     )
 
@@ -43,4 +47,5 @@ def test_build_survey_question_content_translation_event_data() -> None:
         "questionSlugId": "ques1234",
     }
     assert event_data.payload["status"] == "failed"
+    assert event_data.payload["sourceVersion"] == str(source_version)
     assert event_data.topic == "translation:conversation:conv1234:target:fr"


### PR DESCRIPTION
## Summary
- Start bounded polling immediately after pending content translation requests so missed SSE or replica lag does not leave cards stuck.
- Refresh MaxDiff candidate content when candidate snapshots arrive after item details, and hide slug IDs while content is unavailable.
- Emit content translation worker SSE outbox payloads with UUID sourceVersion values so the API validates and broadcasts content_translation_updated events.

## Commits Included
- 13ede7f8 fix(agora): poll pending content translations
- 17eac224 fix(agora): refresh MaxDiff candidate content
- a852e993 fix(agora): hide missing MaxDiff candidate ids
- 758e6d37 fix(content-translation-worker): emit valid SSE versions

## Verification
- cd services/agora && pnpm exec eslint -c ./eslint.config.js "src/utils/translation/useContentTranslationPreview.ts" "src/components/post/maxdiff/MaxDiffVotingTab.vue" "src/utils/maxdiffCandidateDisplay.ts" "src/utils/maxdiffCandidateDisplay.test.ts"
- cd services/agora && pnpm exec vue-tsc --noEmit
- cd services/content-translation-worker && uv run --extra dev ruff check .
- cd services/content-translation-worker && uv run --extra dev basedpyright
- cd services/content-translation-worker && uv run --extra dev python -m pytest

Deploy: agora, content-translation-worker