### PR TITLE
fix: prevent translation request loops

### DIFF
--- a/services/agora/src/utils/translation/useContentTranslationPreview.ts
+++ b/services/agora/src/utils/translation/useContentTranslationPreview.ts
@@ -211,6 +211,14 @@ function useContentTranslationController({
       return "failed";
     }
     if (content?.kind === "translatable") {
+      if (
+        hasRequestedTranslation.value &&
+        modePreference.value === "translated" &&
+        content.variants.translated === undefined &&
+        content.translation.status !== "failed"
+      ) {
+        return "pending";
+      }
       return content.translation.status;
     }
     return "pending";

--- a/services/agora/src/utils/translation/useContentTranslationPreview.ts
+++ b/services/agora/src/utils/translation/useContentTranslationPreview.ts
@@ -154,9 +154,7 @@ function useContentTranslationController({
     [...spokenLanguages.value].sort().join("\u0000")
   );
 
-  const requestMode = computed<ContentTranslationRequestMode>(() =>
-    hasRequestedTranslation.value ? "queue_if_missing" : "read_existing"
-  );
+  const requestMode = ref<ContentTranslationRequestMode>("read_existing");
   const translationPolling = useBoundedTranslationPolling({
     intervalMs: TRANSLATION_POLL_INTERVAL_MS,
     maxDurationMs: TRANSLATION_POLL_MAX_DURATION_MS,
@@ -254,9 +252,24 @@ function useContentTranslationController({
         translationStatus.value !== "completed" ||
         translatedVariant.value === undefined
       ) {
+        if (hasRequestedTranslation.value) {
+          translationPolling.start();
+          return;
+        }
+        translationPolling.stop();
+        requestMode.value = "queue_if_missing";
         hasRequestedTranslation.value = true;
-        translationPolling.start();
-        await query.refetch();
+        try {
+          await query.refetch();
+        } finally {
+          requestMode.value = "read_existing";
+        }
+        if (
+          translationStatus.value !== "completed" ||
+          translatedVariant.value === undefined
+        ) {
+          translationPolling.start();
+        }
       }
       return;
     }
@@ -265,11 +278,14 @@ function useContentTranslationController({
 
   function resetToOriginal(): void {
     translationPolling.stop();
+    requestMode.value = "read_existing";
     modePreference.value = "original";
     hasRequestedTranslation.value = false;
   }
 
   watch([displayLanguage, sortedSpokenLanguageKey], () => {
+    translationPolling.stop();
+    requestMode.value = "read_existing";
     modePreference.value = undefined;
     hasRequestedTranslation.value = false;
   });

--- a/services/agora/src/utils/translation/useConversationDisplayContent.ts
+++ b/services/agora/src/utils/translation/useConversationDisplayContent.ts
@@ -24,7 +24,10 @@ import {
   getConversationLanguageSettingSourceLanguageCode,
   isSameContentLanguage,
 } from "./contentTranslation";
-import { subscribeToContentTranslationUpdated } from "./contentTranslationEvents";
+import {
+  subscribeToContentTranslationFailed,
+  subscribeToContentTranslationUpdated,
+} from "./contentTranslationEvents";
 import {
   type ContentTranslationPreviewTranslations,
   contentTranslationPreviewTranslations,
@@ -104,6 +107,20 @@ export function useConversationDisplayContent({
     refetchInterval: completionPolling.refetchInterval,
   });
 
+  function resetToOriginal(): void {
+    completionPolling.stop();
+    shouldQueueNextTranslatedRequest.value = false;
+    modePreference.value = "original";
+  }
+
+  function handleTranslationFailure(): void {
+    if (modePreference.value !== "translated") {
+      return;
+    }
+    resetToOriginal();
+    showNotifyMessage(t("translationFailed"));
+  }
+
   const activeDisplayContent = computed<ConversationContentFetchResponse | undefined>(
     () => {
       const requestedDisplayContent = requestedContentQuery.data.value;
@@ -174,13 +191,15 @@ export function useConversationDisplayContent({
       displayContent.status === "available" &&
       displayContent.mode === "translated" &&
       modePreference.value !== "original";
-    const translationStatus =
-      isWaitingForTranslatedContent ||
-      (modePreference.value === "translated" &&
-        !hasTranslatedContent &&
-        translationControl.status !== "failed")
-        ? "pending"
-        : translationControl.status;
+    let translationStatus: LocalizedContentTranslationStatus =
+      translationControl.status;
+    if (
+      translationControl.status !== "failed" &&
+      (isWaitingForTranslatedContent ||
+        (modePreference.value === "translated" && !hasTranslatedContent))
+    ) {
+      translationStatus = "pending";
+    }
 
     const sourceLanguageLabel = getContentTranslationSourceLanguageLabel({
       sourceLanguage: undefined,
@@ -268,6 +287,18 @@ export function useConversationDisplayContent({
     completionPolling.start();
   });
 
+  const unsubscribeFailedEvents = subscribeToContentTranslationFailed((data) => {
+    if (
+      modePreference.value !== "translated" ||
+      data.targetLanguageCode !== displayLanguage.value ||
+      data.subject.kind !== "conversation" ||
+      data.subject.conversationSlugId !== conversationSlugId.value
+    ) {
+      return;
+    }
+    handleTranslationFailure();
+  });
+
   function isDisplayContentForMode({
     displayContent,
     mode,
@@ -311,9 +342,19 @@ export function useConversationDisplayContent({
     }
   );
 
+  watch(
+    () => translationPreview.value?.translationStatus,
+    (status) => {
+      if (status === "failed") {
+        handleTranslationFailure();
+      }
+    }
+  );
+
   onScopeDispose(() => {
     completionPolling.stop();
     unsubscribeUpdatedEvents();
+    unsubscribeFailedEvents();
   });
 
   return {

--- a/services/agora/src/utils/translation/useConversationDisplayContent.ts
+++ b/services/agora/src/utils/translation/useConversationDisplayContent.ts
@@ -8,6 +8,7 @@ import type {
 } from "src/shared/types/zod";
 import { useLanguageStore } from "src/stores/language";
 import {
+  type ContentTranslationRequestMode,
   type ConversationContentMode,
   useConversationContentQuery,
   useConversationDisplayContentCache,
@@ -78,6 +79,12 @@ export function useConversationDisplayContent({
   const requestedMode = computed<ConversationContentMode>(
     () => modePreference.value ?? "original"
   );
+  const shouldQueueNextTranslatedRequest = ref(false);
+  const requestMode = computed<ContentTranslationRequestMode>(() =>
+    shouldQueueNextTranslatedRequest.value && requestedMode.value === "translated"
+      ? "queue_if_missing"
+      : "read_existing"
+  );
   const completionPolling = useBoundedTranslationPolling({
     intervalMs: TRANSLATION_COMPLETION_POLL_INTERVAL_MS,
     maxDurationMs: TRANSLATION_COMPLETION_POLL_MAX_DURATION_MS,
@@ -90,9 +97,7 @@ export function useConversationDisplayContent({
     conversationSlugId,
     sourceVersion,
     mode: requestedMode,
-    requestMode: computed(() =>
-      requestedMode.value === "translated" ? "queue_if_missing" : "read_existing"
-    ),
+    requestMode,
     enabled: computed(
       () => modePreference.value !== undefined && toValue(conversationData) !== undefined
     ),
@@ -230,7 +235,18 @@ export function useConversationDisplayContent({
   });
 
   function setTranslationMode(mode: ContentTranslationDisplayMode): void {
+    completionPolling.stop();
+    if (mode !== "translated") {
+      shouldQueueNextTranslatedRequest.value = false;
+      modePreference.value = mode;
+      return;
+    }
+    const shouldRefetchCurrentMode = modePreference.value === "translated";
+    shouldQueueNextTranslatedRequest.value = true;
     modePreference.value = mode;
+    if (shouldRefetchCurrentMode) {
+      void requestedContentQuery.refetch();
+    }
   }
 
   const unsubscribeUpdatedEvents = subscribeToContentTranslationUpdated((data) => {
@@ -264,8 +280,18 @@ export function useConversationDisplayContent({
 
   watch([displayLanguage, sortedSpokenLanguageKey], () => {
     completionPolling.stop();
+    shouldQueueNextTranslatedRequest.value = false;
     modePreference.value = undefined;
   });
+
+  watch(
+    () => requestedContentQuery.isFetching.value,
+    (isFetching, wasFetching) => {
+      if (wasFetching && !isFetching) {
+        shouldQueueNextTranslatedRequest.value = false;
+      }
+    }
+  );
 
   watch(
     () => requestedContentQuery.data.value,

--- a/services/agora/src/utils/translation/useConversationDisplayContent.ts
+++ b/services/agora/src/utils/translation/useConversationDisplayContent.ts
@@ -170,9 +170,17 @@ export function useConversationDisplayContent({
         mode: "translated",
         isFetching: requestedContentQuery.isFetching.value,
       });
-    const translationStatus = isWaitingForTranslatedContent
-      ? "pending"
-      : translationControl.status;
+    const hasTranslatedContent =
+      displayContent.status === "available" &&
+      displayContent.mode === "translated" &&
+      modePreference.value !== "original";
+    const translationStatus =
+      isWaitingForTranslatedContent ||
+      (modePreference.value === "translated" &&
+        !hasTranslatedContent &&
+        translationControl.status !== "failed")
+        ? "pending"
+        : translationControl.status;
 
     const sourceLanguageLabel = getContentTranslationSourceLanguageLabel({
       sourceLanguage: undefined,
@@ -193,16 +201,14 @@ export function useConversationDisplayContent({
       };
     }
 
-    const isTranslatedContent =
-      displayContent.mode === "translated" && modePreference.value !== "original";
     return {
       isAvailable: true,
       isLoadingInitialTranslation: false,
-      mode: isTranslatedContent ? "translated" : "original",
+      mode: hasTranslatedContent ? "translated" : "original",
       sourceLanguageLabel,
       translationStatus,
-      translatedTitle: isTranslatedContent ? displayContent.content.title : "",
-      translatedBody: isTranslatedContent ? displayContent.content.body : undefined,
+      translatedTitle: hasTranslatedContent ? displayContent.content.title : "",
+      translatedBody: hasTranslatedContent ? displayContent.content.body : undefined,
     };
   });
 

--- a/services/api/src/service/contentTranslation.ts
+++ b/services/api/src/service/contentTranslation.ts
@@ -362,6 +362,30 @@ async function ensureTranslationWork({
             existing.priorityRank,
             priority,
         );
+        if (existing.status === "running" && !completedTranslationExists) {
+            await db
+                .update(contentTranslationWorkTable)
+                .set({
+                    priorityRank: nextPriorityRank,
+                    requestedAt: now,
+                    updatedAt: now,
+                })
+                .where(eq(contentTranslationWorkTable.id, existing.id));
+            log.info(
+                {
+                    workId: existing.id,
+                    ...getTranslationWorkLogFields(input),
+                    previousStatus: existing.status,
+                    previousPriorityRank: existing.priorityRank,
+                    nextPriorityRank,
+                    queueMode: getContentTranslationQueueMode(priority),
+                    translationExists,
+                    shouldQueue: false,
+                },
+                "[ContentTranslation] Reused running translation work row",
+            );
+            return { workId: existing.id, shouldQueue: false };
+        }
         await db
             .update(contentTranslationWorkTable)
             .set({
@@ -575,7 +599,7 @@ async function queueMissingTranslationWork({
                 ...getTranslationWorkLogFields(input),
                 queueMode: getContentTranslationQueueMode(priority),
             },
-            "[ContentTranslation] Translation work already completed",
+            "[ContentTranslation] Translation work not queued",
         );
         return;
     }
@@ -1431,7 +1455,7 @@ async function ensureEagerTranslationWork({
                     CONTENT_TRANSLATION_QUEUE_PRIORITIES.eagerVisible,
                 ),
             },
-            "[ContentTranslation] Translation work already completed",
+            "[ContentTranslation] Translation work not queued",
         );
         return undefined;
     }

--- a/services/api/src/service/contentTranslation.ts
+++ b/services/api/src/service/contentTranslation.ts
@@ -53,8 +53,10 @@ import {
     buildTranslationMetadata,
     hasCompleteSurveyQuestionTranslation,
     shouldQueueTranslationWork,
+    toMissingContentTranslationStatus,
 } from "./contentTranslationContent.js";
 import type { ContentTranslationRequestMode } from "./contentTranslationContent.js";
+import type { MissingContentTranslationStatus } from "./contentTranslationContent.js";
 import {
     getConversationOverrideTranslationTargetLanguagePolicy,
     getProjectTranslationTargetLanguagePolicy,
@@ -297,6 +299,92 @@ function getTranslationWorkLogFields(input: TranslationWorkInput) {
     };
 }
 
+function getTranslationWorkSourceWhere(input: TranslationWorkInput) {
+    if (input.sourceKind === "project") {
+        return eq(contentTranslationWorkTable.projectContentId, input.projectContentId);
+    }
+    if (input.sourceKind === "conversation") {
+        return eq(
+            contentTranslationWorkTable.conversationContentId,
+            input.sourceContentId,
+        );
+    }
+    if (input.sourceKind === "opinion") {
+        return eq(contentTranslationWorkTable.opinionContentId, input.sourceContentId);
+    }
+    if (input.sourceKind === "ranking_item") {
+        return eq(
+            contentTranslationWorkTable.rankingItemContentId,
+            input.rankingItemContentId,
+        );
+    }
+    return and(
+        eq(
+            contentTranslationWorkTable.surveyQuestionContentId,
+            input.surveyQuestionContentId,
+        ),
+        eq(
+            contentTranslationWorkTable.surveyQuestionOptionContentIds,
+            input.surveyQuestionOptionContentIds,
+        ),
+    );
+}
+
+async function fetchMissingContentTranslationStatus({
+    db,
+    input,
+}: {
+    db: PostgresDatabase;
+    input: TranslationWorkInput;
+}): Promise<MissingContentTranslationStatus | undefined> {
+    const rows = await db
+        .select({ status: contentTranslationWorkTable.status })
+        .from(contentTranslationWorkTable)
+        .where(
+            and(
+                eq(contentTranslationWorkTable.sourceKind, input.sourceKind),
+                getTranslationWorkSourceWhere(input),
+                eq(
+                    contentTranslationWorkTable.displayLanguageCode,
+                    input.targetLanguageCode,
+                ),
+            ),
+        )
+        .limit(1);
+    const row = rows.at(0);
+    return row === undefined
+        ? undefined
+        : toMissingContentTranslationStatus(row.status);
+}
+
+async function resolveMissingContentTranslationStatus({
+    db,
+    input,
+    translationExists,
+    requestMode,
+}: {
+    db: PostgresDatabase;
+    input: TranslationWorkInput;
+    translationExists: boolean;
+    requestMode: ContentTranslationRequestMode;
+}): Promise<MissingContentTranslationStatus> {
+    if (translationExists) {
+        return "not_requested";
+    }
+    if (requestMode === "queue_if_missing") {
+        return "pending";
+    }
+    return (
+        (await fetchMissingContentTranslationStatus({ db, input })) ?? "not_requested"
+    );
+}
+
+function getSurveyQuestionOptionContentIds(
+    source: SurveyQuestionContentSource,
+): number[] {
+    return source.options.map((option) => option.contentId).sort((a, b) => a - b);
+}
+
 async function ensureTranslationWork({
     db,
     input,
@@ -312,29 +400,6 @@ async function ensureTranslationWork({
     priority: ContentTranslationQueuePriority;
     log: Pick<BaseLogger, "info">;
 }): Promise<{ workId: number; shouldQueue: boolean }> {
-    const sourceWhere =
-        input.sourceKind === "project"
-            ? eq(contentTranslationWorkTable.projectContentId, input.projectContentId)
-            : input.sourceKind === "conversation"
-            ? eq(contentTranslationWorkTable.conversationContentId, input.sourceContentId)
-            : input.sourceKind === "opinion"
-              ? eq(contentTranslationWorkTable.opinionContentId, input.sourceContentId)
-              : input.sourceKind === "ranking_item"
-                ? eq(
-                      contentTranslationWorkTable.rankingItemContentId,
-                      input.rankingItemContentId,
-                  )
-              : and(
-                    eq(
-                        contentTranslationWorkTable.surveyQuestionContentId,
-                        input.surveyQuestionContentId,
-                    ),
-                    eq(
-                        contentTranslationWorkTable.surveyQuestionOptionContentIds,
-                        input.surveyQuestionOptionContentIds,
-                    ),
-                );
-
     const existingRows = await db
         .select({
             id: contentTranslationWorkTable.id,
@@ -345,7 +410,7 @@ async function ensureTranslationWork({
         .where(
             and(
                 eq(contentTranslationWorkTable.sourceKind, input.sourceKind),
-                sourceWhere,
+                getTranslationWorkSourceWhere(input),
                 eq(
                     contentTranslationWorkTable.displayLanguageCode,
                     input.targetLanguageCode,
@@ -479,29 +544,6 @@ async function markExistingTranslationWorkCompleted({
     now: Date;
     log: Pick<BaseLogger, "info">;
 }): Promise<void> {
-    const sourceWhere =
-        input.sourceKind === "project"
-            ? eq(contentTranslationWorkTable.projectContentId, input.projectContentId)
-            : input.sourceKind === "conversation"
-            ? eq(contentTranslationWorkTable.conversationContentId, input.sourceContentId)
-            : input.sourceKind === "opinion"
-              ? eq(contentTranslationWorkTable.opinionContentId, input.sourceContentId)
-              : input.sourceKind === "ranking_item"
-                ? eq(
-                      contentTranslationWorkTable.rankingItemContentId,
-                      input.rankingItemContentId,
-                  )
-              : and(
-                    eq(
-                        contentTranslationWorkTable.surveyQuestionContentId,
-                        input.surveyQuestionContentId,
-                    ),
-                    eq(
-                        contentTranslationWorkTable.surveyQuestionOptionContentIds,
-                        input.surveyQuestionOptionContentIds,
-                    ),
-                );
-
     const updatedRows = await db
         .update(contentTranslationWorkTable)
         .set({
@@ -518,7 +560,7 @@ async function markExistingTranslationWorkCompleted({
         .where(
             and(
                 eq(contentTranslationWorkTable.sourceKind, input.sourceKind),
-                sourceWhere,
+                getTranslationWorkSourceWhere(input),
                 eq(
                     contentTranslationWorkTable.displayLanguageCode,
                     input.targetLanguageCode,
@@ -982,7 +1024,7 @@ async function hasSurveyQuestionTranslation({
         return false;
     }
 
-    const optionContentIds = source.options.map((option) => option.contentId);
+    const optionContentIds = getSurveyQuestionOptionContentIds(source);
     if (optionContentIds.length === 0) {
         return true;
     }
@@ -1675,9 +1717,8 @@ async function createEagerContentTranslationWorkForConversationSources({
                         conversationId: source.conversationId,
                         sourceKind: "survey_question",
                         surveyQuestionContentId: source.contentId,
-                        surveyQuestionOptionContentIds: source.options.map(
-                            (option) => option.contentId,
-                        ),
+                        surveyQuestionOptionContentIds:
+                            getSurveyQuestionOptionContentIds(source),
                         targetLanguageCode,
                         sourceLanguageCode: source.sourceLanguageCode,
                         sourceRawLanguageCode: source.sourceRawLanguageCode,
@@ -1695,9 +1736,8 @@ async function createEagerContentTranslationWorkForConversationSources({
                     conversationId: source.conversationId,
                     sourceKind: "survey_question",
                     surveyQuestionContentId: source.contentId,
-                    surveyQuestionOptionContentIds: source.options.map(
-                        (option) => option.contentId,
-                    ),
+                    surveyQuestionOptionContentIds:
+                        getSurveyQuestionOptionContentIds(source),
                     targetLanguageCode,
                 },
                 translationExists: false,
@@ -2090,6 +2130,25 @@ async function buildSurveyQuestionResponse({
                 row.translatedOptionText,
             ]),
     );
+    const translationExists =
+        freshQuestionTranslation !== undefined &&
+        source.options.every((option) =>
+            translatedOptionsByContentId.has(option.contentId),
+        );
+    const missingTranslationStatus = translationExists
+        ? "not_requested"
+        : await resolveMissingContentTranslationStatus({
+              db,
+              input: {
+                  conversationId: source.conversationId,
+                  sourceKind: "survey_question",
+                  surveyQuestionContentId: source.contentId,
+                  surveyQuestionOptionContentIds: optionContentIds,
+                  targetLanguageCode,
+              },
+              translationExists,
+              requestMode,
+          });
     return buildLocalizedSurveyQuestionContent({
         source,
         translation:
@@ -2108,7 +2167,7 @@ async function buildSurveyQuestionResponse({
                       translatedOptionsByContentId,
                   },
         targetLanguageCode,
-        requestMode,
+        missingTranslationStatus,
     });
 }
 
@@ -2204,10 +2263,17 @@ async function buildConversationResponse({
                 ...buildTranslationMetadata({
                     targetLanguageCode,
                     sourceMetadata: source,
-                    status:
-                        requestMode === "read_existing"
-                            ? "not_requested"
-                            : "pending",
+                    status: await resolveMissingContentTranslationStatus({
+                        db,
+                        input: {
+                            conversationId: source.conversationId,
+                            sourceKind: "conversation",
+                            sourceContentId: source.contentId,
+                            targetLanguageCode,
+                        },
+                        translationExists: false,
+                        requestMode,
+                    }),
                 }),
             },
             variants: {
@@ -2331,8 +2397,17 @@ async function buildProjectResponse({
                 ...buildTranslationMetadata({
                     targetLanguageCode,
                     sourceMetadata: source,
-                    status:
-                        requestMode === "read_existing" ? "not_requested" : "pending",
+                    status: await resolveMissingContentTranslationStatus({
+                        db,
+                        input: {
+                            conversationId: null,
+                            sourceKind: "project",
+                            projectContentId: source.contentId,
+                            targetLanguageCode,
+                        },
+                        translationExists: false,
+                        requestMode,
+                    }),
                 }),
             },
             variants: {
@@ -2397,7 +2472,20 @@ async function buildRankingItemResponse({
         source,
         translation: freshTranslation,
         targetLanguageCode,
-        requestMode,
+        missingTranslationStatus:
+            freshTranslation === undefined
+                ? await resolveMissingContentTranslationStatus({
+                      db,
+                      input: {
+                          conversationId: source.conversationId,
+                          sourceKind: "ranking_item",
+                          rankingItemContentId: source.contentId,
+                          targetLanguageCode,
+                      },
+                      translationExists: false,
+                      requestMode,
+                  })
+                : "not_requested",
     });
 }
 
@@ -2487,10 +2575,17 @@ async function buildOpinionResponse({
                 ...buildTranslationMetadata({
                     targetLanguageCode,
                     sourceMetadata: source,
-                    status:
-                        requestMode === "read_existing"
-                            ? "not_requested"
-                            : "pending",
+                    status: await resolveMissingContentTranslationStatus({
+                        db,
+                        input: {
+                            conversationId: source.conversationId,
+                            sourceKind: "opinion",
+                            sourceContentId: source.contentId,
+                            targetLanguageCode,
+                        },
+                        translationExists: false,
+                        requestMode,
+                    }),
                 }),
             },
             variants: {
@@ -2560,9 +2655,8 @@ export async function requestContentTranslation({
                     conversationId: source.conversationId,
                     sourceKind: "survey_question",
                     surveyQuestionContentId: source.contentId,
-                    surveyQuestionOptionContentIds: source.options.map(
-                        (option) => option.contentId,
-                    ),
+                    surveyQuestionOptionContentIds:
+                        getSurveyQuestionOptionContentIds(source),
                     targetLanguageCode,
                 },
                 translationExists,
@@ -2909,9 +3003,8 @@ export async function requestSurveyQuestionContentTranslation({
                 conversationId: source.conversationId,
                 sourceKind: "survey_question",
                 surveyQuestionContentId: source.contentId,
-                surveyQuestionOptionContentIds: source.options.map(
-                    (option) => option.contentId,
-                ),
+                surveyQuestionOptionContentIds:
+                    getSurveyQuestionOptionContentIds(source),
                 targetLanguageCode,
             },
             translationExists,

--- a/services/api/src/service/contentTranslationContent.ts
+++ b/services/api/src/service/contentTranslationContent.ts
@@ -13,6 +13,16 @@ import type {
 } from "@/shared/languages.js";
 
 export type ContentTranslationRequestMode = "read_existing" | "queue_if_missing";
+export type MissingContentTranslationStatus = Exclude<
+    LocalizedContentTranslationStatus,
+    "completed"
+>;
+
+export function toMissingContentTranslationStatus(
+    status: MissingContentTranslationStatus | "completed",
+): MissingContentTranslationStatus {
+    return status === "completed" ? "not_requested" : status;
+}
 
 export interface SurveyQuestionLocalizedContentSource {
     conversationSlugId: string;
@@ -172,12 +182,12 @@ export function buildLocalizedSurveyQuestionContent({
     source,
     translation,
     targetLanguageCode,
-    requestMode,
+    missingTranslationStatus,
 }: {
     source: SurveyQuestionLocalizedContentSource;
     translation: SurveyQuestionTranslationSource | undefined;
     targetLanguageCode: SupportedDisplayLanguageCodes;
-    requestMode: ContentTranslationRequestMode;
+    missingTranslationStatus: MissingContentTranslationStatus;
 }): {
     subject: Extract<ContentTranslationSubject, { kind: "survey_question" }>;
     content: LocalizedSurveyQuestionContent;
@@ -241,10 +251,9 @@ export function buildLocalizedSurveyQuestionContent({
             initialMode: "original",
             translation: {
                 ...buildTranslationMetadata({
-                        targetLanguageCode,
-                        sourceMetadata: translation ?? source,
-                        status:
-                            requestMode === "read_existing" ? "not_requested" : "pending",
+                    targetLanguageCode,
+                    sourceMetadata: translation ?? source,
+                    status: missingTranslationStatus,
                 }),
             },
             variants: {
@@ -258,12 +267,12 @@ export function buildLocalizedRankingItemContent({
     source,
     translation,
     targetLanguageCode,
-    requestMode,
+    missingTranslationStatus,
 }: {
     source: RankingItemLocalizedContentSource;
     translation: RankingItemTranslationSource | undefined;
     targetLanguageCode: SupportedDisplayLanguageCodes;
-    requestMode: ContentTranslationRequestMode;
+    missingTranslationStatus: MissingContentTranslationStatus;
 }): {
     subject: Extract<ContentTranslationSubject, { kind: "ranking_item" }>;
     content: LocalizedRankingItemContent;
@@ -310,7 +319,7 @@ export function buildLocalizedRankingItemContent({
             translation: buildTranslationMetadata({
                 targetLanguageCode,
                 sourceMetadata: source,
-                status: requestMode === "read_existing" ? "not_requested" : "pending",
+                status: missingTranslationStatus,
             }),
             variants: {
                 original,

--- a/services/api/src/service/rankingItemDisplay.ts
+++ b/services/api/src/service/rankingItemDisplay.ts
@@ -1,6 +1,9 @@
 import { and, eq, inArray } from "drizzle-orm";
 import type { PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgres-js";
-import { rankingItemContentTranslationTable } from "@/shared-backend/schema.js";
+import {
+    contentTranslationWorkTable,
+    rankingItemContentTranslationTable,
+} from "@/shared-backend/schema.js";
 import type { RankingItemDisplayedContent } from "@/shared/types/zod.js";
 import type {
     SupportedDisplayLanguageCodes,
@@ -10,6 +13,7 @@ import { translationSourceMatchesCurrentSource } from "@/shared-backend/translat
 import {
     buildLocalizedRankingItemContent,
     type RankingItemLocalizedContentSource,
+    toMissingContentTranslationStatus,
 } from "./contentTranslationContent.js";
 import { toRankingItemDisplayContent } from "./conversationContent.js";
 
@@ -83,13 +87,53 @@ export async function buildRankingItemDisplayContentByContentId({
         }
     }
 
+    const workRows = preferences.translationAllowed
+        ? await db
+              .select({
+                  rankingItemContentId:
+                      contentTranslationWorkTable.rankingItemContentId,
+                  status: contentTranslationWorkTable.status,
+              })
+              .from(contentTranslationWorkTable)
+              .where(
+                  and(
+                      eq(contentTranslationWorkTable.sourceKind, "ranking_item"),
+                      inArray(
+                          contentTranslationWorkTable.rankingItemContentId,
+                          sources.map((source) => source.contentId),
+                      ),
+                      eq(
+                          contentTranslationWorkTable.displayLanguageCode,
+                          preferences.targetLanguage,
+                      ),
+                  ),
+              )
+        : [];
+    const missingTranslationStatusByContentId = new Map(
+        workRows.flatMap((row) =>
+            row.rankingItemContentId === null
+                ? []
+                : [
+                      [
+                          row.rankingItemContentId,
+                          toMissingContentTranslationStatus(row.status),
+                      ] as const,
+                  ],
+        ),
+    );
+
     const displayContentByContentId = new Map<number, RankingItemDisplayedContent>();
     for (const source of sources) {
+        const translation = translationsByContentId.get(source.contentId);
         const { content } = buildLocalizedRankingItemContent({
             source,
-            translation: translationsByContentId.get(source.contentId),
+            translation,
             targetLanguageCode: preferences.targetLanguage,
-            requestMode: "read_existing",
+            missingTranslationStatus:
+                translation === undefined
+                    ? (missingTranslationStatusByContentId.get(source.contentId) ??
+                      "not_requested")
+                    : "not_requested",
         });
         displayContentByContentId.set(
             source.contentId,

--- a/services/api/tests/contentTranslationContent.test.ts
+++ b/services/api/tests/contentTranslationContent.test.ts
@@ -4,6 +4,7 @@ import {
     buildLocalizedSurveyQuestionContent,
     hasCompleteSurveyQuestionTranslation,
     shouldQueueTranslationWork,
+    toMissingContentTranslationStatus,
     type RankingItemLocalizedContentSource,
     type RankingItemTranslationSource,
     type SurveyQuestionLocalizedContentSource,
@@ -87,6 +88,13 @@ describe("content translation pure content helpers", () => {
         ).toBe(true);
     });
 
+    it("does not expose completed work without content as pending", () => {
+        expect(toMissingContentTranslationStatus("pending")).toBe("pending");
+        expect(toMissingContentTranslationStatus("running")).toBe("running");
+        expect(toMissingContentTranslationStatus("failed")).toBe("failed");
+        expect(toMissingContentTranslationStatus("completed")).toBe("not_requested");
+    });
+
     it("requires question and every current option translation", () => {
         expect(
             hasCompleteSurveyQuestionTranslation({
@@ -123,7 +131,7 @@ describe("content translation pure content helpers", () => {
                 translatedOptionsByContentId: new Map([[21, "Parcs"]]),
             },
             targetLanguageCode: "fr",
-            requestMode: "queue_if_missing",
+            missingTranslationStatus: "pending",
         });
 
         expect(result).toEqual({
@@ -175,7 +183,7 @@ describe("content translation pure content helpers", () => {
                 ]),
             },
             targetLanguageCode: "fr",
-            requestMode: "read_existing",
+            missingTranslationStatus: "not_requested",
         });
 
         expect(result.content.initialMode).toBe("translated");
@@ -206,7 +214,7 @@ describe("content translation pure content helpers", () => {
             source: rankingItemSource,
             translation: rankingItemTranslation,
             targetLanguageCode: "fr",
-            requestMode: "read_existing",
+            missingTranslationStatus: "not_requested",
         });
 
         expect(result.subject).toEqual({
@@ -231,28 +239,17 @@ describe("content translation pure content helpers", () => {
         });
     });
 
-    it("uses request mode for missing ranking item translation status", () => {
-        const readExisting = buildLocalizedRankingItemContent({
+    it("uses explicit missing ranking item translation status", () => {
+        const result = buildLocalizedRankingItemContent({
             source: rankingItemSource,
             translation: undefined,
             targetLanguageCode: "fr",
-            requestMode: "read_existing",
-        });
-        const queueIfMissing = buildLocalizedRankingItemContent({
-            source: rankingItemSource,
-            translation: undefined,
-            targetLanguageCode: "fr",
-            requestMode: "queue_if_missing",
+            missingTranslationStatus: "failed",
         });
 
-        expect(readExisting.content).toMatchObject({
+        expect(result.content).toMatchObject({
             initialMode: "original",
-            translation: { status: "not_requested" },
-            variants: { original: { title: "Source title" } },
-        });
-        expect(queueIfMissing.content).toMatchObject({
-            initialMode: "original",
-            translation: { status: "pending" },
+            translation: { status: "failed" },
             variants: { original: { title: "Source title" } },
         });
     });

--- a/services/content-translation-worker/src/content_translation_worker/db.py
+++ b/services/content-translation-worker/src/content_translation_worker/db.py
@@ -346,7 +346,11 @@ class ClaimedContentTranslationWork:
 @dataclass(frozen=True)
 class ProcessWorkResult:
     work_id: int
-    status: Literal["completed", "failed", "missing_source"]
+    status: Literal["completed", "failed", "missing_source", "lost_lease"]
+
+
+class LostContentTranslationWorkLeaseError(RuntimeError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -880,13 +884,20 @@ def process_claimed_work(
             return ProcessWorkResult(work_id=claim.id, status="failed")
         _mark_completed(session, claim=claim)
         return ProcessWorkResult(work_id=claim.id, status="completed")
+    except LostContentTranslationWorkLeaseError as error:
+        log.warning("[Worker] %s", error)
+        return ProcessWorkResult(work_id=claim.id, status="lost_lease")
     except Exception as error:
-        _mark_failed(
-            session,
-            claim=claim,
-            error_code=error.__class__.__name__,
-            error_message=str(error),
-        )
+        try:
+            _mark_failed(
+                session,
+                claim=claim,
+                error_code=error.__class__.__name__,
+                error_message=str(error),
+            )
+        except LostContentTranslationWorkLeaseError as lease_error:
+            log.warning("[Worker] %s", lease_error)
+            return ProcessWorkResult(work_id=claim.id, status="lost_lease")
         return ProcessWorkResult(work_id=claim.id, status="failed")
 
 
@@ -2146,7 +2157,7 @@ def _update_claimed_work(
     )
     if updated_id is None:
         msg = f"Lost lease while updating content translation work {claim.id}"
-        raise RuntimeError(msg)
+        raise LostContentTranslationWorkLeaseError(msg)
 
 
 def _insert_translation_event(


### PR DESCRIPTION
## Summary
- Make content translation fallback polling and SSE refetches read-only after the initial user-triggered queue request.
- Avoid repeated queue requests/rate-limit toasts when translation is already pending.
- Preserve running content-translation work leases when duplicate queue requests arrive.
- Treat content-translation worker lost leases as non-fatal processing outcomes instead of crashing the worker.
- Propagate failed content-translation work status through API responses immediately for conversation, opinion, ranking item, survey question, and project content.
- Return conversation display to original mode and show the localized translation failure notification as soon as failure is observed.

## Verification
- cd services/agora && pnpm exec eslint -c ./eslint.config.js "src/utils/translation/useContentTranslationPreview.ts" "src/utils/translation/useConversationDisplayContent.ts"
- cd services/agora && pnpm exec vue-tsc --noEmit
- cd services/api && pnpm lint
- cd services/api && pnpm typecheck
- cd services/api && pnpm vitest tests/contentTranslationContent.test.ts
- cd services/content-translation-worker && uv run --extra dev ruff check .
- cd services/content-translation-worker && uv run --extra dev basedpyright
- cd services/content-translation-worker && uv run --extra dev python -m pytest

Deploy: agora, api, content-translation-worker