### PR TITLE
fix(agora): align project details layout

### DIFF
--- a/services/agora/src/components/project/ProjectContactCard.vue
+++ b/services/agora/src/components/project/ProjectContactCard.vue
@@ -1,8 +1,5 @@
 <template>
-  <section
-    class="project-contact-card"
-    :class="`project-contact-card--${layout}`"
-  >
+  <section class="project-contact-card">
     <div class="project-contact-card__header">
       <div
         class="project-contact-card__avatar"
@@ -33,7 +30,7 @@
         :href="safeEmailHref"
         :external="false"
         variant="outline"
-        :block="layout === 'sidebar'"
+        block
         :accessible-label="t('emailContactAriaLabel', { name: displayName })"
         :interactive="true"
       />
@@ -45,7 +42,7 @@
         :href="safeWebsiteHref"
         :external="true"
         variant="outline"
-        :block="layout === 'sidebar'"
+        block
         :accessible-label="t('contactPageAriaLabel', { name: displayName })"
         :interactive="true"
       />
@@ -69,7 +66,6 @@ import { getSafeProjectHref, getSafeProjectWebHref } from "./projectUrlSafety";
 const props = defineProps<{
   contact: ProjectContact;
   languageCode: SupportedDisplayLanguageCodes;
-  layout: "sidebar" | "wide";
 }>();
 
 const subtitle = computed(() => {
@@ -181,30 +177,5 @@ p {
 .project-contact-card__actions {
   display: grid;
   gap: 0.85rem;
-}
-
-.project-contact-card--wide {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 1rem;
-
-  .project-contact-card__actions {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 0.5rem;
-  }
-}
-
-@container (max-width: 34rem) {
-  .project-contact-card--wide {
-    grid-template-columns: 1fr;
-
-    .project-contact-card__actions {
-      display: grid;
-      justify-content: flex-start;
-    }
-  }
 }
 </style>

--- a/services/agora/src/components/project/ProjectConversationHeaderCard.vue
+++ b/services/agora/src/components/project/ProjectConversationHeaderCard.vue
@@ -105,88 +105,15 @@
       </div>
     </div>
 
-    <div
-      v-if="hasMobileProjectDetails"
-      class="project-conversation-header-card__mobile-project-details"
-    >
-      <button
-        type="button"
-        class="project-conversation-header-card__mobile-project-details-button"
-        :class="{
-          'project-conversation-header-card__mobile-project-details-button--without-logos':
-            !hasMobileProjectDetailLogos,
-        }"
-        @click="showMobileProjectDetails = true"
-      >
-        <span
-          v-if="hasMobileProjectDetailLogos"
-          class="project-conversation-header-card__mobile-project-details-logos"
-          aria-hidden="true"
-        >
-          <span
-            v-for="entry in mobileAttributionPreviewEntries"
-            :key="`${entry.role}-${entry.displayName}`"
-            class="project-conversation-header-card__mobile-project-details-logo"
-            :class="{
-              'project-conversation-header-card__mobile-project-details-logo--image':
-                entry.imageUrl !== undefined,
-            }"
-            :style="
-              entry.imageUrl === undefined
-                ? logoStyle(entry.accentColor)
-                : undefined
-            "
-          >
-            <OrganizationImage
-              v-if="entry.imageUrl !== undefined"
-              class="project-conversation-header-card__mobile-project-details-logo-image"
-              height="100%"
-              :organization-image-url="entry.imageUrl"
-              :organization-name="entry.displayName"
-            />
-            <template v-else>{{ entry.initials }}</template>
-          </span>
-
-          <span
-            v-if="mobileAttributionHiddenCount > 0"
-            class="project-conversation-header-card__mobile-project-details-logo project-conversation-header-card__mobile-project-details-logo--more"
-          >
-            +{{ mobileAttributionHiddenCount }}
-          </span>
-        </span>
-
-        <span
-          class="project-conversation-header-card__mobile-project-details-summary"
-        >
-          {{ mobileProjectDetailsSummary }}
-        </span>
-
-        <q-icon
-          :name="breadcrumbIcon"
-          size="1.1rem"
-          class="project-conversation-header-card__mobile-project-details-chevron"
-          aria-hidden="true"
-        />
-      </button>
-    </div>
-
-    <q-dialog v-model="showMobileProjectDetails" position="bottom">
-      <ZKBottomDialogContainer
-        :title="t({ key: 'projectDetailsAriaLabel' })"
-        show-close-button
-      >
-        <ProjectDetailsAside
-          :attributions="project.attributions"
-          :contact="project.contact"
-          :language-code="selectedLanguage"
-        />
-      </ZKBottomDialogContainer>
-    </q-dialog>
+    <ProjectMobileDetails
+      :attributions="project.attributions"
+      :contact="project.contact"
+      :language-code="selectedLanguage"
+    />
   </article>
 </template>
 
 <script setup lang="ts">
-import OrganizationImage from "src/components/account/OrganizationImage.vue";
 import ConversationTitle from "src/components/features/conversation/ConversationTitle.vue";
 import {
   type UserIdentityCardTranslations,
@@ -196,7 +123,6 @@ import PostMetadata from "src/components/post/display/PostMetadata.vue";
 import ContentTranslationControl from "src/components/translation/ContentTranslationControl.vue";
 import ContentMetadataLine from "src/components/ui-library/ContentMetadataLine.vue";
 import SpaLink from "src/components/ui-library/SpaLink.vue";
-import ZKBottomDialogContainer from "src/components/ui-library/ZKBottomDialogContainer.vue";
 import ZKChip from "src/components/ui-library/ZKChip.vue";
 import ZKHtmlContent from "src/components/ui-library/ZKHtmlContent.vue";
 import {
@@ -211,15 +137,15 @@ import type {
   ParticipationMode,
 } from "src/shared/types/zod";
 import { useConversationDisplayContent } from "src/utils/translation/useConversationDisplayContent";
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import type { RouteLocationRaw } from "vue-router";
 
-import ProjectDetailsAside from "./ProjectDetailsAside.vue";
+import ProjectMobileDetails from "./ProjectMobileDetails.vue";
 import {
   type ProjectPageTranslations,
   translateProjectPageText,
 } from "./projectPageI18n";
-import type { ProjectAttribution, ProjectPageData } from "./projectPageTypes";
+import type { ProjectPageData } from "./projectPageTypes";
 
 interface ProjectConversationStatusBadge {
   key: string;
@@ -240,7 +166,6 @@ const emit = defineEmits<{
   conversationDeleted: [];
 }>();
 
-const showMobileProjectDetails = ref(false);
 const selectedSupportedLanguage = computed(
   () => parseSupportedDisplayLanguageOrUndefined(props.selectedLanguage) ?? "en"
 );
@@ -280,68 +205,9 @@ const {
   initialDisplayContent,
   fallbackPayload,
 });
-const projectOwnerAttributions = computed(() =>
-  filterAttributions("project_owner")
-);
-const sponsorAttributions = computed(() => filterAttributions("sponsor"));
-const partnerAttributions = computed(() => filterAttributions("partner"));
-const orderedAttributions = computed(() => [
-  ...sponsorAttributions.value,
-  ...projectOwnerAttributions.value,
-  ...partnerAttributions.value,
-]);
-const mobileAttributionPreviewEntries = computed(() =>
-  orderedAttributions.value.slice(0, 4)
-);
-const hasMobileProjectDetailLogos = computed(
-  () => mobileAttributionPreviewEntries.value.length > 0
-);
-const mobileAttributionHiddenCount = computed(() =>
-  Math.max(
-    orderedAttributions.value.length -
-      mobileAttributionPreviewEntries.value.length,
-    0
-  )
-);
-const hasMobileProjectDetails = computed(
-  () =>
-    props.project.attributions.length > 0 || props.project.contact !== undefined
-);
-const mobileProjectDetailsSummary = computed(() => {
-  const leadEntry =
-    projectOwnerAttributions.value.at(0) ?? orderedAttributions.value.at(0);
-  if (leadEntry !== undefined) {
-    const otherCount = orderedAttributions.value.length - 1;
-    if (otherCount <= 0) {
-      return leadEntry.displayName;
-    }
-
-    return `${leadEntry.displayName} & ${otherCount.toString()} others`;
-  }
-
-  return projectContactName.value;
-});
-const projectContactName = computed(() => {
-  const contact = props.project.contact;
-  if (contact === undefined) return "";
-
-  return [contact.firstName, contact.lastName]
-    .filter((part): part is string => part !== undefined)
-    .join(" ");
-});
 const participationStatusBadge = computed<ProjectConversationStatusBadge>(() =>
   getParticipationStatusBadge(props.conversationData.metadata.participationMode)
 );
-
-function filterAttributions(
-  role: ProjectAttribution["role"]
-): readonly ProjectAttribution[] {
-  return props.project.attributions.filter((entry) => entry.role === role);
-}
-
-function logoStyle(color: string): { backgroundColor: string } {
-  return { backgroundColor: color };
-}
 
 function getParticipationStatusBadge(
   participationMode: ParticipationMode
@@ -527,90 +393,6 @@ function t({
 .project-conversation-header-card__conversation-body :deep(.textBreak) {
   font-size: 1rem;
   line-height: 1.65;
-}
-
-.project-conversation-header-card__mobile-project-details {
-  display: none;
-  padding: 0;
-  border: 1px solid $sky-lighter;
-  border-radius: 12px;
-  background: $app-background-color;
-  box-shadow: 0 0.35rem 1rem rgba(10, 7, 20, 0.04);
-}
-
-.project-conversation-header-card__mobile-project-details-button {
-  width: 100%;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 0.65rem;
-  padding: 0.65rem 0.75rem;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  text-align: start;
-  cursor: pointer;
-}
-
-.project-conversation-header-card__mobile-project-details-button--without-logos {
-  grid-template-columns: minmax(0, 1fr) auto;
-}
-
-.project-conversation-header-card__mobile-project-details-logos {
-  display: flex;
-  min-width: 4.1rem;
-}
-
-.project-conversation-header-card__mobile-project-details-logo {
-  width: 1.55rem;
-  height: 1.55rem;
-  display: grid;
-  place-items: center;
-  overflow: hidden;
-  border: 1px solid $sky-lighter;
-  border-radius: 0.35rem;
-  color: white;
-  font-size: 0.55rem;
-  font-weight: var(--font-weight-bold);
-  box-shadow: 0 0 0 2px $app-background-color;
-
-  & + & {
-    margin-inline-start: -0.35rem;
-  }
-}
-
-.project-conversation-header-card__mobile-project-details-logo--image,
-.project-conversation-header-card__mobile-project-details-logo--more {
-  background: white;
-  color: $ink-light;
-}
-
-.project-conversation-header-card__mobile-project-details-logo-image {
-  width: 100%;
-  max-width: 100%;
-  display: block;
-  object-fit: contain;
-}
-
-.project-conversation-header-card__mobile-project-details-summary {
-  overflow: hidden;
-  color: $ink-light;
-  font-size: 0.84rem;
-  font-weight: var(--font-weight-bold);
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.project-conversation-header-card__mobile-project-details-chevron {
-  color: $sky-dark;
-}
-
-@media (max-width: 860px) {
-  .project-conversation-header-card__mobile-project-details {
-    display: grid;
-  }
 }
 
 @media (max-width: 520px) {

--- a/services/agora/src/components/project/ProjectDetailsAside.vue
+++ b/services/agora/src/components/project/ProjectDetailsAside.vue
@@ -22,11 +22,7 @@
       <h2 class="project-details-aside__title">
         {{ t("projectContactTitle") }}
       </h2>
-      <ProjectContactCard
-        :contact="contact"
-        :language-code="languageCode"
-        layout="sidebar"
-      />
+      <ProjectContactCard :contact="contact" :language-code="languageCode" />
     </section>
   </aside>
 </template>

--- a/services/agora/src/components/project/ProjectMobileDetails.vue
+++ b/services/agora/src/components/project/ProjectMobileDetails.vue
@@ -1,0 +1,263 @@
+<template>
+  <div v-if="hasProjectDetails" class="project-mobile-details">
+    <button
+      type="button"
+      class="project-mobile-details__button"
+      :aria-label="t({ key: 'projectDetailsAriaLabel' })"
+      aria-haspopup="dialog"
+      :aria-expanded="showProjectDetails"
+      :class="{
+        'project-mobile-details__button--without-logos': !hasPreviewLogos,
+      }"
+      @click="showProjectDetails = true"
+    >
+      <span
+        v-if="hasPreviewLogos"
+        class="project-mobile-details__logos"
+        aria-hidden="true"
+      >
+        <span
+          v-for="(entry, index) in attributionPreviewEntries"
+          :key="`${entry.role}-${entry.displayName}-${index.toString()}`"
+          class="project-mobile-details__logo"
+          :class="{
+            'project-mobile-details__logo--image': entry.imageUrl !== undefined,
+          }"
+          :style="
+            entry.imageUrl === undefined
+              ? { backgroundColor: entry.accentColor }
+              : undefined
+          "
+        >
+          <OrganizationImage
+            v-if="entry.imageUrl !== undefined"
+            class="project-mobile-details__logo-image"
+            height="100%"
+            loading="lazy"
+            :organization-image-url="entry.imageUrl"
+            :organization-name="entry.displayName"
+          />
+          <template v-else>{{ entry.initials }}</template>
+        </span>
+
+        <span
+          v-if="hiddenAttributionCount > 0"
+          class="project-mobile-details__logo project-mobile-details__logo--more"
+        >
+          +{{ hiddenAttributionCount }}
+        </span>
+      </span>
+
+      <span class="project-mobile-details__summary">
+        {{ projectDetailsSummary }}
+      </span>
+
+      <q-icon
+        :name="detailsIcon"
+        size="1.1rem"
+        class="project-mobile-details__chevron"
+        aria-hidden="true"
+      />
+    </button>
+  </div>
+
+  <q-dialog
+    v-if="hasProjectDetails"
+    v-model="showProjectDetails"
+    position="bottom"
+  >
+    <ZKBottomDialogContainer
+      :title="t({ key: 'projectDetailsAriaLabel' })"
+      show-close-button
+    >
+      <ProjectDetailsAside
+        :attributions="attributions"
+        :contact="contact"
+        :language-code="languageCode"
+      />
+    </ZKBottomDialogContainer>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import OrganizationImage from "src/components/account/OrganizationImage.vue";
+import ZKBottomDialogContainer from "src/components/ui-library/ZKBottomDialogContainer.vue";
+import {
+  getLanguageTextDirection,
+  type SupportedDisplayLanguageCodes,
+} from "src/shared/languages";
+import { computed, ref } from "vue";
+
+import ProjectDetailsAside from "./ProjectDetailsAside.vue";
+import {
+  type ProjectPageTranslations,
+  translateProjectPageText,
+} from "./projectPageI18n";
+import type { ProjectAttribution, ProjectContact } from "./projectPageTypes";
+
+const props = defineProps<{
+  attributions: readonly ProjectAttribution[];
+  contact: ProjectContact | undefined;
+  languageCode: SupportedDisplayLanguageCodes;
+}>();
+
+const attributionRoleOrder = [
+  "sponsor",
+  "project_owner",
+  "partner",
+] satisfies readonly ProjectAttribution["role"][];
+
+const showProjectDetails = ref(false);
+const orderedAttributions = computed(() =>
+  attributionRoleOrder.flatMap((role) => filterAttributions(role))
+);
+const attributionPreviewEntries = computed(() =>
+  orderedAttributions.value.slice(0, 4)
+);
+const hasPreviewLogos = computed(
+  () => attributionPreviewEntries.value.length > 0
+);
+const hiddenAttributionCount = computed(
+  () =>
+    orderedAttributions.value.length - attributionPreviewEntries.value.length
+);
+const hasProjectDetails = computed(
+  () => props.attributions.length > 0 || props.contact !== undefined
+);
+const projectDetailsSummary = computed(() => {
+  const leadEntry =
+    props.attributions.find((entry) => entry.role === "project_owner") ??
+    orderedAttributions.value.at(0);
+  if (leadEntry !== undefined) {
+    const otherCount = orderedAttributions.value.length - 1;
+    if (otherCount === 0) {
+      return leadEntry.displayName;
+    }
+
+    return t({
+      key: "projectDetailsSummary",
+      params: { name: leadEntry.displayName, count: otherCount },
+    });
+  }
+
+  return projectContactName.value;
+});
+const projectContactName = computed(() => {
+  if (props.contact === undefined) return "";
+
+  return [props.contact.firstName, props.contact.lastName]
+    .filter((part): part is string => part !== undefined)
+    .join(" ");
+});
+const detailsIcon = computed(() =>
+  getLanguageTextDirection(props.languageCode) === "rtl"
+    ? "mdi-chevron-left"
+    : "mdi-chevron-right"
+);
+
+function filterAttributions(
+  role: ProjectAttribution["role"]
+): readonly ProjectAttribution[] {
+  return props.attributions.filter((entry) => entry.role === role);
+}
+
+function t({
+  key,
+  params,
+}: {
+  key: keyof ProjectPageTranslations;
+  params?: Readonly<Record<string, string | number>>;
+}): string {
+  return translateProjectPageText({
+    languageCode: props.languageCode,
+    key,
+    params,
+  });
+}
+</script>
+
+<style scoped lang="scss">
+.project-mobile-details {
+  display: none;
+  padding: 0;
+  border: 1px solid $sky-lighter;
+  border-radius: 12px;
+  background: $app-background-color;
+  box-shadow: 0 0.35rem 1rem rgba(10, 7, 20, 0.04);
+}
+
+.project-mobile-details__button {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.65rem 0.75rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+}
+
+.project-mobile-details__button--without-logos {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.project-mobile-details__logos {
+  display: flex;
+  min-width: 4.1rem;
+}
+
+.project-mobile-details__logo {
+  width: 1.55rem;
+  height: 1.55rem;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid $sky-lighter;
+  border-radius: 0.35rem;
+  color: white;
+  font-size: 0.55rem;
+  font-weight: var(--font-weight-bold);
+  box-shadow: 0 0 0 2px $app-background-color;
+
+  & + & {
+    margin-inline-start: -0.35rem;
+  }
+}
+
+.project-mobile-details__logo--image,
+.project-mobile-details__logo--more {
+  background: white;
+  color: $ink-light;
+}
+
+.project-mobile-details__logo-image {
+  width: 100%;
+  max-width: 100%;
+  display: block;
+  object-fit: contain;
+}
+
+.project-mobile-details__summary {
+  overflow: hidden;
+  color: $ink-light;
+  font-size: 0.84rem;
+  font-weight: var(--font-weight-bold);
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-mobile-details__chevron {
+  color: $sky-dark;
+}
+
+@media (max-width: 860px) {
+  .project-mobile-details {
+    display: grid;
+  }
+}
+</style>

--- a/services/agora/src/components/project/ProjectPageView.vue
+++ b/services/agora/src/components/project/ProjectPageView.vue
@@ -77,6 +77,14 @@
             :desktop-collapsed-line-count="4"
           />
 
+          <div class="project-page-view__mobile-details">
+            <ProjectMobileDetails
+              :attributions="project.attributions"
+              :contact="project.contact"
+              :language-code="selectedLanguage"
+            />
+          </div>
+
           <div class="project-page-view__stats">
             <span>
               <q-icon name="mdi-account-outline" size="1rem" />
@@ -112,7 +120,8 @@
         <div
           class="project-page-view__content-grid"
           :class="{
-            'project-page-view__content-grid--without-aside': !hasAttributions,
+            'project-page-view__content-grid--without-aside':
+              !hasProjectDetails,
           }"
         >
           <section
@@ -182,39 +191,20 @@
           </section>
 
           <ProjectDetailsAside
-            v-if="hasAttributions"
+            v-if="hasProjectDetails"
             class="project-page-view__aside"
             :attributions="project.attributions"
-            :contact="undefined"
+            :contact="project.contact"
             :language-code="selectedLanguage"
           />
 
-          <div
-            v-if="project.documents.length > 0 || project.contact !== undefined"
+          <ProjectDocuments
+            v-if="project.documents.length > 0"
             class="project-page-view__supplemental"
-          >
-            <ProjectDocuments
-              :project-slug="project.slug"
-              :documents="project.documents"
-              :language-code="selectedLanguage"
-            />
-
-            <section
-              v-if="project.contact !== undefined"
-              class="project-page-view__facilitator"
-              aria-labelledby="project-facilitator-title"
-            >
-              <ProjectSectionHeading
-                heading-id="project-facilitator-title"
-                :title="t('facilitatorTitle')"
-              />
-              <ProjectContactCard
-                :contact="project.contact"
-                :language-code="selectedLanguage"
-                layout="wide"
-              />
-            </section>
-          </div>
+            :project-slug="project.slug"
+            :documents="project.documents"
+            :language-code="selectedLanguage"
+          />
         </div>
 
         <ProjectPageFooter :language-code="selectedLanguage" />
@@ -234,10 +224,10 @@ import { useProjectDisplayContent } from "src/utils/translation/useProjectDispla
 import { computed } from "vue";
 
 import ProjectActivityCard from "./ProjectActivityCard.vue";
-import ProjectContactCard from "./ProjectContactCard.vue";
 import ProjectDetailsAside from "./ProjectDetailsAside.vue";
 import ProjectDocuments from "./ProjectDocuments.vue";
 import ProjectLanguageSelect from "./ProjectLanguageSelect.vue";
+import ProjectMobileDetails from "./ProjectMobileDetails.vue";
 import ProjectPageFooter from "./ProjectPageFooter.vue";
 import {
   type ProjectPageTranslations,
@@ -249,7 +239,6 @@ import {
   type ProjectLanguageOption,
   type ProjectPageData,
 } from "./projectPageTypes";
-import ProjectSectionHeading from "./ProjectSectionHeading.vue";
 
 type ConsultationStatus = "none" | "live" | "closed";
 
@@ -308,7 +297,10 @@ const consultationStatusClass = computed(() => ({
     consultationStatus.value === "closed",
 }));
 const canLoadMoreActivities = computed(() => props.canLoadMoreActivities);
-const hasAttributions = computed(() => props.project.attributions.length > 0);
+const hasProjectDetails = computed(
+  () =>
+    props.project.attributions.length > 0 || props.project.contact !== undefined
+);
 const hasMultipleLanguageOptions = computed(
   () => new Set(props.languageOptions.map((option) => option.value)).size > 1
 );
@@ -490,6 +482,10 @@ h1 {
   }
 }
 
+.project-page-view__mobile-details {
+  display: none;
+}
+
 .project-page-view__stats {
   display: flex;
   flex-wrap: wrap;
@@ -542,20 +538,9 @@ h1 {
 }
 
 .project-page-view__supplemental {
-  display: flex;
   grid-area: supplemental;
   min-width: 0;
-  flex-direction: column;
-  gap: 1.5rem;
   margin-block-start: 0.5rem;
-}
-
-.project-page-view__facilitator {
-  container-type: inline-size;
-  display: flex;
-  min-width: 0;
-  flex-direction: column;
-  gap: 0.75rem;
 }
 
 .project-page-view__section-heading {
@@ -622,16 +607,20 @@ h2 {
 }
 
 @media (max-width: 860px) {
+  .project-page-view__mobile-details {
+    display: block;
+    margin-block-start: 1rem;
+  }
+
   .project-page-view__content-grid {
     grid-template-columns: 1fr;
     grid-template-areas:
       "activities"
-      "supplemental"
-      "aside";
+      "supplemental";
   }
 
   .project-page-view__aside {
-    position: static;
+    display: none;
   }
 }
 

--- a/services/agora/src/components/project/projectPageI18n.test.ts
+++ b/services/agora/src/components/project/projectPageI18n.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { translateProjectPageText } from "./projectPageI18n";
+
+describe("translateProjectPageText", () => {
+  test("pluralizes the compact project details summary", () => {
+    expect(
+      translateProjectPageText({
+        languageCode: "en",
+        key: "projectDetailsSummary",
+        params: { name: "Polity Cooperative", count: 1 },
+      })
+    ).toBe("Polity Cooperative & 1 other");
+
+    expect(
+      translateProjectPageText({
+        languageCode: "en",
+        key: "projectDetailsSummary",
+        params: { name: "Polity Cooperative", count: 2 },
+      })
+    ).toBe("Polity Cooperative & 2 others");
+  });
+});

--- a/services/agora/src/components/project/projectPageI18n.ts
+++ b/services/agora/src/components/project/projectPageI18n.ts
@@ -5,6 +5,7 @@ import {
 } from "src/shared/languages";
 
 type PluralizableProjectPageTranslationKey =
+  | "projectDetailsSummary"
   | "uniqueParticipantsCount"
   | "participationsCount"
   | "activitiesCount"
@@ -19,6 +20,7 @@ type ProjectPageCountTranslations = Readonly<
 const pluralizableProjectPageTranslationKeys: Readonly<
   Record<PluralizableProjectPageTranslationKey, true>
 > = {
+  projectDetailsSummary: true,
   uniqueParticipantsCount: true,
   participationsCount: true,
   activitiesCount: true,
@@ -58,11 +60,11 @@ export interface ProjectPageTranslations {
   activitiesLoadFailed: string;
   allActivitiesLoaded: string;
   projectDetailsAriaLabel: string;
+  projectDetailsSummary: string;
   sponsorsTitle: string;
   projectOwnersTitle: string;
   partnersTitle: string;
   projectContactTitle: string;
-  facilitatorTitle: string;
   poweredBy: string;
   homeAriaLabel: string;
   contentOwnedByProjectOwners: string;
@@ -121,11 +123,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "More activities could not be loaded.",
     allActivitiesLoaded: "All activities loaded",
     projectDetailsAriaLabel: "Project details",
+    projectDetailsSummary: "{name} & {count} others",
     sponsorsTitle: "Sponsors",
     projectOwnersTitle: "Project Owners",
     partnersTitle: "Partners",
     projectContactTitle: "Contact",
-    facilitatorTitle: "Facilitator",
     poweredBy: "Powered by",
     homeAriaLabel: "Go to Agora Citizen Network home",
     contentOwnedByProjectOwners:
@@ -181,11 +183,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "No se pudieron cargar más actividades.",
     allActivitiesLoaded: "Todas las actividades cargadas",
     projectDetailsAriaLabel: "Detalles del proyecto",
+    projectDetailsSummary: "{name} y {count} más",
     sponsorsTitle: "Patrocinadores",
     projectOwnersTitle: "Responsables del proyecto",
     partnersTitle: "Socios",
     projectContactTitle: "Contacto",
-    facilitatorTitle: "Facilitación",
     poweredBy: "Con tecnología de",
     homeAriaLabel: "Ir al inicio de Agora Citizen Network",
     contentOwnedByProjectOwners:
@@ -241,11 +243,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "Les activités suivantes n'ont pas pu être chargées.",
     allActivitiesLoaded: "Toutes les activités sont chargées",
     projectDetailsAriaLabel: "Détails du projet",
+    projectDetailsSummary: "{name} et {count} autres",
     sponsorsTitle: "Financeurs",
     projectOwnersTitle: "Porteurs du projet",
     partnersTitle: "Partenaires",
     projectContactTitle: "Contact",
-    facilitatorTitle: "Facilitateur",
     poweredBy: "Propulsé par",
     homeAriaLabel: "Aller à l'accueil d'Agora Citizen Network",
     contentOwnedByProjectOwners:
@@ -300,11 +302,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "无法加载更多活动。",
     allActivitiesLoaded: "所有活动已加载",
     projectDetailsAriaLabel: "项目详情",
+    projectDetailsSummary: "{name}及其他 {count} 个",
     sponsorsTitle: "赞助方",
     projectOwnersTitle: "项目负责人",
     partnersTitle: "合作伙伴",
     projectContactTitle: "联系人",
-    facilitatorTitle: "协调人",
     poweredBy: "技术支持",
     homeAriaLabel: "前往 Agora Citizen Network 首页",
     contentOwnedByProjectOwners: "项目内容归项目负责人所有",
@@ -358,11 +360,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "無法載入更多活動。",
     allActivitiesLoaded: "所有活動已載入",
     projectDetailsAriaLabel: "專案詳情",
+    projectDetailsSummary: "{name}及其他 {count} 個",
     sponsorsTitle: "贊助方",
     projectOwnersTitle: "專案負責人",
     partnersTitle: "合作夥伴",
     projectContactTitle: "聯絡人",
-    facilitatorTitle: "協調人",
     poweredBy: "技術支援",
     homeAriaLabel: "前往 Agora Citizen Network 首頁",
     contentOwnedByProjectOwners: "專案內容歸專案負責人所有",
@@ -417,11 +419,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "追加のアクティビティを読み込めませんでした。",
     allActivitiesLoaded: "すべてのアクティビティを読み込みました",
     projectDetailsAriaLabel: "プロジェクト詳細",
+    projectDetailsSummary: "{name}ほか{count}件",
     sponsorsTitle: "スポンサー",
     projectOwnersTitle: "プロジェクトオーナー",
     partnersTitle: "パートナー",
     projectContactTitle: "連絡先",
-    facilitatorTitle: "ファシリテーター",
     poweredBy: "提供",
     homeAriaLabel: "Agora Citizen Network ホームへ移動",
     contentOwnedByProjectOwners:
@@ -476,11 +478,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "تعذر تحميل المزيد من الأنشطة.",
     allActivitiesLoaded: "تم تحميل جميع الأنشطة",
     projectDetailsAriaLabel: "تفاصيل المشروع",
+    projectDetailsSummary: "{name} و{count} آخرون",
     sponsorsTitle: "الرعاة",
     projectOwnersTitle: "مالكو المشروع",
     partnersTitle: "الشركاء",
     projectContactTitle: "جهة الاتصال",
-    facilitatorTitle: "المُيسّر",
     poweredBy: "مدعوم من",
     homeAriaLabel: "الانتقال إلى الصفحة الرئيسية لـ Agora Citizen Network",
     contentOwnedByProjectOwners: "محتوى المشروع مملوك لمالكي المشروع",
@@ -534,11 +536,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "فعالیت‌های بیشتری بارگذاری نشد.",
     allActivitiesLoaded: "همه فعالیت‌ها بارگذاری شدند",
     projectDetailsAriaLabel: "جزئیات پروژه",
+    projectDetailsSummary: "{name} و {count} مورد دیگر",
     sponsorsTitle: "حامیان مالی",
     projectOwnersTitle: "مالکان پروژه",
     partnersTitle: "شرکا",
     projectContactTitle: "تماس",
-    facilitatorTitle: "تسهیل‌گر",
     poweredBy: "قدرت‌گرفته از",
     homeAriaLabel: "رفتن به صفحه اصلی Agora Citizen Network",
     contentOwnedByProjectOwners: "محتوای پروژه متعلق به مالکان پروژه است",
@@ -592,11 +594,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "לא ניתן לטעון פעילויות נוספות.",
     allActivitiesLoaded: "כל הפעילויות נטענו",
     projectDetailsAriaLabel: "פרטי הפרויקט",
+    projectDetailsSummary: "{name} ועוד {count}",
     sponsorsTitle: "נותני חסות",
     projectOwnersTitle: "בעלי הפרויקט",
     partnersTitle: "שותפים",
     projectContactTitle: "איש קשר",
-    facilitatorTitle: "מנחה",
     poweredBy: "מופעל על ידי",
     homeAriaLabel: "מעבר לדף הבית של Agora Citizen Network",
     contentOwnedByProjectOwners: "תוכן הפרויקט שייך לבעלי הפרויקט",
@@ -650,11 +652,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "Кошумча иш-чаралар жүктөлгөн жок.",
     allActivitiesLoaded: "Бардык иш-чаралар жүктөлдү",
     projectDetailsAriaLabel: "Долбоор тууралуу маалымат",
+    projectDetailsSummary: "{name} жана дагы {count}",
     sponsorsTitle: "Демөөрчүлөр",
     projectOwnersTitle: "Долбоор ээлери",
     partnersTitle: "Өнөктөштөр",
     projectContactTitle: "Байланыш",
-    facilitatorTitle: "Фасилитатор",
     poweredBy: "Түзгөн",
     homeAriaLabel: "Agora Citizen Network башкы бетине өтүү",
     contentOwnedByProjectOwners: "Долбоордун мазмуну Долбоор ээлерине таандык",
@@ -709,11 +711,11 @@ export const projectPageTranslations: Readonly<
     activitiesLoadFailed: "Не удалось загрузить больше активностей.",
     allActivitiesLoaded: "Все активности загружены",
     projectDetailsAriaLabel: "Информация о проекте",
+    projectDetailsSummary: "{name} и ещё {count}",
     sponsorsTitle: "Спонсоры",
     projectOwnersTitle: "Владельцы проекта",
     partnersTitle: "Партнеры",
     projectContactTitle: "Контакт",
-    facilitatorTitle: "Фасилитатор",
     poweredBy: "Работает на",
     homeAriaLabel: "Перейти на главную Agora Citizen Network",
     contentOwnedByProjectOwners:
@@ -746,6 +748,10 @@ const projectPageCountTranslations: Readonly<
   >
 > = {
   en: {
+    projectDetailsSummary: {
+      one: "{name} & {count} other",
+      other: "{name} & {count} others",
+    },
     uniqueParticipantsCount: {
       one: "{count} unique participant",
       other: "{count} unique participants",
@@ -763,6 +769,7 @@ const projectPageCountTranslations: Readonly<
     },
   },
   es: {
+    projectDetailsSummary: { other: "{name} y {count} más" },
     uniqueParticipantsCount: {
       one: "{count} participante único",
       other: "{count} participantes únicos",
@@ -783,6 +790,10 @@ const projectPageCountTranslations: Readonly<
     },
   },
   fr: {
+    projectDetailsSummary: {
+      one: "{name} et {count} autre",
+      other: "{name} et {count} autres",
+    },
     uniqueParticipantsCount: {
       one: "{count} participant unique",
       other: "{count} participants uniques",
@@ -803,6 +814,7 @@ const projectPageCountTranslations: Readonly<
     },
   },
   "zh-Hans": {
+    projectDetailsSummary: { other: "{name}及其他 {count} 个" },
     uniqueParticipantsCount: { other: "{count} 位独立参与者" },
     participationsCount: { other: "{count} 次对话参与" },
     activitiesCount: { other: "{count} 个活动" },
@@ -811,6 +823,7 @@ const projectPageCountTranslations: Readonly<
     participantsCount: { other: "{count} 位参与者" },
   },
   "zh-Hant": {
+    projectDetailsSummary: { other: "{name}及其他 {count} 個" },
     uniqueParticipantsCount: { other: "{count} 位不重複參與者" },
     participationsCount: { other: "{count} 次對話參與" },
     activitiesCount: { other: "{count} 個活動" },
@@ -819,6 +832,7 @@ const projectPageCountTranslations: Readonly<
     participantsCount: { other: "{count} 位參與者" },
   },
   ja: {
+    projectDetailsSummary: { other: "{name}ほか{count}件" },
     uniqueParticipantsCount: { other: "{count}人のユニーク参加者" },
     participationsCount: { other: "{count}件の会話参加" },
     activitiesCount: { other: "{count}件のアクティビティ" },
@@ -827,6 +841,7 @@ const projectPageCountTranslations: Readonly<
     participantsCount: { other: "{count}人の参加者" },
   },
   ar: {
+    projectDetailsSummary: { other: "{name} و{count} آخرون" },
     uniqueParticipantsCount: {
       one: "{count} مشارك فريد",
       two: "{count} مشاركان فريدان",
@@ -871,6 +886,7 @@ const projectPageCountTranslations: Readonly<
     },
   },
   fa: {
+    projectDetailsSummary: { other: "{name} و {count} مورد دیگر" },
     uniqueParticipantsCount: { other: "{count} شرکت‌کننده منحصربه‌فرد" },
     participationsCount: { other: "{count} مشارکت در گفتگوها" },
     activitiesCount: { other: "{count} فعالیت" },
@@ -879,6 +895,7 @@ const projectPageCountTranslations: Readonly<
     participantsCount: { other: "{count} شرکت‌کننده" },
   },
   he: {
+    projectDetailsSummary: { other: "{name} ועוד {count}" },
     uniqueParticipantsCount: {
       one: "{count} משתתף ייחודי",
       other: "{count} משתתפים ייחודיים",
@@ -893,6 +910,7 @@ const projectPageCountTranslations: Readonly<
     participantsCount: { one: "{count} משתתף", other: "{count} משתתפים" },
   },
   ky: {
+    projectDetailsSummary: { other: "{name} жана дагы {count}" },
     uniqueParticipantsCount: { other: "{count} уникалдуу катышуучу" },
     participationsCount: { other: "{count} талкууга катышуу" },
     activitiesCount: { other: "{count} иш-чара" },
@@ -901,6 +919,7 @@ const projectPageCountTranslations: Readonly<
     participantsCount: { other: "{count} катышуучу" },
   },
   ru: {
+    projectDetailsSummary: { other: "{name} и ещё {count}" },
     uniqueParticipantsCount: {
       one: "{count} уникальный участник",
       few: "{count} уникальных участника",


### PR DESCRIPTION
## Summary
- move project contact information into the desktop details sidebar with owners, sponsors, and partners
- show all project details through the shared folded control below the project description on mobile
- localize and pluralize the compact summary, improve dialog accessibility, and remove obsolete contact layout code

## Testing
- pnpm exec eslint on changed project components and tests
- pnpm exec vue-tsc --noEmit
- pnpm test (86 files, 552 tests)

Deploy: agora