### PR TITLE
fix(agora): keep comment fetches viewer-aware

### DIFF
--- a/services/agora/src/utils/api/comment/comment.ts
+++ b/services/agora/src/utils/api/comment/comment.ts
@@ -29,7 +29,7 @@ import type {
   PolisKey,
 } from "src/shared/types/zod";
 import { useAuthenticationStore } from "src/stores/authentication";
-import { watch } from "vue";
+import { waitForAuthInitialization } from "src/utils/auth/waitForAuthInitialization";
 
 import { useBackendAuthApi } from "../auth";
 import { api } from "../client";
@@ -66,7 +66,7 @@ type CreateNewCommentResult =
 
 export function useBackendCommentApi() {
   const { buildEncodedUcan, createRawAxiosRequestConfig } = useCommonApi();
-  const { isGuestOrLoggedIn, isAuthInitialized } = storeToRefs(
+  const { isAuthInitialized, isGuestOrLoggedIn } = storeToRefs(
     useAuthenticationStore()
   );
   const { updateAuthState } = useBackendAuthApi();
@@ -91,21 +91,6 @@ export function useBackendCommentApi() {
     }
 
     return result.data;
-  }
-
-  async function waitForAuthInitialization(): Promise<void> {
-    if (isAuthInitialized.value) {
-      return;
-    }
-
-    await new Promise<void>((resolve) => {
-      const stop = watch(isAuthInitialized, (initialized) => {
-        if (initialized) {
-          stop();
-          resolve();
-        }
-      });
-    });
   }
 
   async function fetchHiddenCommentsForPost(

--- a/services/agora/src/utils/api/comment/comment.ts
+++ b/services/agora/src/utils/api/comment/comment.ts
@@ -29,6 +29,7 @@ import type {
   PolisKey,
 } from "src/shared/types/zod";
 import { useAuthenticationStore } from "src/stores/authentication";
+import { watch } from "vue";
 
 import { useBackendAuthApi } from "../auth";
 import { api } from "../client";
@@ -90,6 +91,21 @@ export function useBackendCommentApi() {
     }
 
     return result.data;
+  }
+
+  async function waitForAuthInitialization(): Promise<void> {
+    if (isAuthInitialized.value) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const stop = watch(isAuthInitialized, (initialized) => {
+        if (initialized) {
+          stop();
+          resolve();
+        }
+      });
+    });
   }
 
   async function fetchHiddenCommentsForPost(
@@ -154,8 +170,9 @@ export function useBackendCommentApi() {
       clusterKey: clusterKey,
     };
 
-    // Use authenticated endpoint only if auth is initialized AND user is logged in/guest
-    if (isAuthInitialized.value && isGuestOrLoggedIn.value) {
+    await waitForAuthInitialization();
+
+    if (isGuestOrLoggedIn.value) {
       const { url, options } =
         await DefaultApiAxiosParamCreator().apiV1OpinionFetchByConversationPost(
           params
@@ -257,6 +274,26 @@ export function useBackendCommentApi() {
     const params: ApiV1OpinionFetchBySlugIdListPostRequest = {
       opinionSlugIdList: opinionSlugIdList,
     };
+
+    await waitForAuthInitialization();
+
+    if (isGuestOrLoggedIn.value) {
+      const { url, options } =
+        await DefaultApiAxiosParamCreator().apiV1OpinionFetchBySlugIdListPost(
+          params
+        );
+      const encodedUcan = await buildEncodedUcan(url, options);
+      const response = await DefaultApiFactory(
+        undefined,
+        undefined,
+        api
+      ).apiV1OpinionFetchBySlugIdListPost(
+        params,
+        createRawAxiosRequestConfig({ encodedUcan: encodedUcan })
+      );
+
+      return Dto.getOpinionBySlugIdListResponse.parse(response.data);
+    }
 
     const response = await DefaultApiFactory(
       undefined,

--- a/services/agora/src/utils/api/comment/comment.ts
+++ b/services/agora/src/utils/api/comment/comment.ts
@@ -66,7 +66,7 @@ type CreateNewCommentResult =
 
 export function useBackendCommentApi() {
   const { buildEncodedUcan, createRawAxiosRequestConfig } = useCommonApi();
-  const { isAuthInitialized, isGuestOrLoggedIn } = storeToRefs(
+  const { isGuestOrLoggedIn } = storeToRefs(
     useAuthenticationStore()
   );
   const { updateAuthState } = useBackendAuthApi();
@@ -306,7 +306,9 @@ export function useBackendCommentApi() {
         freshness: params.freshness,
       };
 
-    if (isAuthInitialized.value && isGuestOrLoggedIn.value) {
+    await waitForAuthInitialization();
+
+    if (isGuestOrLoggedIn.value) {
       const { url, options } =
         await DefaultApiAxiosParamCreator().apiV1OpinionFetchAnalysisFrameManifestByConversationPost(
           requestParams
@@ -349,7 +351,9 @@ export function useBackendCommentApi() {
         freshness: params.freshness,
       };
 
-    if (isAuthInitialized.value && isGuestOrLoggedIn.value) {
+    await waitForAuthInitialization();
+
+    if (isGuestOrLoggedIn.value) {
       const { url, options } =
         await DefaultApiAxiosParamCreator().apiV1OpinionFetchAnalysisFrameGroupsByFramePost(
           requestParams
@@ -392,7 +396,9 @@ export function useBackendCommentApi() {
         freshness: params.freshness,
       };
 
-    if (isAuthInitialized.value && isGuestOrLoggedIn.value) {
+    await waitForAuthInitialization();
+
+    if (isGuestOrLoggedIn.value) {
       const { url, options } =
         await DefaultApiAxiosParamCreator().apiV1OpinionFetchAnalysisFrameGroupLabelsByFramePost(
           requestParams
@@ -437,7 +443,9 @@ export function useBackendCommentApi() {
         freshness: params.freshness,
       };
 
-    if (isAuthInitialized.value && isGuestOrLoggedIn.value) {
+    await waitForAuthInitialization();
+
+    if (isGuestOrLoggedIn.value) {
       const { url, options } =
         await DefaultApiAxiosParamCreator().apiV1OpinionFetchAnalysisFrameOpinionListByFramePost(
           requestParams

--- a/services/agora/src/utils/api/survey/survey.ts
+++ b/services/agora/src/utils/api/survey/survey.ts
@@ -22,6 +22,7 @@ import type {
   SurveyConfig,
 } from "src/shared/types/zod";
 import { useAuthenticationStore } from "src/stores/authentication";
+import { waitForAuthInitialization } from "src/utils/auth/waitForAuthInitialization";
 
 import { api } from "../client";
 import type { AxiosErrorResponse, AxiosSuccessResponse } from "../common";
@@ -33,7 +34,7 @@ export function useBackendSurveyApi() {
     createAxiosErrorResponse,
     createRawAxiosRequestConfig,
   } = useCommonApi();
-  const { isAuthInitialized, isGuestOrLoggedIn } = storeToRefs(
+  const { isGuestOrLoggedIn } = storeToRefs(
     useAuthenticationStore()
   );
 
@@ -44,7 +45,9 @@ export function useBackendSurveyApi() {
     url: string;
     options: RawAxiosRequestConfig;
   }): Promise<RawAxiosRequestConfig> {
-    if (isAuthInitialized.value && isGuestOrLoggedIn.value) {
+    await waitForAuthInitialization();
+
+    if (isGuestOrLoggedIn.value) {
       const encodedUcan = await buildEncodedUcan(url, options);
       return createRawAxiosRequestConfig({ encodedUcan });
     }

--- a/services/agora/src/utils/auth/waitForAuthInitialization.ts
+++ b/services/agora/src/utils/auth/waitForAuthInitialization.ts
@@ -1,0 +1,22 @@
+import { storeToRefs } from "pinia";
+import { useAuthenticationStore } from "src/stores/authentication";
+import { watch } from "vue";
+
+// TODO: Reuse this for optional-auth API wrappers that currently decide between
+// anonymous and authenticated requests from a raw isAuthInitialized.value check.
+export async function waitForAuthInitialization(): Promise<void> {
+  const { isAuthInitialized } = storeToRefs(useAuthenticationStore());
+
+  if (isAuthInitialized.value) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    const stop = watch(isAuthInitialized, (initialized) => {
+      if (initialized) {
+        stop();
+        resolve();
+      }
+    });
+  });
+}

--- a/services/agora/src/utils/auth/waitForAuthInitialization.ts
+++ b/services/agora/src/utils/auth/waitForAuthInitialization.ts
@@ -2,8 +2,6 @@ import { storeToRefs } from "pinia";
 import { useAuthenticationStore } from "src/stores/authentication";
 import { watch } from "vue";
 
-// TODO: Reuse this for optional-auth API wrappers that currently decide between
-// anonymous and authenticated requests from a raw isAuthInitialized.value check.
 export async function waitForAuthInitialization(): Promise<void> {
   const { isAuthInitialized } = storeToRefs(useAuthenticationStore());
 


### PR DESCRIPTION
## Summary
- wait for auth initialization before comment API optional-auth requests choose anonymous vs authenticated mode
- send UCAN for highlighted comments fetched by slug id when the viewer is authenticated
- add a small helper with a TODO for later optional-auth wrapper refactors

## Verification
- cd services/agora && pnpm lint
- cd services/agora && pnpm exec vue-tsc --noEmit

Deploy: agora