### PR TITLE
fix(email-updates): grant organization access

### DIFF
--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -109,11 +109,7 @@ export const ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrg
 export type ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrganizationListInnerLocalizationsInnerLanguageCodeEnum = typeof ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrganizationListInnerLocalizationsInnerLanguageCodeEnum[keyof typeof ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrganizationListInnerLocalizationsInnerLanguageCodeEnum];
 
 export interface ApiV1AdministratorOrganizationGetMembersPost200Response {
-    'memberList': Array<ApiV1AdministratorOrganizationGetMembersPost200ResponseMemberListInner>;
-}
-export interface ApiV1AdministratorOrganizationGetMembersPost200ResponseMemberListInner {
-    'username': string;
-    'conversationEmailUpdateCapabilityEnabled': boolean;
+    'memberList': Array<ApiV1UserUsernameUpdatePostRequest>;
 }
 export interface ApiV1AdministratorOrganizationGetOrganizationDetailsPost200Response {
     'organization'?: ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrganizationListInner;
@@ -159,11 +155,6 @@ export const ApiV1AdministratorOrganizationLocalizationUpdatePostRequestLanguage
 
 export type ApiV1AdministratorOrganizationLocalizationUpdatePostRequestLanguageCodeEnum = typeof ApiV1AdministratorOrganizationLocalizationUpdatePostRequestLanguageCodeEnum[keyof typeof ApiV1AdministratorOrganizationLocalizationUpdatePostRequestLanguageCodeEnum];
 
-export interface ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest {
-    'username': string;
-    'organizationSlug': string;
-    'enabled': boolean;
-}
 /**
  * @type ApiV1AdministratorOrganizationSlugUpdatePost200Response
  */
@@ -8658,43 +8649,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @param {ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest} apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost: async (apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest: ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest' is not null or undefined
-            assertParamExists('apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost', 'apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest', apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest)
-            const localVarPath = `/api/v1/administrator/organization/member/email-update-capability/update`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
          * @param {ApiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest} apiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13665,18 +13619,6 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @param {ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest} apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest: ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
          * @param {ApiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest} apiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -15335,15 +15277,6 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @param {ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest} apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest: ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
-            return localVarFp.apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
          * @param {ApiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest} apiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -16614,16 +16547,6 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV1AdministratorOrganizationLocalizationUpdatePost(apiV1AdministratorOrganizationLocalizationUpdatePostRequest: ApiV1AdministratorOrganizationLocalizationUpdatePostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1AdministratorOrganizationLocalizationUpdatePost(apiV1AdministratorOrganizationLocalizationUpdatePostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest} apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    public apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest: ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/services/agora/src/components/administrator/organization/OrganizationManagePanel.vue
+++ b/services/agora/src/components/administrator/organization/OrganizationManagePanel.vue
@@ -172,28 +172,12 @@
             >
               <div class="member-summary">
                 <div class="summary-title">{{ member.username }}</div>
-                <q-checkbox
-                  :model-value="member.conversationEmailUpdateCapabilityEnabled"
-                  :label="t('emailUpdatesCapabilityLabel')"
-                  :disable="
-                    updatingCapabilityUsername !== undefined ||
-                    removingMemberUsername === member.username
-                  "
-                  @update:model-value="
-                    (enabled) =>
-                      updateMemberEmailUpdatesCapability({
-                        username: member.username,
-                        enabled: enabled === true,
-                      })
-                  "
-                />
               </div>
               <q-btn
                 flat
                 color="negative"
                 no-caps
                 :loading="removingMemberUsername === member.username"
-                :disable="updatingCapabilityUsername === member.username"
                 :label="t('removeUserButton')"
                 @click="removeFetchedMember(member.username)"
               />
@@ -337,7 +321,6 @@ const {
   deleteOrganization,
   getOrganizationMembers,
   removeUserOrganizationMapping,
-  updateMemberConversationEmailUpdateCapability,
   updateOrganizationLocalization,
   updateOrganizationSlug,
 } = useBackendAdministratorOrganizationApi();
@@ -350,7 +333,6 @@ const memberUsername = ref("");
 const organizationMembers = ref<OrganizationMember[]>([]);
 const hasLoadedMembers = ref(false);
 const removingMemberUsername = ref<string | undefined>(undefined);
-const updatingCapabilityUsername = ref<string | undefined>(undefined);
 const showDeleteConfirmDialog = ref(false);
 const showSlugConfirmDialog = ref(false);
 const isSaving = ref(false);
@@ -681,41 +663,6 @@ async function removeFetchedMember(username: string): Promise<void> {
 
   if (success) {
     await fetchMembers();
-  }
-}
-
-async function updateMemberEmailUpdatesCapability({
-  username,
-  enabled,
-}: {
-  username: string;
-  enabled: boolean;
-}): Promise<void> {
-  const organization = selectedOrganization.value;
-  if (
-    organization === undefined ||
-    updatingCapabilityUsername.value !== undefined
-  ) {
-    return;
-  }
-
-  updatingCapabilityUsername.value = username;
-  const success = await updateMemberConversationEmailUpdateCapability({
-    username,
-    organizationSlug: organization.slug,
-    enabled,
-  });
-  updatingCapabilityUsername.value = undefined;
-
-  if (success && selectedOrganization.value?.slug === organization.slug) {
-    organizationMembers.value = organizationMembers.value.map((member) =>
-      member.username === username
-        ? {
-            ...member,
-            conversationEmailUpdateCapabilityEnabled: enabled,
-          }
-        : member
-    );
   }
 }
 

--- a/services/agora/src/pages/settings/account/administrator/organization/index.i18n.ts
+++ b/services/agora/src/pages/settings/account/administrator/organization/index.i18n.ts
@@ -41,7 +41,6 @@ export interface AdministratorOrganizationTranslations {
   memberListDescription: string;
   fetchMembersButton: string;
   noMembersMessage: string;
-  emailUpdatesCapabilityLabel: string;
   localizationMissingHint: string;
   defaultLanguageBadge: string;
   localizationReadyBadge: string;
@@ -100,7 +99,6 @@ const en: AdministratorOrganizationTranslations = {
     "Fetch the current member list, then remove users directly from the list.",
   fetchMembersButton: "Fetch members",
   noMembersMessage: "No members found for this organization.",
-  emailUpdatesCapabilityLabel: "Can send Email Updates",
   localizationMissingHint:
     "This language has no saved localization yet. The form is prefilled from the default profile so you can translate it quickly.",
   defaultLanguageBadge: "Default",
@@ -162,7 +160,6 @@ const ar: AdministratorOrganizationTranslations = {
     "استرد قائمة الأعضاء الحالية، ثم أزل المستخدمين مباشرةً من القائمة.",
   fetchMembersButton: "استرداد الأعضاء",
   noMembersMessage: "لم يتم العثور على أعضاء لهذه المنظمة.",
-  emailUpdatesCapabilityLabel: "يمكنه إرسال تحديثات البريد الإلكتروني",
   localizationMissingHint:
     "لا توجد ترجمة محفوظة لهذه اللغة حتى الآن. تمت تعبئة النموذج مسبقًا من الملف التعريفي الافتراضي حتى تتمكن من ترجمته بسرعة.",
   defaultLanguageBadge: "افتراضي",
@@ -226,7 +223,6 @@ const es: AdministratorOrganizationTranslations = {
     "Obtén la lista actual de miembros y después quita usuarios directamente de ella.",
   fetchMembersButton: "Obtener miembros",
   noMembersMessage: "No se encontraron miembros en esta organización.",
-  emailUpdatesCapabilityLabel: "Puede enviar actualizaciones por correo",
   localizationMissingHint:
     "Todavía no hay ninguna localización guardada para este idioma. El formulario se ha rellenado previamente con el perfil predeterminado para que puedas traducirlo rápidamente.",
   defaultLanguageBadge: "Predeterminado",
@@ -288,7 +284,6 @@ const fa: AdministratorOrganizationTranslations = {
     "فهرست اعضای فعلی را دریافت کنید، سپس کاربران را مستقیماً از فهرست حذف کنید.",
   fetchMembersButton: "دریافت اعضا",
   noMembersMessage: "هیچ عضوی برای این سازمان یافت نشد.",
-  emailUpdatesCapabilityLabel: "می‌تواند به‌روزرسانی ایمیلی ارسال کند",
   localizationMissingHint:
     "هنوز بومی‌سازی ذخیره‌شده‌ای برای این زبان وجود ندارد. فرم از نمایه پیش‌فرض از پیش پر شده است تا بتوانید آن را سریع ترجمه کنید.",
   defaultLanguageBadge: "پیش‌فرض",
@@ -352,7 +347,6 @@ const fr: AdministratorOrganizationTranslations = {
     "Récupérez la liste actuelle des membres, puis retirez des utilisateurs directement depuis cette liste.",
   fetchMembersButton: "Récupérer les membres",
   noMembersMessage: "Aucun membre trouvé pour cette organisation.",
-  emailUpdatesCapabilityLabel: "Peut envoyer des suivis par e-mail",
   localizationMissingHint:
     "Aucune localisation n’est encore enregistrée pour cette langue. Le formulaire est prérempli à partir du profil par défaut afin que vous puissiez le traduire rapidement.",
   defaultLanguageBadge: "Par défaut",
@@ -413,7 +407,6 @@ const he: AdministratorOrganizationTranslations = {
     "יש לאחזר את רשימת החברים הנוכחית ולאחר מכן להסיר משתמשים ישירות מהרשימה.",
   fetchMembersButton: "אחזור חברים",
   noMembersMessage: "לא נמצאו חברים בארגון זה.",
-  emailUpdatesCapabilityLabel: "יכול לשלוח עדכונים בדוא״ל",
   localizationMissingHint:
     "עדיין לא נשמרה התאמה לשפה זו. הטופס מולא מראש מנתוני פרופיל ברירת המחדל כדי לאפשר תרגום מהיר.",
   defaultLanguageBadge: "ברירת מחדל",
@@ -475,7 +468,6 @@ const ja: AdministratorOrganizationTranslations = {
     "現在のメンバー一覧を取得し、その一覧からユーザーを直接削除します。",
   fetchMembersButton: "メンバーを取得",
   noMembersMessage: "この組織のメンバーは見つかりませんでした。",
-  emailUpdatesCapabilityLabel: "メール更新を送信可能",
   localizationMissingHint:
     "この言語のローカライズはまだ保存されていません。すぐに翻訳できるよう、フォームにはデフォルトプロフィールの内容があらかじめ入力されています。",
   defaultLanguageBadge: "デフォルト",
@@ -538,7 +530,6 @@ const ky: AdministratorOrganizationTranslations = {
     "Учурдагы мүчөлөрдүн тизмесин алып, андан соң колдонуучуларды тизмеден түз алып салыңыз.",
   fetchMembersButton: "Мүчөлөрдү алуу",
   noMembersMessage: "Бул уюмда мүчөлөр табылган жок.",
-  emailUpdatesCapabilityLabel: "Электрондук жаңыртууларды жөнөтө алат",
   localizationMissingHint:
     "Бул тил үчүн сакталган локалдаштыруу азырынча жок. Тез которушуңуз үчүн форма демейки профилдеги маалыматтар менен алдын ала толтурулду.",
   defaultLanguageBadge: "Демейки",
@@ -602,8 +593,6 @@ const ru: AdministratorOrganizationTranslations = {
     "Получите текущий список участников, а затем удаляйте пользователей непосредственно из списка.",
   fetchMembersButton: "Получить список участников",
   noMembersMessage: "В этой организации нет участников.",
-  emailUpdatesCapabilityLabel:
-    "Может отправлять обновления по электронной почте",
   localizationMissingHint:
     "Для этого языка еще не сохранена локализация. Форма предварительно заполнена данными профиля по умолчанию, чтобы вы могли быстро их перевести.",
   defaultLanguageBadge: "По умолчанию",
@@ -662,7 +651,6 @@ const zhHans: AdministratorOrganizationTranslations = {
   memberListDescription: "获取当前成员列表，然后直接从列表中移除用户。",
   fetchMembersButton: "获取成员",
   noMembersMessage: "未找到该组织的成员。",
-  emailUpdatesCapabilityLabel: "可以发送电子邮件更新",
   localizationMissingHint:
     "此语言尚无已保存的本地化内容。表单已根据默认资料预先填充，方便你快速翻译。",
   defaultLanguageBadge: "默认",
@@ -721,7 +709,6 @@ const zhHant: AdministratorOrganizationTranslations = {
   memberListDescription: "擷取目前的成員清單，然後直接從清單中移除使用者。",
   fetchMembersButton: "擷取成員",
   noMembersMessage: "找不到這個組織的成員。",
-  emailUpdatesCapabilityLabel: "可以傳送電子郵件更新",
   localizationMissingHint:
     "此語言尚無已儲存的本地化內容。表單已根據預設資料預先填入，方便你快速翻譯。",
   defaultLanguageBadge: "預設",

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -2112,7 +2112,6 @@ export class Dto {
     static organizationMember = z
         .object({
             username: zodUsername,
-            conversationEmailUpdateCapabilityEnabled: z.boolean(),
         })
         .strict();
     static getOrganizationMembersResponse = z
@@ -2130,13 +2129,6 @@ export class Dto {
         .object({
             username: zodUsername,
             organizationName: zodOrganizationSlug,
-        })
-        .strict();
-    static updateOrganizationMemberConversationEmailUpdateCapabilityRequest = z
-        .object({
-            username: zodUsername,
-            organizationSlug: zodOrganizationSlug,
-            enabled: z.boolean(),
         })
         .strict();
     static createProjectAttributionRequest = z.discriminatedUnion("source", [
@@ -3748,10 +3740,6 @@ export type OrganizationMember = z.infer<typeof Dto.organizationMember>;
 export type GetOrganizationMembersResponse = z.infer<
     typeof Dto.getOrganizationMembersResponse
 >;
-export type UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest =
-    z.infer<
-        typeof Dto.updateOrganizationMemberConversationEmailUpdateCapabilityRequest
-    >;
 export type AdminOrganizationProperties = z.infer<typeof zodAdminOrganization>;
 export type CreateOrganizationRequest = z.infer<
     typeof Dto.createOrganizationRequest

--- a/services/agora/src/utils/api/administrator/organization.ts
+++ b/services/agora/src/utils/api/administrator/organization.ts
@@ -7,7 +7,6 @@ import {
   type GetOrganizationDetailsRequest,
   type OrganizationMember,
   type UpdateOrganizationLocalizationRequest,
-  type UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest,
   type UpdateOrganizationSlugRequest,
 } from "src/shared/types/dto";
 import type { OrganizationProperties } from "src/shared/types/zod";
@@ -169,27 +168,6 @@ export function useBackendAdministratorOrganizationApi() {
     }
   }
 
-  async function updateMemberConversationEmailUpdateCapability(
-    request: UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest
-  ): Promise<boolean> {
-    try {
-      const params =
-        Dto.updateOrganizationMemberConversationEmailUpdateCapabilityRequest.parse(
-          request
-        );
-      await postWithUcan({
-        url: "/api/v1/administrator/organization/member/email-update-capability/update",
-        data: params,
-      });
-      showNotifyMessage(t("updatedOrganization"));
-      return true;
-    } catch (e) {
-      console.error(e);
-      showNotifyMessage(t("failedToUpdateOrganization"));
-      return false;
-    }
-  }
-
   async function deleteOrganization({
     organizationName,
   }: {
@@ -304,7 +282,6 @@ export function useBackendAdministratorOrganizationApi() {
     updateOrganizationSlug,
     addUserOrganizationMapping,
     removeUserOrganizationMapping,
-    updateMemberConversationEmailUpdateCapability,
     getOrganizationDetails,
     getOrganizationOptions,
     getOrganizationMembers,

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -26945,14 +26945,10 @@
                                                     "username": {
                                                         "type": "string",
                                                         "pattern": "^[a-z0-9_]*$"
-                                                    },
-                                                    "conversationEmailUpdateCapabilityEnabled": {
-                                                        "type": "boolean"
                                                     }
                                                 },
                                                 "required": [
-                                                    "username",
-                                                    "conversationEmailUpdateCapabilityEnabled"
+                                                    "username"
                                                 ],
                                                 "additionalProperties": false
                                             }
@@ -26965,45 +26961,6 @@
                                 }
                             }
                         }
-                    }
-                }
-            }
-        },
-        "/api/v1/administrator/organization/member/email-update-capability/update": {
-            "post": {
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "username": {
-                                        "type": "string",
-                                        "pattern": "^[a-z0-9_]*$"
-                                    },
-                                    "organizationSlug": {
-                                        "type": "string",
-                                        "maxLength": 65,
-                                        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
-                                    },
-                                    "enabled": {
-                                        "type": "boolean"
-                                    }
-                                },
-                                "required": [
-                                    "username",
-                                    "organizationSlug",
-                                    "enabled"
-                                ],
-                                "additionalProperties": false
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "200": {
-                        "description": "Default Response"
                     }
                 }
             }

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -227,7 +227,6 @@ import {
     getOrganizationMembers,
     getOrganizationsByUsername,
     removeUserOrganizationMapping,
-    updateOrganizationMemberConversationEmailUpdateCapability,
     updateOrganizationLocalization,
     updateOrganizationSlug,
 } from "./service/administrator/organization.js";
@@ -5677,22 +5676,6 @@ server.after(() => {
             return await getOrganizationMembers({
                 db,
                 organizationName: request.body.organizationName,
-            });
-        },
-    });
-
-    server.withTypeProvider<ZodTypeProvider>().route({
-        method: "POST",
-        url: `/api/${apiVersion}/administrator/organization/member/email-update-capability/update`,
-        schema: {
-            body: Dto.updateOrganizationMemberConversationEmailUpdateCapabilityRequest,
-        },
-        handler: async (request) => {
-            const adminUserId = await requireSiteOrgAdmin(request);
-            await updateOrganizationMemberConversationEmailUpdateCapability({
-                db,
-                adminUserId,
-                request: request.body,
             });
         },
     });

--- a/services/api/src/service/administrator/organization.ts
+++ b/services/api/src/service/administrator/organization.ts
@@ -19,7 +19,6 @@ import type {
     GetOrganizationOptionsResponse,
     GetOrganizationMembersResponse,
     GetOrganizationsByUsernameResponse,
-    UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest,
     UpdateOrganizationSlugResponse,
     UpdateOrganizationLocalizationRequest,
     UpdateOrganizationLocalizationResponse,
@@ -275,8 +274,6 @@ export async function getOrganizationMembers({
     const memberRows = await getPrimaryDatabase(db)
         .select({
             username: userTable.username,
-            conversationEmailUpdateCapability:
-                organizationMembershipAllProjectCapabilityTable.capability,
         })
         .from(organizationMembershipTable)
         .innerJoin(
@@ -289,22 +286,6 @@ export async function getOrganizationMembers({
         .innerJoin(
             userTable,
             eq(userTable.id, organizationMembershipTable.userId),
-        )
-        .leftJoin(
-            organizationMembershipAllProjectCapabilityTable,
-            and(
-                eq(
-                    organizationMembershipAllProjectCapabilityTable.organizationMembershipId,
-                    organizationMembershipTable.id,
-                ),
-                eq(
-                    organizationMembershipAllProjectCapabilityTable.capability,
-                    "conversation_email_update",
-                ),
-                isNull(
-                    organizationMembershipAllProjectCapabilityTable.deletedAt,
-                ),
-            ),
         )
         .where(
             and(
@@ -320,92 +301,8 @@ export async function getOrganizationMembers({
     return {
         memberList: memberRows.map((member) => ({
             username: member.username,
-            conversationEmailUpdateCapabilityEnabled:
-                member.conversationEmailUpdateCapability ===
-                "conversation_email_update",
         })),
     };
-}
-
-export async function updateOrganizationMemberConversationEmailUpdateCapability({
-    db,
-    adminUserId,
-    request,
-}: {
-    db: PostgresJsDatabase;
-    adminUserId: string;
-    request: UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest;
-}): Promise<void> {
-    const primaryDb = getPrimaryDatabase(db);
-    await primaryDb.transaction(async (transaction) => {
-        const membership = (
-            await transaction
-                .select({ id: organizationMembershipTable.id })
-                .from(organizationMembershipTable)
-                .innerJoin(
-                    organizationTable,
-                    eq(
-                        organizationTable.id,
-                        organizationMembershipTable.organizationId,
-                    ),
-                )
-                .innerJoin(
-                    userTable,
-                    eq(userTable.id, organizationMembershipTable.userId),
-                )
-                .where(
-                    and(
-                        eq(userTable.username, request.username),
-                        eq(userTable.isDeleted, false),
-                        eq(organizationTable.slug, request.organizationSlug),
-                        eq(organizationTable.directoryVisibility, "listed"),
-                        isNull(organizationMembershipTable.deletedAt),
-                        isNull(organizationTable.deletedAt),
-                    ),
-                )
-                .limit(1)
-                .for("update")
-        ).at(0);
-        if (membership === undefined) {
-            throw httpErrors.notFound("Organization membership not found");
-        }
-
-        if (request.enabled) {
-            await transaction
-                .insert(organizationMembershipAllProjectCapabilityTable)
-                .values({
-                    organizationMembershipId: membership.id,
-                    capability: "conversation_email_update",
-                    grantedByUserId: adminUserId,
-                })
-                .onConflictDoNothing();
-            return;
-        }
-
-        const now = new Date();
-        await transaction
-            .update(organizationMembershipAllProjectCapabilityTable)
-            .set({
-                revokedByUserId: adminUserId,
-                updatedAt: now,
-                deletedAt: now,
-            })
-            .where(
-                and(
-                    eq(
-                        organizationMembershipAllProjectCapabilityTable.organizationMembershipId,
-                        membership.id,
-                    ),
-                    eq(
-                        organizationMembershipAllProjectCapabilityTable.capability,
-                        "conversation_email_update",
-                    ),
-                    isNull(
-                        organizationMembershipAllProjectCapabilityTable.deletedAt,
-                    ),
-                ),
-            );
-    });
 }
 
 export async function updateOrganizationSlug({
@@ -671,14 +568,15 @@ export async function addUserOrganizationMapping({
     username,
     organizationName,
 }: AddUserOrganizationMappingProps) {
+    const primaryDb = getPrimaryDatabase(db);
     const { getUserIdFromUsername } = useCommonUser();
     const targetUserId = await getUserIdFromUsername({
-        db: db,
-        username: username,
+        db: primaryDb,
+        username,
     });
 
     const organizationId = await getListedOrganizationIdFromOrganizationSlug({
-        db,
+        db: primaryDb,
         organizationSlug: organizationName,
     });
 
@@ -686,10 +584,12 @@ export async function addUserOrganizationMapping({
         throw httpErrors.notFound("Organization not found");
     }
 
-    await ensureOrganizationMembershipBaselineCapabilities({
-        db,
-        userId: targetUserId,
-        organizationId,
+    await primaryDb.transaction(async (transaction) => {
+        await ensureOrganizationMembershipBaselineCapabilities({
+            db: transaction,
+            userId: targetUserId,
+            organizationId,
+        });
     });
 }
 

--- a/services/api/src/service/administrator/organizationCapability.test.ts
+++ b/services/api/src/service/administrator/organizationCapability.test.ts
@@ -3,11 +3,11 @@ import postgres from "postgres";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+    addUserOrganizationMapping,
     getOrganizationMembers,
-    updateOrganizationMemberConversationEmailUpdateCapability,
 } from "./organization.js";
 
-describe("organization Email Updates capability administration", () => {
+describe("organization membership baseline capabilities", () => {
     let container: StartedTestContainer | undefined;
     let sqlClient: postgres.Sql | undefined;
     let db: PostgresJsDatabase;
@@ -42,11 +42,27 @@ describe("organization Email Updates capability administration", () => {
                 "deleted_at" timestamp
             );
             CREATE TABLE "organization_membership" (
-                "id" integer PRIMARY KEY,
+                "id" integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 "user_id" uuid NOT NULL,
                 "organization_id" integer NOT NULL,
+                "created_at" timestamp NOT NULL DEFAULT now(),
+                "updated_at" timestamp NOT NULL DEFAULT now(),
                 "deleted_at" timestamp
             );
+            CREATE UNIQUE INDEX "organization_membership_active_unique"
+                ON "organization_membership" ("user_id", "organization_id")
+                WHERE "deleted_at" IS NULL;
+            CREATE TABLE "organization_membership_capability" (
+                "id" integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                "organization_membership_id" integer NOT NULL,
+                "capability" text NOT NULL,
+                "created_at" timestamp NOT NULL DEFAULT now()
+            );
+            CREATE UNIQUE INDEX "organization_membership_capability_unique"
+                ON "organization_membership_capability" (
+                    "organization_membership_id",
+                    "capability"
+                );
             CREATE TABLE "organization_membership_all_project_capability" (
                 "id" integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
                 "organization_membership_id" integer NOT NULL,
@@ -66,11 +82,6 @@ describe("organization Email Updates capability administration", () => {
             VALUES ('00000000-0000-4000-8000-000000000001', 'author');
             INSERT INTO "organization" ("id", "slug", "directory_visibility")
             VALUES (1, 'test-org', 'listed');
-            INSERT INTO "organization_membership" (
-                "id",
-                "user_id",
-                "organization_id"
-            ) VALUES (1, '00000000-0000-4000-8000-000000000001', 1);
         `);
     }, 60_000);
 
@@ -83,115 +94,37 @@ describe("organization Email Updates capability administration", () => {
         }
     });
 
-    it("records capability grant and revocation history", async () => {
+    it("grants Email Updates when adding an organization member", async () => {
         const client = sqlClient;
         if (client === undefined) {
             throw new Error("Test database client was not initialized");
         }
-        await expect(
-            getOrganizationMembers({
-                db,
-                organizationName: "test-org",
-            }),
-        ).resolves.toEqual({
-            memberList: [
-                {
-                    username: "author",
-                    conversationEmailUpdateCapabilityEnabled: false,
-                },
-            ],
-        });
 
-        await updateOrganizationMemberConversationEmailUpdateCapability({
-            db,
-            adminUserId: "00000000-0000-4000-8000-000000000001",
-            request: {
+        await Promise.all([
+            addUserOrganizationMapping({
+                db,
                 username: "author",
-                organizationSlug: "test-org",
-                enabled: true,
-            },
-        });
-        await expect(
-            getOrganizationMembers({
-                db,
                 organizationName: "test-org",
             }),
-        ).resolves.toEqual({
-            memberList: [
-                {
-                    username: "author",
-                    conversationEmailUpdateCapabilityEnabled: true,
-                },
-            ],
-        });
-
-        await updateOrganizationMemberConversationEmailUpdateCapability({
-            db,
-            adminUserId: "00000000-0000-4000-8000-000000000001",
-            request: {
+            addUserOrganizationMapping({
+                db,
                 username: "author",
-                organizationSlug: "test-org",
-                enabled: false,
-            },
-        });
-        await expect(
-            getOrganizationMembers({
-                db,
                 organizationName: "test-org",
             }),
-        ).resolves.toEqual({
-            memberList: [
-                {
-                    username: "author",
-                    conversationEmailUpdateCapabilityEnabled: false,
-                },
-            ],
-        });
+        ]);
 
-        const revokedGrants = await client`
-            SELECT
-                granted_by_user_id,
-                revoked_by_user_id,
-                deleted_at
-            FROM organization_membership_all_project_capability
+        const emailUpdateCapabilities = await client`
+            SELECT "capability"
+            FROM "organization_membership_all_project_capability"
+            WHERE "capability" = 'conversation_email_update'
+                AND "deleted_at" IS NULL
         `;
-        expect(revokedGrants).toHaveLength(1);
-        expect(revokedGrants[0]).toMatchObject({
-            granted_by_user_id: "00000000-0000-4000-8000-000000000001",
-            revoked_by_user_id: "00000000-0000-4000-8000-000000000001",
-        });
-        expect(revokedGrants[0].deleted_at).not.toBeNull();
-
-        await updateOrganizationMemberConversationEmailUpdateCapability({
-            db,
-            adminUserId: "00000000-0000-4000-8000-000000000001",
-            request: {
-                username: "author",
-                organizationSlug: "test-org",
-                enabled: true,
-            },
-        });
-        const grantHistory = await client`
-            SELECT deleted_at
-            FROM organization_membership_all_project_capability
-            ORDER BY id
-        `;
-        expect(grantHistory).toHaveLength(2);
-        expect(grantHistory[0].deleted_at).not.toBeNull();
-        expect(grantHistory[1].deleted_at).toBeNull();
-    });
-
-    it("rejects users who are not active organization members", async () => {
+        expect(emailUpdateCapabilities).toHaveLength(1);
         await expect(
-            updateOrganizationMemberConversationEmailUpdateCapability({
+            getOrganizationMembers({
                 db,
-                adminUserId: "00000000-0000-4000-8000-000000000001",
-                request: {
-                    username: "missing",
-                    organizationSlug: "test-org",
-                    enabled: true,
-                },
+                organizationName: "test-org",
             }),
-        ).rejects.toMatchObject({ statusCode: 404 });
+        ).resolves.toEqual({ memberList: [{ username: "author" }] });
     });
 });

--- a/services/api/src/service/conversationEmailUpdate.ts
+++ b/services/api/src/service/conversationEmailUpdate.ts
@@ -2440,6 +2440,112 @@ async function lockProject({
     return rows.length === 1;
 }
 
+async function lockActiveEmailUpdateAuthorization({
+    db,
+    projectId,
+    organizationId,
+    entitlementId,
+    userId,
+    now,
+}: {
+    db: PostgresJsDatabase;
+    projectId: number;
+    organizationId: number;
+    entitlementId: number;
+    userId: string;
+    now: Date;
+}): Promise<boolean> {
+    const rows = await db
+        .select({ membershipId: organizationMembershipTable.id })
+        .from(projectOrganizationOwnershipTable)
+        .innerJoin(
+            organizationTable,
+            and(
+                eq(
+                    organizationTable.id,
+                    projectOrganizationOwnershipTable.organizationId,
+                ),
+                isNull(organizationTable.deletedAt),
+            ),
+        )
+        .innerJoin(
+            organizationMembershipTable,
+            and(
+                eq(
+                    organizationMembershipTable.organizationId,
+                    projectOrganizationOwnershipTable.organizationId,
+                ),
+                eq(organizationMembershipTable.userId, userId),
+                isNull(organizationMembershipTable.deletedAt),
+            ),
+        )
+        .innerJoin(
+            userTable,
+            and(
+                eq(userTable.id, organizationMembershipTable.userId),
+                eq(userTable.isDeleted, false),
+            ),
+        )
+        .innerJoin(
+            organizationMembershipAllProjectCapabilityTable,
+            and(
+                eq(
+                    organizationMembershipAllProjectCapabilityTable.organizationMembershipId,
+                    organizationMembershipTable.id,
+                ),
+                eq(
+                    organizationMembershipAllProjectCapabilityTable.capability,
+                    "conversation_email_update",
+                ),
+                isNull(
+                    organizationMembershipAllProjectCapabilityTable.deletedAt,
+                ),
+            ),
+        )
+        .innerJoin(
+            premiumFeatureEntitlementTable,
+            and(
+                eq(premiumFeatureEntitlementTable.id, entitlementId),
+                eq(
+                    premiumFeatureEntitlementTable.organizationId,
+                    projectOrganizationOwnershipTable.organizationId,
+                ),
+                eq(
+                    premiumFeatureEntitlementTable.feature,
+                    "conversation_email_update",
+                ),
+                lte(premiumFeatureEntitlementTable.startsAt, now),
+                isNull(premiumFeatureEntitlementTable.revokedAt),
+                or(
+                    isNull(premiumFeatureEntitlementTable.expiresAt),
+                    gt(premiumFeatureEntitlementTable.expiresAt, now),
+                ),
+            ),
+        )
+        .where(
+            and(
+                eq(projectOrganizationOwnershipTable.projectId, projectId),
+                eq(
+                    projectOrganizationOwnershipTable.organizationId,
+                    organizationId,
+                ),
+                isNull(projectOrganizationOwnershipTable.deletedAt),
+            ),
+        )
+        .limit(1)
+        .for("update", {
+            of: [
+                projectOrganizationOwnershipTable,
+                organizationTable,
+                organizationMembershipTable,
+                userTable,
+                organizationMembershipAllProjectCapabilityTable,
+                premiumFeatureEntitlementTable,
+            ],
+        });
+    return rows.length === 1;
+}
+
 async function hasActiveDelivery({
     db,
     projectId,
@@ -3311,6 +3417,23 @@ export function createConversationEmailUpdateService({
                             } as const;
                         }
                         if (project === undefined) {
+                            return {
+                                success: false,
+                                reason: "sending_disabled",
+                            } as const;
+                        }
+                        if (
+                            !(await lockActiveEmailUpdateAuthorization({
+                                db: tx,
+                                projectId: attempt.project_id,
+                                organizationId:
+                                    attempt.authorizing_organization_id,
+                                entitlementId:
+                                    attempt.authorizing_entitlement_id,
+                                userId,
+                                now,
+                            }))
+                        ) {
                             return {
                                 success: false,
                                 reason: "sending_disabled",

--- a/services/api/src/service/merge.ts
+++ b/services/api/src/service/merge.ts
@@ -20,6 +20,7 @@ import { type PostgresJsDatabase as PostgresDatabase } from "drizzle-orm/postgre
 import { log } from "@/app.js";
 import { scheduleConversationAnalysisRefresh } from "@/shared-backend/conversationCounters.js";
 import { recordIdentityChangedUsers } from "./authSession.js";
+import { ensureOrganizationMembershipBaselineCapabilities } from "./projectAccess.js";
 
 interface MergeGuestIntoVerifiedUserProps {
     db: PostgresDatabase;
@@ -214,13 +215,11 @@ export async function mergeGuestIntoVerifiedUser({
         );
 
     for (const mapping of guestOrgMappings) {
-        await db
-            .insert(organizationMembershipTable)
-            .values({
-                userId: verifiedUserId,
-                organizationId: mapping.organizationId,
-            })
-            .onConflictDoNothing();
+        await ensureOrganizationMembershipBaselineCapabilities({
+            db,
+            userId: verifiedUserId,
+            organizationId: mapping.organizationId,
+        });
     }
 
     // 11. Transfer votes (uses authorId, unique constraint: authorId + opinionId)

--- a/services/api/src/service/projectAccess.ts
+++ b/services/api/src/service/projectAccess.ts
@@ -63,6 +63,7 @@ const baselineAllProjectCapabilities = [
     "conversation_export_owner_data",
     "conversation_moderate",
     "conversation_manage_integrations",
+    "conversation_email_update",
 ] satisfies readonly AllProjectCapability[];
 
 function personalOrganizationSlug(userId: string): string {
@@ -110,6 +111,16 @@ async function getOrCreateMembership({
     userId: string;
     organizationId: number;
 }): Promise<number> {
+    const insertedRows = await db
+        .insert(organizationMembershipTable)
+        .values({ userId, organizationId })
+        .onConflictDoNothing()
+        .returning({ id: organizationMembershipTable.id });
+    const inserted = insertedRows.at(0);
+    if (inserted !== undefined) {
+        return inserted.id;
+    }
+
     const existingRows = await db
         .select({ id: organizationMembershipTable.id })
         .from(organizationMembershipTable)
@@ -126,17 +137,9 @@ async function getOrCreateMembership({
         return existing.id;
     }
 
-    const insertedRows = await db
-        .insert(organizationMembershipTable)
-        .values({ userId, organizationId })
-        .returning({ id: organizationMembershipTable.id });
-    const inserted = insertedRows.at(0);
-    if (inserted === undefined) {
-        throw httpErrors.internalServerError(
-            "Failed to create organization membership",
-        );
-    }
-    return inserted.id;
+    throw httpErrors.internalServerError(
+        "Failed to create organization membership",
+    );
 }
 
 export async function ensureOrganizationMembershipBaselineCapabilities({

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -2112,7 +2112,6 @@ export class Dto {
     static organizationMember = z
         .object({
             username: zodUsername,
-            conversationEmailUpdateCapabilityEnabled: z.boolean(),
         })
         .strict();
     static getOrganizationMembersResponse = z
@@ -2130,13 +2129,6 @@ export class Dto {
         .object({
             username: zodUsername,
             organizationName: zodOrganizationSlug,
-        })
-        .strict();
-    static updateOrganizationMemberConversationEmailUpdateCapabilityRequest = z
-        .object({
-            username: zodUsername,
-            organizationSlug: zodOrganizationSlug,
-            enabled: z.boolean(),
         })
         .strict();
     static createProjectAttributionRequest = z.discriminatedUnion("source", [
@@ -3748,10 +3740,6 @@ export type OrganizationMember = z.infer<typeof Dto.organizationMember>;
 export type GetOrganizationMembersResponse = z.infer<
     typeof Dto.getOrganizationMembersResponse
 >;
-export type UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest =
-    z.infer<
-        typeof Dto.updateOrganizationMemberConversationEmailUpdateCapabilityRequest
-    >;
 export type AdminOrganizationProperties = z.infer<typeof zodAdminOrganization>;
 export type CreateOrganizationRequest = z.infer<
     typeof Dto.createOrganizationRequest

--- a/services/conversation-email-update-worker/README.md
+++ b/services/conversation-email-update-worker/README.md
@@ -55,7 +55,7 @@ Before creating a plan:
 1. Create a dedicated local database named `agora_email_exercise_*` and apply all normal application migrations.
 2. Run the API against that same database with `CONVERSATION_EMAIL_UPDATES_ENABLED=true`, `CONVERSATION_EMAIL_UPDATES_KILL_SWITCH=false`, and no read-replica connection.
 3. Run Agora at `http://127.0.0.1:3200`.
-4. Bootstrap a site administrator, then use the administrator UI to grant the facilitator the Email Updates entitlement and organization-member capability.
+4. Bootstrap a site administrator, grant the organization the Email Updates entitlement, and add the facilitator as an organization member. Membership automatically grants the capability.
 5. Create the target through the normal UI. It must be an active, open Polis conversation in an active listed project, have current conversation content and at least one active opinion with current content, and have no votes, participants, or previous Email Update.
 6. Record the generated eight-character conversation slug for the environment below.
 

--- a/services/conversation-email-update-worker/src/logger.test.ts
+++ b/services/conversation-email-update-worker/src/logger.test.ts
@@ -97,7 +97,7 @@ describe("privacy-safe structured logging", () => {
         });
 
         log.info(
-            'AGORA_LOAD_EVENT {"service":"conversation-email-update-worker","event":"simulator_started","provider":"ses","mode":"success"}',
+            'AGORA_LOAD_EVENT {"service":"conversation-email-update-worker","event":"simulator_started","provider":"simulated","mode":"success"}',
         );
 
         expect(lines.join("")).toContain("AGORA_LOAD_EVENT");

--- a/services/conversation-email-update-worker/src/logger.ts
+++ b/services/conversation-email-update-worker/src/logger.ts
@@ -13,7 +13,7 @@ const DRIZZLE_QUERY_FORMAT = "%s --";
 const loadEventSchema = z.object({
     service: z.literal(OBSERVABILITY_SERVICE),
     event: z.literal("simulator_started"),
-    provider: z.literal("ses"),
+    provider: z.literal("simulated"),
     mode: z.enum([
         "success",
         "retryable_rejected",

--- a/services/conversation-email-update-worker/src/shared/types/dto.ts
+++ b/services/conversation-email-update-worker/src/shared/types/dto.ts
@@ -2112,7 +2112,6 @@ export class Dto {
     static organizationMember = z
         .object({
             username: zodUsername,
-            conversationEmailUpdateCapabilityEnabled: z.boolean(),
         })
         .strict();
     static getOrganizationMembersResponse = z
@@ -2130,13 +2129,6 @@ export class Dto {
         .object({
             username: zodUsername,
             organizationName: zodOrganizationSlug,
-        })
-        .strict();
-    static updateOrganizationMemberConversationEmailUpdateCapabilityRequest = z
-        .object({
-            username: zodUsername,
-            organizationSlug: zodOrganizationSlug,
-            enabled: z.boolean(),
         })
         .strict();
     static createProjectAttributionRequest = z.discriminatedUnion("source", [
@@ -3748,10 +3740,6 @@ export type OrganizationMember = z.infer<typeof Dto.organizationMember>;
 export type GetOrganizationMembersResponse = z.infer<
     typeof Dto.getOrganizationMembersResponse
 >;
-export type UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest =
-    z.infer<
-        typeof Dto.updateOrganizationMemberConversationEmailUpdateCapabilityRequest
-    >;
 export type AdminOrganizationProperties = z.infer<typeof zodAdminOrganization>;
 export type CreateOrganizationRequest = z.infer<
     typeof Dto.createOrganizationRequest

--- a/services/conversation-email-update-worker/src/store.ts
+++ b/services/conversation-email-update-worker/src/store.ts
@@ -42,6 +42,7 @@ import {
     opinionTable,
     organizationMembershipAllProjectCapabilityTable,
     organizationMembershipTable,
+    organizationTable,
     premiumFeatureEntitlementTable,
     projectOrganizationOwnershipTable,
     projectTable,
@@ -480,6 +481,37 @@ export async function authorizeTestAttempt({
     const authorization = db
         .select({ id: conversationEmailUpdateTable.id })
         .from(conversationEmailUpdateTable)
+        .innerJoin(
+            projectTable,
+            and(
+                eq(projectTable.id, conversationEmailUpdateTable.projectId),
+                isNull(projectTable.deletedAt),
+            ),
+        )
+        .innerJoin(
+            projectOrganizationOwnershipTable,
+            and(
+                eq(
+                    projectOrganizationOwnershipTable.projectId,
+                    conversationEmailUpdateTable.projectId,
+                ),
+                eq(
+                    projectOrganizationOwnershipTable.organizationId,
+                    conversationEmailUpdateTable.authorizingOrganizationId,
+                ),
+                isNull(projectOrganizationOwnershipTable.deletedAt),
+            ),
+        )
+        .innerJoin(
+            organizationTable,
+            and(
+                eq(
+                    organizationTable.id,
+                    conversationEmailUpdateTable.authorizingOrganizationId,
+                ),
+                isNull(organizationTable.deletedAt),
+            ),
+        )
         .innerJoin(
             emailTable,
             and(

--- a/services/load-testing/src/api/api.ts
+++ b/services/load-testing/src/api/api.ts
@@ -109,11 +109,7 @@ export const ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrg
 export type ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrganizationListInnerLocalizationsInnerLanguageCodeEnum = typeof ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrganizationListInnerLocalizationsInnerLanguageCodeEnum[keyof typeof ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrganizationListInnerLocalizationsInnerLanguageCodeEnum];
 
 export interface ApiV1AdministratorOrganizationGetMembersPost200Response {
-    'memberList': Array<ApiV1AdministratorOrganizationGetMembersPost200ResponseMemberListInner>;
-}
-export interface ApiV1AdministratorOrganizationGetMembersPost200ResponseMemberListInner {
-    'username': string;
-    'conversationEmailUpdateCapabilityEnabled': boolean;
+    'memberList': Array<ApiV1UserUsernameUpdatePostRequest>;
 }
 export interface ApiV1AdministratorOrganizationGetOrganizationDetailsPost200Response {
     'organization'?: ApiV1AdministratorOrganizationGetAllOrganizationsPost200ResponseOrganizationListInner;
@@ -159,11 +155,6 @@ export const ApiV1AdministratorOrganizationLocalizationUpdatePostRequestLanguage
 
 export type ApiV1AdministratorOrganizationLocalizationUpdatePostRequestLanguageCodeEnum = typeof ApiV1AdministratorOrganizationLocalizationUpdatePostRequestLanguageCodeEnum[keyof typeof ApiV1AdministratorOrganizationLocalizationUpdatePostRequestLanguageCodeEnum];
 
-export interface ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest {
-    'username': string;
-    'organizationSlug': string;
-    'enabled': boolean;
-}
 /**
  * @type ApiV1AdministratorOrganizationSlugUpdatePost200Response
  */
@@ -8658,43 +8649,6 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
-         * @param {ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest} apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost: async (apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest: ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest' is not null or undefined
-            assertParamExists('apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost', 'apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest', apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest)
-            const localVarPath = `/api/v1/administrator/organization/member/email-update-capability/update`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication BearerAuth required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * 
          * @param {ApiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest} apiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -13665,18 +13619,6 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
-         * @param {ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest} apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest: ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * 
          * @param {ApiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest} apiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -15335,15 +15277,6 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
-         * @param {ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest} apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest: ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options?: RawAxiosRequestConfig): AxiosPromise<void> {
-            return localVarFp.apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * 
          * @param {ApiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest} apiV1AdministratorOrganizationAddUserOrganizationMappingPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -16614,16 +16547,6 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV1AdministratorOrganizationLocalizationUpdatePost(apiV1AdministratorOrganizationLocalizationUpdatePostRequest: ApiV1AdministratorOrganizationLocalizationUpdatePostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1AdministratorOrganizationLocalizationUpdatePost(apiV1AdministratorOrganizationLocalizationUpdatePostRequest, options).then((request) => request(this.axios, this.basePath));
-    }
-
-    /**
-     * 
-     * @param {ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest} apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    public apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest: ApiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options?: RawAxiosRequestConfig) {
-        return DefaultApiFp(this.configuration).apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePost(apiV1AdministratorOrganizationMemberEmailUpdateCapabilityUpdatePostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/services/load-testing/src/shared/types/dto.ts
+++ b/services/load-testing/src/shared/types/dto.ts
@@ -2112,7 +2112,6 @@ export class Dto {
     static organizationMember = z
         .object({
             username: zodUsername,
-            conversationEmailUpdateCapabilityEnabled: z.boolean(),
         })
         .strict();
     static getOrganizationMembersResponse = z
@@ -2130,13 +2129,6 @@ export class Dto {
         .object({
             username: zodUsername,
             organizationName: zodOrganizationSlug,
-        })
-        .strict();
-    static updateOrganizationMemberConversationEmailUpdateCapabilityRequest = z
-        .object({
-            username: zodUsername,
-            organizationSlug: zodOrganizationSlug,
-            enabled: z.boolean(),
         })
         .strict();
     static createProjectAttributionRequest = z.discriminatedUnion("source", [
@@ -3748,10 +3740,6 @@ export type OrganizationMember = z.infer<typeof Dto.organizationMember>;
 export type GetOrganizationMembersResponse = z.infer<
     typeof Dto.getOrganizationMembersResponse
 >;
-export type UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest =
-    z.infer<
-        typeof Dto.updateOrganizationMemberConversationEmailUpdateCapabilityRequest
-    >;
 export type AdminOrganizationProperties = z.infer<typeof zodAdminOrganization>;
 export type CreateOrganizationRequest = z.infer<
     typeof Dto.createOrganizationRequest

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -2111,7 +2111,6 @@ export class Dto {
     static organizationMember = z
         .object({
             username: zodUsername,
-            conversationEmailUpdateCapabilityEnabled: z.boolean(),
         })
         .strict();
     static getOrganizationMembersResponse = z
@@ -2129,13 +2128,6 @@ export class Dto {
         .object({
             username: zodUsername,
             organizationName: zodOrganizationSlug,
-        })
-        .strict();
-    static updateOrganizationMemberConversationEmailUpdateCapabilityRequest = z
-        .object({
-            username: zodUsername,
-            organizationSlug: zodOrganizationSlug,
-            enabled: z.boolean(),
         })
         .strict();
     static createProjectAttributionRequest = z.discriminatedUnion("source", [
@@ -3747,10 +3739,6 @@ export type OrganizationMember = z.infer<typeof Dto.organizationMember>;
 export type GetOrganizationMembersResponse = z.infer<
     typeof Dto.getOrganizationMembersResponse
 >;
-export type UpdateOrganizationMemberConversationEmailUpdateCapabilityRequest =
-    z.infer<
-        typeof Dto.updateOrganizationMemberConversationEmailUpdateCapabilityRequest
-    >;
 export type AdminOrganizationProperties = z.infer<typeof zodAdminOrganization>;
 export type CreateOrganizationRequest = z.infer<
     typeof Dto.createOrganizationRequest


### PR DESCRIPTION
## Summary

- grant `conversation_email_update` automatically with the standard organization membership capability baseline
- remove the standalone per-member capability endpoint, DTO field, administrator checkbox, and generated client surface
- make membership provisioning primary-consistent, transactional, concurrency-safe, and reusable during guest-account merges
- lock the exact active membership, capability, ownership, organization, user, and entitlement rows before accepting a final delivery
- revalidate active project ownership when the worker authorizes test sends
- fix simulated-provider load-event parsing and update the local exercise instructions

## Security model

The organization entitlement enables the feature for the organization. Every member receives the backend capability through normal membership provisioning, while send authorization still requires active membership, capability, project ownership, organization state, and entitlement.

Final delivery acceptance remains the durable authorization boundary. Accepted jobs continue under the frozen delivery contract, with explicit safety blocks and recipient eligibility rechecked by the worker. The acceptance transaction now locks the exact authorization rows so concurrent revocation cannot race delivery creation.

## Migration

No migration or backfill is included. Conversation Email Updates has not been deployed and the database will be recreated from the already corrected `V0086` migration.

## Verification

- API: 58 files, 556 tests
- Agora: 98 files, 615 tests
- Conversation Email Update worker: 26 files, 148 tests
- API, Agora, worker, and load-testing lint
- Worker production build
- Load-testing production build
- OpenAPI client regeneration
- `git diff --check`

Agora lint retains 11 existing `vue/one-component-per-file` warnings and reports no errors.

Deploy: agora, api, conversation-email-update-worker