### PR TITLE
fix(math-updater): publish empty snapshots

### DIFF
--- a/services/math-updater/src/math_updater/worker.py
+++ b/services/math-updater/src/math_updater/worker.py
@@ -1576,6 +1576,7 @@ def _run_worker_once() -> None:
                     primary_engine,
                     claims=empty_claims,
                     stored_input_snapshots_by_conversation_id=stored_snapshots,
+                    prepared_input_snapshots_by_conversation_id=snapshots_by_conversation_id,
                 )
             except SQLAlchemyError as error:
                 log_database_error(
@@ -1595,6 +1596,9 @@ def _run_worker_once() -> None:
                                 primary_engine,
                                 claims=[claim],
                                 stored_input_snapshots_by_conversation_id=stored_snapshots,
+                                prepared_input_snapshots_by_conversation_id=(
+                                    snapshots_by_conversation_id
+                                ),
                             )
                         )
                     except SQLAlchemyError as isolated_error:

--- a/services/shared-analysis-worker/src/agora_analysis_worker_shared/db.py
+++ b/services/shared-analysis-worker/src/agora_analysis_worker_shared/db.py
@@ -1990,6 +1990,92 @@ def _fetch_previous_selected_view_snapshots_by_pair(
     return previous_by_pair
 
 
+def _persist_conversation_view_snapshot_rows(
+    session: Session,
+    *,
+    pairs: list[tuple[int, int]],
+    snapshot_id_by_conversation_id: dict[int, int],
+    vote_count_by_conversation_id: dict[int, int],
+    participant_count_by_conversation_id: dict[int, int],
+    selected_by_pair: dict[tuple[int, int], _CheckpointCandidateOption | None],
+    survey_aggregate_snapshot_id_by_conversation_id: dict[int, int],
+    premium_analysis_conversation_ids: set[int],
+    ai_generation_expected: bool,
+) -> dict[tuple[int, int], _PersistedConversationViewSnapshot]:
+    unique_pairs = sorted(set(pairs))
+    if not unique_pairs:
+        return {}
+
+    conversation_ids = sorted({conversation_id for conversation_id, _spec_id in unique_pairs})
+    state_by_conversation_id = _fetch_conversation_view_snapshot_state_by_id(
+        session,
+        conversation_ids=conversation_ids,
+    )
+    counters_by_conversation_id = _fetch_conversation_view_snapshot_counters_by_id(
+        session,
+        conversation_ids=conversation_ids,
+    )
+
+    view_snapshot_values: list[dict[str, object]] = []
+    for pair in unique_pairs:
+        conversation_id, opinion_group_spec_id = pair
+        selected = selected_by_pair[pair]
+        state = state_by_conversation_id[conversation_id]
+        counters = counters_by_conversation_id[conversation_id]
+        view_snapshot_values.append(
+            {
+                "conversation_id": conversation_id,
+                "opinion_group_spec_id": opinion_group_spec_id,
+                "analysis_snapshot_id": snapshot_id_by_conversation_id[conversation_id],
+                "survey_aggregate_snapshot_id": (
+                    survey_aggregate_snapshot_id_by_conversation_id.get(conversation_id)
+                ),
+                "conversation_content_id": state.conversation_content_id,
+                "view_reason": ConversationViewSnapshotReasonEnum.analysis_completed,
+                "preferred_opinion_group_count": state.preferred_opinion_group_count
+                if conversation_id in premium_analysis_conversation_ids
+                else None,
+                "is_closed": state.is_closed,
+                "opinion_count": counters.opinion_count,
+                "vote_count": vote_count_by_conversation_id[conversation_id],
+                "participant_count": participant_count_by_conversation_id[conversation_id],
+                "total_opinion_count": counters.total_opinion_count,
+                "total_vote_count": counters.total_vote_count,
+                "total_participant_count": counters.total_participant_count,
+                "moderated_opinion_count": counters.moderated_opinion_count,
+                "hidden_opinion_count": counters.hidden_opinion_count,
+                "activated_at": None
+                if state.ai_labeling_enabled and ai_generation_expected and selected is not None
+                else func.now(),
+            }
+        )
+
+    view_rows = session.execute(
+        sqlalchemy_insert(ConversationViewSnapshot)
+        .values(view_snapshot_values)
+        .returning(
+            ConversationViewSnapshot.id,
+            ConversationViewSnapshot.conversation_id,
+            ConversationViewSnapshot.opinion_group_spec_id,
+        )
+    ).all()
+    view_snapshot_id_by_pair = {
+        (row.conversation_id, row.opinion_group_spec_id): row.id for row in view_rows
+    }
+
+    return {
+        pair: _PersistedConversationViewSnapshot(
+            view_snapshot_id=view_snapshot_id_by_pair[pair],
+            selected_candidate=selected_by_pair[pair],
+            conversation_state=state_by_conversation_id[pair[0]],
+            opinion_count=counters_by_conversation_id[pair[0]].opinion_count,
+            vote_count=vote_count_by_conversation_id[pair[0]],
+            participant_count=participant_count_by_conversation_id[pair[0]],
+        )
+        for pair in unique_pairs
+    }
+
+
 def _persist_conversation_view_snapshots(
     session: Session,
     *,
@@ -2020,14 +2106,6 @@ def _persist_conversation_view_snapshots(
     if not pairs:
         return {}, {}
 
-    state_by_conversation_id = _fetch_conversation_view_snapshot_state_by_id(
-        session,
-        conversation_ids=[claim.conversation_id for claim in claims],
-    )
-    counters_by_conversation_id = _fetch_conversation_view_snapshot_counters_by_id(
-        session,
-        conversation_ids=[claim.conversation_id for claim in claims],
-    )
     # The view snapshot is the consistency boundary for counts and analysis.
     # A selected candidate only controls display/checkpoint/AI-label side effects.
     selected_by_pair: dict[tuple[int, int], _CheckpointCandidateOption | None] = {}
@@ -2036,66 +2114,26 @@ def _persist_conversation_view_snapshots(
         selected = _select_checkpoint_candidate(options)
         selected_by_pair[pair] = selected
 
-    view_snapshot_values: list[dict[str, object]] = []
-    for pair, selected in selected_by_pair.items():
-        conversation_id, opinion_group_spec_id = pair
-        state = state_by_conversation_id[conversation_id]
-        counters = counters_by_conversation_id[conversation_id]
-        input_snapshot = prepared_input_snapshots_by_conversation_id[conversation_id]
-        view_snapshot_values.append(
-            {
-                "conversation_id": conversation_id,
-                "opinion_group_spec_id": opinion_group_spec_id,
-                "analysis_snapshot_id": snapshot_id_by_conversation_id[conversation_id],
-                "survey_aggregate_snapshot_id": (
-                    survey_aggregate_snapshot_id_by_conversation_id.get(conversation_id)
-                ),
-                "conversation_content_id": state.conversation_content_id,
-                "view_reason": ConversationViewSnapshotReasonEnum.analysis_completed,
-                "preferred_opinion_group_count": state.preferred_opinion_group_count
-                if conversation_id in premium_analysis_conversation_ids
-                else None,
-                "is_closed": state.is_closed,
-                "opinion_count": counters.opinion_count,
-                "vote_count": len(input_snapshot.votes),
-                "participant_count": len(input_snapshot.participants),
-                "total_opinion_count": counters.total_opinion_count,
-                "total_vote_count": counters.total_vote_count,
-                "total_participant_count": counters.total_participant_count,
-                "moderated_opinion_count": counters.moderated_opinion_count,
-                "hidden_opinion_count": counters.hidden_opinion_count,
-                "activated_at": None
-                if state.ai_labeling_enabled and ai_generation_expected and selected is not None
-                else func.now(),
-            }
-        )
-
-    view_rows = session.execute(
-        sqlalchemy_insert(ConversationViewSnapshot)
-        .values(view_snapshot_values)
-        .returning(
-            ConversationViewSnapshot.id,
-            ConversationViewSnapshot.conversation_id,
-            ConversationViewSnapshot.opinion_group_spec_id,
-        )
-    ).all()
-    view_snapshot_id_by_pair = {
-        (row.conversation_id, row.opinion_group_spec_id): row.id for row in view_rows
-    }
-
-    return {
-        pair: _PersistedConversationViewSnapshot(
-            view_snapshot_id=view_snapshot_id_by_pair[pair],
-            selected_candidate=selected,
-            conversation_state=state_by_conversation_id[pair[0]],
-            opinion_count=counters_by_conversation_id[pair[0]].opinion_count,
-            vote_count=len(prepared_input_snapshots_by_conversation_id[pair[0]].votes),
-            participant_count=len(
-                prepared_input_snapshots_by_conversation_id[pair[0]].participants
-            ),
-        )
-        for pair, selected in selected_by_pair.items()
-    }, displayable_options_by_pair
+    persisted_view_snapshots_by_pair = _persist_conversation_view_snapshot_rows(
+        session,
+        pairs=pairs,
+        snapshot_id_by_conversation_id=snapshot_id_by_conversation_id,
+        vote_count_by_conversation_id={
+            conversation_id: len(snapshot.votes)
+            for conversation_id, snapshot in prepared_input_snapshots_by_conversation_id.items()
+        },
+        participant_count_by_conversation_id={
+            conversation_id: len(snapshot.participants)
+            for conversation_id, snapshot in prepared_input_snapshots_by_conversation_id.items()
+        },
+        selected_by_pair=selected_by_pair,
+        survey_aggregate_snapshot_id_by_conversation_id=(
+            survey_aggregate_snapshot_id_by_conversation_id
+        ),
+        premium_analysis_conversation_ids=premium_analysis_conversation_ids,
+        ai_generation_expected=ai_generation_expected,
+    )
+    return persisted_view_snapshots_by_pair, displayable_options_by_pair
 
 
 def _queue_conversation_analysis_updated_events_for_view_snapshots(
@@ -3183,6 +3221,7 @@ def persist_empty_vote_matrix_results_batch(
     *,
     claims: list[ClaimedWorkItem],
     stored_input_snapshots_by_conversation_id: dict[int, StoredInputSnapshot],
+    prepared_input_snapshots_by_conversation_id: dict[int, PreparedInputSnapshot],
 ) -> list[int]:
     if not claims:
         return []
@@ -3296,6 +3335,36 @@ def persist_empty_vote_matrix_results_batch(
             ]
         )
         session.execute(candidate_insert)
+
+        pairs = [(claim.conversation_id, claim.opinion_group_spec_id) for claim in claims]
+        persisted_view_snapshots_by_pair = _persist_conversation_view_snapshot_rows(
+            session,
+            pairs=pairs,
+            snapshot_id_by_conversation_id=snapshot_id_by_conversation_id,
+            vote_count_by_conversation_id={
+                claim.conversation_id: len(
+                    prepared_input_snapshots_by_conversation_id[claim.conversation_id].votes
+                )
+                for claim in claims
+            },
+            participant_count_by_conversation_id={
+                claim.conversation_id: len(
+                    prepared_input_snapshots_by_conversation_id[claim.conversation_id].participants
+                )
+                for claim in claims
+            },
+            selected_by_pair={pair: None for pair in pairs},
+            survey_aggregate_snapshot_id_by_conversation_id={},
+            premium_analysis_conversation_ids=premium_analysis_conversation_ids,
+            ai_generation_expected=False,
+        )
+        _queue_conversation_analysis_updated_events_for_view_snapshots(
+            session,
+            conversation_view_snapshot_ids=[
+                view_snapshot.view_snapshot_id
+                for view_snapshot in persisted_view_snapshots_by_pair.values()
+            ],
+        )
 
         completed_generation = case(
             {claim.id: claim.data_generation for claim in claims},

--- a/services/shared-analysis-worker/tests/test_empty_vote_matrix_persistence.py
+++ b/services/shared-analysis-worker/tests/test_empty_vote_matrix_persistence.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Engine, create_engine, literal, select
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from agora_analysis_worker_shared.db import (
+    ClaimedWorkItem,
+    StoredInputSnapshot,
+    persist_empty_vote_matrix_results_batch,
+)
+from agora_analysis_worker_shared.generated_models import (
+    AnalysisInsufficientDataReasonEnum,
+    AnalysisResultOutcomeEnum,
+    AnalysisSnapshot,
+    AnalysisSnapshotResult,
+    AnalysisWorkState,
+    Base,
+    Conversation,
+    ConversationLanguageSettingsSource,
+    ConversationType,
+    ConversationViewSnapshot,
+    ConversationViewSnapshotReasonEnum,
+    OpinionGroupVariant,
+    ParticipationMode,
+    PolisConversationConfig,
+    RealtimeEventOutbox,
+)
+from agora_analysis_worker_shared.input_snapshot import prepare_input_snapshot
+
+if TYPE_CHECKING:
+    import pytest
+    from sqlalchemy.sql.elements import ColumnElement
+
+NOW = datetime(2026, 8, 21, 10, 0, 0, tzinfo=UTC)
+
+
+def _create_engine() -> Engine:
+    def connect() -> sqlite3.Connection:
+        connection = sqlite3.connect(":memory:", check_same_thread=False)
+        connection.create_function("greatest", 2, max)
+        return connection
+
+    engine = create_engine(
+        "sqlite://",
+        creator=connect,
+        poolclass=StaticPool,
+    )
+    created_at_columns = [
+        table.c.created_at for table in Base.metadata.tables.values() if "created_at" in table.c
+    ]
+    for column in created_at_columns:
+        column.nullable = True
+    Base.metadata.create_all(engine)
+    for column in created_at_columns:
+        column.nullable = False
+    return engine
+
+
+def test_empty_vote_matrix_publishes_activated_zero_count_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def current_analysis_generation() -> ColumnElement[int]:
+        return literal(2)
+
+    monkeypatch.setattr(
+        "agora_analysis_worker_shared.db._current_analysis_generation_subquery",
+        current_analysis_generation,
+    )
+    engine = _create_engine()
+    lease_token = "empty-matrix-token"
+    with Session(engine) as session:
+        session.add(
+            PolisConversationConfig(
+                id=10,
+                ai_labeling_enabled=True,
+                analysis_data_generation=2,
+                preferred_opinion_group_count=None,
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+        session.add(
+            Conversation(
+                id=10,
+                slug_id="abc12345",
+                project_id=1,
+                current_content_id=None,
+                polis_config_id=10,
+                ranking_config_id=None,
+                dynamic_translation_enabled=False,
+                language_settings_source=(ConversationLanguageSettingsSource.conversation_override),
+                is_indexed=True,
+                participation_mode=ParticipationMode.account_required,
+                conversation_type=ConversationType.polis,
+                is_importing=False,
+                is_closed=False,
+                is_edited=False,
+                requires_event_ticket=None,
+                created_at=NOW,
+                updated_at=NOW,
+                last_reacted_at=NOW,
+            )
+        )
+        session.add(
+            OpinionGroupVariant(
+                id=20,
+                opinion_group_spec_id=1,
+                group_count=2,
+                created_at=NOW,
+            )
+        )
+        session.add(
+            ConversationViewSnapshot(
+                id=30,
+                conversation_id=10,
+                opinion_group_spec_id=1,
+                analysis_snapshot_id=None,
+                survey_aggregate_snapshot_id=None,
+                conversation_content_id=None,
+                view_reason=ConversationViewSnapshotReasonEnum.analysis_completed,
+                preferred_opinion_group_count=None,
+                is_closed=False,
+                opinion_count=1,
+                vote_count=1,
+                participant_count=1,
+                total_opinion_count=1,
+                total_vote_count=1,
+                total_participant_count=1,
+                moderated_opinion_count=0,
+                hidden_opinion_count=0,
+                activated_at=NOW,
+                created_at=NOW,
+            )
+        )
+        session.add(
+            AnalysisWorkState(
+                id=40,
+                conversation_id=10,
+                opinion_group_spec_id=1,
+                last_completed_data_generation=1,
+                running_data_generation=2,
+                persisted_analysis_snapshot_id=None,
+                dirty_since=NOW,
+                attempt_generation=2,
+                attempt_count=1,
+                non_retryable_generation=None,
+                non_retryable_analysis_engine_epoch=None,
+                lease_owner="math-updater",
+                lease_token=lease_token,
+                lease_expires_at=NOW + timedelta(minutes=5),
+                last_error_kind=None,
+                last_error_code=None,
+                last_error_message=None,
+                last_error_stack_hash=None,
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+        session.commit()
+
+    prepared_snapshot = prepare_input_snapshot(
+        conversation_id=10,
+        data_generation=2,
+        rows=[],
+    )
+    claim = ClaimedWorkItem(
+        id=40,
+        conversation_id=10,
+        conversation_slug_id="abc12345",
+        opinion_group_spec_id=1,
+        data_generation=2,
+        attempt_count=1,
+        lease_token=lease_token,
+        persisted_analysis_snapshot_id=None,
+    )
+
+    newer_generation_ids = persist_empty_vote_matrix_results_batch(
+        engine,
+        claims=[claim],
+        stored_input_snapshots_by_conversation_id={
+            10: StoredInputSnapshot(
+                id=50,
+                conversation_id=10,
+                data_generation=2,
+                input_hash=prepared_snapshot.input_hash,
+            )
+        },
+        prepared_input_snapshots_by_conversation_id={10: prepared_snapshot},
+    )
+
+    with Session(engine) as session:
+        analysis_snapshot = session.execute(select(AnalysisSnapshot)).scalar_one()
+        result = session.execute(select(AnalysisSnapshotResult)).scalar_one()
+        view_snapshots = session.scalars(
+            select(ConversationViewSnapshot).order_by(ConversationViewSnapshot.id)
+        ).all()
+        events = session.scalars(select(RealtimeEventOutbox)).all()
+        work_state = session.execute(select(AnalysisWorkState)).scalar_one()
+
+    assert newer_generation_ids == []
+    assert result.analysis_snapshot_id == analysis_snapshot.id
+    assert result.outcome == AnalysisResultOutcomeEnum.insufficient_data
+    assert result.outcome_reason == AnalysisInsufficientDataReasonEnum.empty_vote_matrix
+    assert len(view_snapshots) == 2
+    published_snapshot = view_snapshots[-1]
+    assert published_snapshot.analysis_snapshot_id == analysis_snapshot.id
+    assert published_snapshot.view_reason == ConversationViewSnapshotReasonEnum.analysis_completed
+    assert published_snapshot.vote_count == 0
+    assert published_snapshot.participant_count == 0
+    assert published_snapshot.activated_at is not None
+    assert len(events) == 1
+    assert events[0].event_type == "conversation_analysis_updated"
+    assert events[0].payload["conversationViewSnapshotId"] == published_snapshot.id
+    assert events[0].payload["analysisSnapshotId"] == analysis_snapshot.id
+    assert events[0].payload["voteCount"] == 0
+    assert events[0].payload["participantCount"] == 0
+    assert work_state.last_completed_data_generation == 2
+    assert work_state.running_data_generation is None
+    assert work_state.lease_token is None


### PR DESCRIPTION
## Summary
- publish an activated conversation view snapshot when the final vote is removed and analysis receives an empty vote matrix
- emit the standard conversation analysis update event with zero vote and participant counts
- share snapshot-row persistence between computed and empty analyses without changing normal candidate selection or AI activation behavior
- add regression coverage for the one-vote-to-zero transition

## Root cause
The empty-matrix path persisted an insufficient-data analysis result and completed the work item, but did not publish an activated conversation view snapshot. Comments used live stats and showed zero, while analysis and project readers remained on the previous activated one-vote snapshot.

## Verification
- shared analysis worker: 149 tests passed
- math updater: 3 tests passed
- Ruff passed for both services
- basedpyright passed for both services
- git diff check passed

## Operational note
Conversations whose empty generation completed before this fix must be reprocessed after deployment, for example through another vote/cancel cycle, because that generation is already marked complete.

Deploy: math-updater