### PR TITLE
feat(email-updates): add contextual controls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,12 @@ dev-api:
 	$(LOG_RUNNER) --service api -- $(MAKE) dev-api-raw
 
 dev-api-raw:
-	cd services/api && pnpm start:dev
+	cd services/api && \
+		NODE_ENV=development \
+		CONVERSATION_EMAIL_UPDATES_ENABLED=true \
+		CONVERSATION_EMAIL_UPDATES_KILL_SWITCH=false \
+		CONVERSATION_EMAIL_UPDATE_SNS_SIMULATOR_ENABLED=true \
+		pnpm start:dev
 
 dev-conversation-email-update-worker:
 	$(LOG_RUNNER) --service conversation-email-update-worker -- $(MAKE) dev-conversation-email-update-worker-scenario-raw SCENARIO="$(CONVERSATION_EMAIL_UPDATE_WORKER_DEV_SCENARIO)"

--- a/services/agora/src/api/api.ts
+++ b/services/agora/src/api/api.ts
@@ -2661,6 +2661,7 @@ export interface ApiV1ConversationCreatePostRequestOneOf {
     'multilingualSetting': ApiV1ConversationCreatePostRequestOneOfMultilingualSetting;
     'seedOpinionList': Array<string>;
     'requiresEventTicket'?: ApiV1ConversationCreatePostRequestOneOfRequiresEventTicketEnum;
+    'conversationEmailUpdateEnabledOverride'?: boolean;
     'conversationType': ApiV1ConversationCreatePostRequestOneOfConversationTypeEnum;
     'aiLabelingEnabled'?: boolean;
     'preferredOpinionGroupCount'?: number | null;
@@ -2703,6 +2704,7 @@ export interface ApiV1ConversationCreatePostRequestOneOf1 {
     'multilingualSetting': ApiV1ConversationCreatePostRequestOneOfMultilingualSetting;
     'seedOpinionList': Array<string>;
     'requiresEventTicket'?: ApiV1ConversationCreatePostRequestOneOf1RequiresEventTicketEnum;
+    'conversationEmailUpdateEnabledOverride'?: boolean;
     'conversationType': ApiV1ConversationCreatePostRequestOneOf1ConversationTypeEnum;
     'rankingMode': ApiV1ConversationCreatePostRequestOneOf1RankingModeEnum;
     'externalSourceConfig'?: ApiV1ConversationCreatePostRequestOneOf1ExternalSourceConfig | null;
@@ -5059,13 +5061,14 @@ export interface ApiV1ConversationGetForEditPost200ResponseOneOf {
     'languageSetting': ApiV1ConversationFetchRecentPost200ResponseFeedItemListInnerConversationDataMetadataOneOfLanguageSetting;
     'multilingualSetting': ApiV1ConversationCreatePostRequestOneOfMultilingualSetting;
     'languageSettingsSource': ApiV1ConversationGetForEditPost200ResponseOneOfLanguageSettingsSourceEnum;
-    'projectLanguageProject'?: ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInner;
+    'projectLanguageProject'?: ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProject;
     'isIndexed': boolean;
     'participationMode': ApiV1ConversationGetForEditPost200ResponseOneOfParticipationModeEnum;
     'requiresEventTicket'?: ApiV1ConversationGetForEditPost200ResponseOneOfRequiresEventTicketEnum;
     'aiLabelingEnabled': boolean;
     'preferredOpinionGroupCount': number | null;
     'postAsOrganizationName'?: string;
+    'postAsOrganizationSlug'?: string;
     'surveyConfig'?: ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig | null;
     'createdAt': string;
     'updatedAt': string;
@@ -5159,6 +5162,29 @@ export const ApiV1ConversationGetForEditPost200ResponseOneOfEditPermissionsRestr
 } as const;
 
 export type ApiV1ConversationGetForEditPost200ResponseOneOfEditPermissionsRestrictedPremiumFeaturesEnum = typeof ApiV1ConversationGetForEditPost200ResponseOneOfEditPermissionsRestrictedPremiumFeaturesEnum[keyof typeof ApiV1ConversationGetForEditPost200ResponseOneOfEditPermissionsRestrictedPremiumFeaturesEnum];
+
+export interface ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProject {
+    'projectSlug': string;
+    'projectTitle': string;
+    'defaultLanguageCode': ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum;
+    'languageSettings': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerLanguageSettings;
+}
+
+export const ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum = {
+    En: 'en',
+    Es: 'es',
+    Fr: 'fr',
+    ZhHant: 'zh-Hant',
+    ZhHans: 'zh-Hans',
+    Ja: 'ja',
+    Ar: 'ar',
+    Fa: 'fa',
+    He: 'he',
+    Ky: 'ky',
+    Ru: 'ru',
+} as const;
+
+export type ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum = typeof ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum[keyof typeof ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum];
 
 export interface ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig {
     'isOptional': boolean;
@@ -6641,6 +6667,7 @@ export type ApiV1ProjectCreateOptionsListPost200Response = ApiV1ProjectCreateOpt
 export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOf {
     'success': boolean;
     'projectList': Array<ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInner>;
+    'noProjectEmailUpdates': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerEmailUpdates;
 }
 export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOf1 {
     'success': boolean;
@@ -6659,6 +6686,7 @@ export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInn
     'projectTitle': string;
     'defaultLanguageCode': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum;
     'languageSettings': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerLanguageSettings;
+    'emailUpdates': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerEmailUpdates;
 }
 
 export const ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum = {
@@ -6677,6 +6705,10 @@ export const ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDe
 
 export type ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum = typeof ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum[keyof typeof ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum];
 
+export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerEmailUpdates {
+    'canConfigure': boolean;
+    'scopeDefaultEnabled': boolean;
+}
 export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerLanguageSettings {
     'dynamicTranslationEnabled': boolean;
     'targetLanguageCodes': Array<ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerLanguageSettingsTargetLanguageCodesEnum>;
@@ -6747,6 +6779,51 @@ export const ApiV1ProjectDocumentAccessPostRequestModeEnum = {
 } as const;
 
 export type ApiV1ProjectDocumentAccessPostRequestModeEnum = typeof ApiV1ProjectDocumentAccessPostRequestModeEnum[keyof typeof ApiV1ProjectDocumentAccessPostRequestModeEnum];
+
+/**
+ * @type ApiV1ProjectEmailUpdateSummaryGetPost200Response
+ */
+export type ApiV1ProjectEmailUpdateSummaryGetPost200Response = ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf | ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1;
+
+export interface ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf {
+    'success': boolean;
+    'authoringAction': ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum;
+    'participantPreference'?: ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreference;
+}
+
+export const ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum = {
+    None: 'none',
+    Compose: 'compose',
+    History: 'history',
+} as const;
+
+export type ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum = typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum[keyof typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum];
+
+export interface ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1 {
+    'success': boolean;
+    'reason': ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum;
+}
+
+export const ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum = {
+    ProjectNotFound: 'project_not_found',
+    FeatureNotAvailable: 'feature_not_available',
+    SummaryUnavailable: 'summary_unavailable',
+} as const;
+
+export type ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum = typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum[keyof typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum];
+
+export interface ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreference {
+    'state': ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum;
+    'resolvedEnabled': boolean;
+}
+
+export const ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum = {
+    Disabled: 'disabled',
+    Enabled: 'enabled',
+    Undisclosed: 'undisclosed',
+} as const;
+
+export type ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum = typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum[keyof typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum];
 
 export interface ApiV1ProjectPageActivitiesFetchPost200Response {
     'activities': Array<ApiV1ProjectPageFetchPost200ResponseActivitiesInner>;
@@ -12081,6 +12158,44 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @param {ApiV1AdministratorProjectGetProjectDetailsPostRequest} apiV1AdministratorProjectGetProjectDetailsPostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiV1ProjectEmailUpdateSummaryGetPost: async (apiV1AdministratorProjectGetProjectDetailsPostRequest: ApiV1AdministratorProjectGetProjectDetailsPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'apiV1AdministratorProjectGetProjectDetailsPostRequest' is not null or undefined
+            assertParamExists('apiV1ProjectEmailUpdateSummaryGetPost', 'apiV1AdministratorProjectGetProjectDetailsPostRequest', apiV1AdministratorProjectGetProjectDetailsPostRequest)
+            const localVarPath = `/api/v1/project/email-update/summary/get`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(apiV1AdministratorProjectGetProjectDetailsPostRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {ApiV1ProjectPageFetchPostRequest} apiV1ProjectPageFetchPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -14722,6 +14837,18 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {ApiV1AdministratorProjectGetProjectDetailsPostRequest} apiV1AdministratorProjectGetProjectDetailsPostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest: ApiV1AdministratorProjectGetProjectDetailsPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ProjectEmailUpdateSummaryGetPost200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1ProjectEmailUpdateSummaryGetPost']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @param {ApiV1ProjectPageFetchPostRequest} apiV1ProjectPageFetchPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -16101,6 +16228,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
+         * @param {ApiV1AdministratorProjectGetProjectDetailsPostRequest} apiV1AdministratorProjectGetProjectDetailsPostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest: ApiV1AdministratorProjectGetProjectDetailsPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ProjectEmailUpdateSummaryGetPost200Response> {
+            return localVarFp.apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {ApiV1ProjectPageFetchPostRequest} apiV1ProjectPageFetchPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -17464,6 +17600,16 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV1ProjectDocumentAccessPost(apiV1ProjectDocumentAccessPostRequest: ApiV1ProjectDocumentAccessPostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1ProjectDocumentAccessPost(apiV1ProjectDocumentAccessPostRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {ApiV1AdministratorProjectGetProjectDetailsPostRequest} apiV1AdministratorProjectGetProjectDetailsPostRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest: ApiV1AdministratorProjectGetProjectDetailsPostRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/services/agora/src/components/conversationUpdates/ConversationUpdateAuthFreePreferenceManager.vue
+++ b/services/agora/src/components/conversationUpdates/ConversationUpdateAuthFreePreferenceManager.vue
@@ -1,0 +1,135 @@
+<template>
+  <section class="action-card">
+    <h1>{{ translate("title") }}</h1>
+    <p class="action-description">{{ translate("description") }}</p>
+
+    <ul class="preference-list">
+      <li v-for="item in items" :key="item.key" class="preference-item">
+        <div class="preference-copy">
+          <span class="preference-type">{{ translate(item.type) }}</span>
+          <h2>{{ item.title }}</h2>
+          <span
+            v-if="successfulKeys.has(item.key)"
+            class="preference-success"
+            role="status"
+          >
+            {{ translate("optedOut") }}
+          </span>
+          <span
+            v-else-if="errorKey === item.key"
+            class="action-error"
+            role="alert"
+          >
+            {{ translate("submitFailed") }}
+          </span>
+        </div>
+        <div class="preference-action">
+          <ZKButton
+            button-type="standardButton"
+            outline
+            color="primary"
+            :disable="
+              isManageOptOutDisabled({
+                itemKey: item.key,
+                pendingKey,
+                successfulKeys,
+              })
+            "
+            :loading="pendingKey === item.key"
+            :aria-label="translate('optOutTarget', { title: item.title })"
+            @click="emit('optOut', item)"
+          >
+            {{
+              pendingKey === item.key
+                ? translate("optingOut")
+                : translate("optOut")
+            }}
+          </ZKButton>
+        </div>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+import ZKButton from "src/components/ui-library/ZKButton.vue";
+
+import {
+  isManageOptOutDisabled,
+  type ManageOptOutItem,
+} from "./authFreePreferenceManager";
+
+type TranslationKey =
+  | "conversation"
+  | "description"
+  | "optedOut"
+  | "optOut"
+  | "optOutTarget"
+  | "optingOut"
+  | "project"
+  | "submitFailed"
+  | "title";
+
+defineProps<{
+  items: readonly ManageOptOutItem[];
+  pendingKey: string | undefined;
+  errorKey: string | undefined;
+  successfulKeys: ReadonlySet<string>;
+  translate: (
+    key: TranslationKey,
+    params?: Readonly<Record<string, string | number>>
+  ) => string;
+}>();
+const emit = defineEmits<{
+  optOut: [item: ManageOptOutItem];
+}>();
+</script>
+
+<style scoped lang="scss">
+@use "../../pages/email-updates/actionPageStyles";
+
+.preference-list {
+  display: grid;
+  gap: 0.8rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.preference-item {
+  display: grid;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid $grey-4;
+  border-radius: 14px;
+}
+
+.preference-copy {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.preference-type {
+  color: $grey-7;
+  font-size: 0.8rem;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.preference-success {
+  color: $positive;
+  font-weight: var(--font-weight-semibold);
+}
+
+.preference-action {
+  width: 8rem;
+}
+
+@media (min-width: $breakpoint-sm-min) {
+  .preference-item {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+}
+</style>

--- a/services/agora/src/components/conversationUpdates/authFreePreferenceManager.ts
+++ b/services/agora/src/components/conversationUpdates/authFreePreferenceManager.ts
@@ -1,0 +1,20 @@
+import type { ConversationEmailUpdateActionManageOptOutRequest } from "src/shared/types/dto";
+
+export interface ManageOptOutItem {
+  key: string;
+  title: string;
+  target: ConversationEmailUpdateActionManageOptOutRequest["target"];
+  type: "project" | "conversation";
+}
+
+export function isManageOptOutDisabled({
+  itemKey,
+  pendingKey,
+  successfulKeys,
+}: {
+  itemKey: string;
+  pendingKey: string | undefined;
+  successfulKeys: ReadonlySet<string>;
+}): boolean {
+  return pendingKey !== undefined || successfulKeys.has(itemKey);
+}

--- a/services/agora/src/components/conversationUpdates/conversationUpdatePreferenceAction.test.ts
+++ b/services/agora/src/components/conversationUpdates/conversationUpdatePreferenceAction.test.ts
@@ -36,12 +36,14 @@ describe("createConversationUpdatePreferenceAction", () => {
 
   it("uses a switch for the saved preference", () => {
     const enabledAction = createConversationUpdatePreferenceAction({
+      id: "conversationEmailUpdates",
       label: "Receive email updates for this conversation",
       enabled: true,
       description: undefined,
       onToggle: vi.fn(),
     });
     const disabledAction = createConversationUpdatePreferenceAction({
+      id: "conversationEmailUpdates",
       label: "Receive email updates for this conversation",
       enabled: false,
       description: undefined,
@@ -61,6 +63,7 @@ describe("createConversationUpdatePreferenceAction", () => {
 
   it("describes a conversation-only opt-in", () => {
     const action = createConversationUpdatePreferenceAction({
+      id: "conversationEmailUpdates",
       label: "Receive email updates for this conversation",
       enabled: false,
       description: "Turn on updates for this conversation only",
@@ -76,6 +79,7 @@ describe("createConversationUpdatePreferenceAction", () => {
   it("runs the supplied toggle handler", async () => {
     const onToggle = vi.fn();
     const action = createConversationUpdatePreferenceAction({
+      id: "conversationEmailUpdates",
       label: "Receive email updates for this conversation",
       enabled: false,
       description: undefined,

--- a/services/agora/src/components/conversationUpdates/conversationUpdatePreferenceAction.ts
+++ b/services/agora/src/components/conversationUpdates/conversationUpdatePreferenceAction.ts
@@ -1,4 +1,4 @@
-import type { ContentAction } from "src/utils/actions/core/types";
+import type { HandlerContentAction } from "src/utils/actions/core/types";
 
 export type ConversationUpdatePreferenceState =
   | "disabled"
@@ -18,20 +18,22 @@ export function getConversationUpdatePreferenceDisplay(
 }
 
 export function createConversationUpdatePreferenceAction({
+  id,
   label,
   enabled,
   description,
   disabled = false,
   onToggle,
 }: {
+  id: string;
   label: string;
   enabled: boolean;
   description: string | undefined;
   disabled?: boolean;
   onToggle: () => void;
-}): ContentAction {
+}): HandlerContentAction {
   return {
-    id: "conversationEmailUpdates",
+    id,
     label,
     description,
     ...(disabled ? { disabled: true } : {}),

--- a/services/agora/src/components/newConversation/ConversationControlButton.vue
+++ b/services/agora/src/components/newConversation/ConversationControlButton.vue
@@ -6,6 +6,7 @@
       { 'show-border': showBorder },
     ]"
     type="button"
+    :disabled="disabled"
     @click="$emit('click')"
   >
     <i v-if="icon && iconPosition === 'left'" :class="icon" class="icon" />
@@ -22,12 +23,14 @@ withDefaults(
     showBorder?: boolean;
     iconPosition?: "left" | "right";
     variant?: "light" | "filled";
+    disabled?: boolean;
   }>(),
   {
     showBorder: true,
     icon: undefined,
     iconPosition: "right",
     variant: "light",
+    disabled: false,
   }
 );
 
@@ -51,6 +54,11 @@ defineEmits<{
   outline: none;
   transition: all 0.2s ease-in-out;
   min-height: 48px; // WCAG 2.2 AA minimum touch target
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.75;
+  }
 
   // Light variant (default - original style)
   &.variant-light {

--- a/services/agora/src/components/newConversation/CreateConversationUpdatesSettings.vue
+++ b/services/agora/src/components/newConversation/CreateConversationUpdatesSettings.vue
@@ -11,10 +11,7 @@
         :title="t('emailUpdates')"
         :subtitle="dialogSubtitle"
       >
-        <q-list
-          separator
-          class="conversation-updates-settings__list"
-        >
+        <q-list separator class="conversation-updates-settings__list">
           <q-item
             v-for="option in settingOptions"
             :key="option.id"
@@ -54,7 +51,7 @@ const props = defineProps<{
   scopeKind: "project" | "no-project";
   projectTitle: string | undefined;
   scopeDefaultEnabled: boolean;
-  hasEntitlement: boolean;
+  canConfigure: boolean;
 }>();
 
 type SettingMode = "inherit" | "off" | "on";
@@ -71,7 +68,7 @@ const { t } = useComponentI18n<CreateConversationUpdatesSettingsTranslations>(
   createConversationUpdatesSettingsTranslations
 );
 
-const shouldShow = computed(() => props.hasEntitlement);
+const shouldShow = computed(() => props.canConfigure);
 const displayEnabled = computed(
   () => override.value ?? props.scopeDefaultEnabled
 );
@@ -85,9 +82,7 @@ const dialogSubtitle = computed(() => t("manualUpdatesSubtitle"));
 const controlLabel = computed(() => {
   const value = displayEnabled.value ? t("on") : t("off");
   const inheritedSource =
-    props.scopeKind === "project"
-      ? t("projectDefault")
-      : t("noProjectDefault");
+    props.scopeKind === "project" ? t("projectDefault") : t("noProjectDefault");
   const source = override.value === undefined ? inheritedSource : t("override");
   return t("controlLabel", { value, source });
 });
@@ -98,9 +93,7 @@ const settingOptions = computed<readonly SettingOption[]>(() => {
       ? (props.projectTitle ?? t("projectFallback"))
       : t("noProjectGroup");
   const defaultSource =
-    props.scopeKind === "project"
-      ? t("projectDefault")
-      : t("noProjectDefault");
+    props.scopeKind === "project" ? t("projectDefault") : t("noProjectDefault");
   const overrideDescription = t("overridesDescription", {
     defaultValue,
     scopeLabel,

--- a/services/agora/src/components/newConversation/NewConversationControlBar.vue
+++ b/services/agora/src/components/newConversation/NewConversationControlBar.vue
@@ -12,6 +12,7 @@
       :key="button.id"
       :label="button.label"
       :icon="button.icon"
+      :disabled="!button.clickable"
       :class="{ 'cursor-pointer': button.clickable }"
       :aria-label="button.label"
       @click="button.clickHandler"
@@ -22,6 +23,7 @@
       :key="button.id"
       :label="button.label"
       :icon="button.icon"
+      :disabled="!button.clickable"
       :class="{ 'cursor-pointer': button.clickable }"
       :aria-label="button.label"
       @click="button.clickHandler"
@@ -268,7 +270,7 @@ const selectedOrganizationImageUrl = computed(() => {
 });
 
 const showPostAsImage = computed(() => {
-  return !postAs.value.postAsOrganization || selectedOrganizationImageUrl.value !== "";
+  return true;
 });
 
 const showPostAsDialogVisible = ref(false);
@@ -573,20 +575,28 @@ watch(
   }
 );
 
-watch(isAnalysisVariantsPreferenceDenied, (isDenied) => {
-  if (isDenied) {
-    preferredOpinionGroupCount.value = null;
-  }
-}, { immediate: true });
+watch(
+  isAnalysisVariantsPreferenceDenied,
+  (isDenied) => {
+    if (isDenied) {
+      preferredOpinionGroupCount.value = null;
+    }
+  },
+  { immediate: true }
+);
 
-watch(isDynamicTranslationDenied, (isDenied) => {
-  if (isDenied) {
-    multilingualSetting.value = {
-      dynamicTranslationEnabled: false,
-      additionalLanguageCodes: [],
-    };
-  }
-}, { immediate: true });
+watch(
+  isDynamicTranslationDenied,
+  (isDenied) => {
+    if (isDenied) {
+      multilingualSetting.value = {
+        dynamicTranslationEnabled: false,
+        additionalLanguageCodes: [],
+      };
+    }
+  },
+  { immediate: true }
+);
 
 const canOpenEventTicketRequirementDialog = computed(() => {
   if (requiresEventTicket.value === undefined) {
@@ -623,7 +633,8 @@ const analysisPreferenceLabel = computed(() => {
 
 const languageSettingLabel = computed(() => {
   const detectedLanguage =
-    props.detectedLanguageCode === null || props.detectedLanguageCode === undefined
+    props.detectedLanguageCode === null ||
+    props.detectedLanguageCode === undefined
       ? t("languagePrimaryAuto")
       : getLanguageLabel({
           languageCode: props.detectedLanguageCode,
@@ -645,10 +656,12 @@ const controlButtons = computed((): ControlButton[] => [
     label: t("asLabel").replace("{name}", postAsDisplayName.value),
     icon: showPostAsDialogVisible.value
       ? "pi pi-chevron-up"
-      : "pi pi-chevron-down",
-    isVisible: isLoggedIn.value && !props.isEditMode,
+      : props.isEditMode
+        ? ""
+        : "pi pi-chevron-down",
+    isVisible: isLoggedIn.value,
     clickHandler: showAsDialog,
-    clickable: true,
+    clickable: !props.isEditMode,
   },
   {
     id: "post-type",

--- a/services/agora/src/components/post/display/PostMetadata.vue
+++ b/services/agora/src/components/post/display/PostMetadata.vue
@@ -508,6 +508,7 @@ function addConversationUpdateActions(): void {
           : t("emailUpdatesPreferenceUndisclosed");
     additions.push(
       createConversationUpdatePreferenceAction({
+        id: "conversationEmailUpdates",
         label: t("receiveEmailUpdatesLabel"),
         enabled,
         description,

--- a/services/agora/src/components/project/ProjectEmailUpdatesMenu.i18n.ts
+++ b/services/agora/src/components/project/ProjectEmailUpdatesMenu.i18n.ts
@@ -1,0 +1,170 @@
+import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
+
+export interface ProjectEmailUpdatesMenuTranslations {
+  projectActions: string;
+  receiveUpdates: string;
+  preferenceOn: string;
+  preferenceOnPaused: string;
+  preferenceOff: string;
+  preferenceDefault: string;
+  sendUpdate: string;
+  sendUpdateDescription: string;
+  updateHistory: string;
+  updateHistoryDescription: string;
+  saveError: string;
+}
+
+export const projectEmailUpdatesMenuTranslations: Record<
+  SupportedDisplayLanguageCodes,
+  ProjectEmailUpdatesMenuTranslations
+> = {
+  en: {
+    projectActions: "Project actions",
+    receiveUpdates: "Receive Email Updates",
+    preferenceOn: "On for this project",
+    preferenceOnPaused: "On for this project, but paused in account settings",
+    preferenceOff: "Off for this project",
+    preferenceDefault: "Using your account default",
+    sendUpdate: "Send Email Update",
+    sendUpdateDescription: "Compose an update for this project",
+    updateHistory: "Email Update History",
+    updateHistoryDescription: "View updates sent for this project",
+    saveError: "Could not save your Email Update preference",
+  },
+  ar: {
+    projectActions: "إجراءات المشروع",
+    receiveUpdates: "تلقي التحديثات عبر البريد الإلكتروني",
+    preferenceOn: "مفعّل لهذا المشروع",
+    preferenceOnPaused:
+      "مفعّل لهذا المشروع، لكنه متوقف مؤقتًا في إعدادات الحساب",
+    preferenceOff: "متوقف لهذا المشروع",
+    preferenceDefault: "استخدام الإعداد الافتراضي لحسابك",
+    sendUpdate: "إرسال تحديث بالبريد الإلكتروني",
+    sendUpdateDescription: "إنشاء تحديث لهذا المشروع",
+    updateHistory: "سجل التحديثات عبر البريد الإلكتروني",
+    updateHistoryDescription: "عرض التحديثات المرسلة لهذا المشروع",
+    saveError: "تعذر حفظ تفضيل التحديثات عبر البريد الإلكتروني",
+  },
+  es: {
+    projectActions: "Acciones del proyecto",
+    receiveUpdates: "Recibir novedades por correo",
+    preferenceOn: "Activadas para este proyecto",
+    preferenceOnPaused:
+      "Activadas para este proyecto, pero pausadas en la cuenta",
+    preferenceOff: "Desactivadas para este proyecto",
+    preferenceDefault: "Usando la configuración predeterminada de la cuenta",
+    sendUpdate: "Enviar novedad por correo",
+    sendUpdateDescription: "Redactar una novedad para este proyecto",
+    updateHistory: "Historial de novedades por correo",
+    updateHistoryDescription: "Ver las novedades enviadas para este proyecto",
+    saveError: "No se pudo guardar la preferencia de correo",
+  },
+  fa: {
+    projectActions: "اقدامات پروژه",
+    receiveUpdates: "دریافت به‌روزرسانی‌های ایمیلی",
+    preferenceOn: "برای این پروژه روشن است",
+    preferenceOnPaused:
+      "برای این پروژه روشن است، اما در تنظیمات حساب متوقف شده",
+    preferenceOff: "برای این پروژه خاموش است",
+    preferenceDefault: "استفاده از تنظیم پیش‌فرض حساب",
+    sendUpdate: "ارسال به‌روزرسانی ایمیلی",
+    sendUpdateDescription: "نوشتن به‌روزرسانی برای این پروژه",
+    updateHistory: "تاریخچه به‌روزرسانی‌های ایمیلی",
+    updateHistoryDescription: "مشاهده به‌روزرسانی‌های ارسال‌شده برای این پروژه",
+    saveError: "ذخیره ترجیح به‌روزرسانی ایمیلی ممکن نشد",
+  },
+  fr: {
+    projectActions: "Actions du projet",
+    receiveUpdates: "Recevoir les actualités par e-mail",
+    preferenceOn: "Activées pour ce projet",
+    preferenceOnPaused:
+      "Activées pour ce projet, mais suspendues dans le compte",
+    preferenceOff: "Désactivées pour ce projet",
+    preferenceDefault: "Paramètre par défaut du compte",
+    sendUpdate: "Envoyer une actualité par e-mail",
+    sendUpdateDescription: "Rédiger une actualité pour ce projet",
+    updateHistory: "Historique des actualités par e-mail",
+    updateHistoryDescription: "Voir les actualités envoyées pour ce projet",
+    saveError: "Impossible d’enregistrer la préférence d’e-mail",
+  },
+  "zh-Hans": {
+    projectActions: "项目操作",
+    receiveUpdates: "接收电子邮件更新",
+    preferenceOn: "已为此项目开启",
+    preferenceOnPaused: "已为此项目开启，但在账户设置中暂停",
+    preferenceOff: "已为此项目关闭",
+    preferenceDefault: "使用账户默认设置",
+    sendUpdate: "发送电子邮件更新",
+    sendUpdateDescription: "为此项目撰写更新",
+    updateHistory: "电子邮件更新历史",
+    updateHistoryDescription: "查看此项目已发送的更新",
+    saveError: "无法保存电子邮件更新偏好",
+  },
+  "zh-Hant": {
+    projectActions: "專案操作",
+    receiveUpdates: "接收電子郵件更新",
+    preferenceOn: "已為此專案開啟",
+    preferenceOnPaused: "已為此專案開啟，但在帳戶設定中暫停",
+    preferenceOff: "已為此專案關閉",
+    preferenceDefault: "使用帳戶預設設定",
+    sendUpdate: "傳送電子郵件更新",
+    sendUpdateDescription: "為此專案撰寫更新",
+    updateHistory: "電子郵件更新歷史",
+    updateHistoryDescription: "查看此專案已傳送的更新",
+    saveError: "無法儲存電子郵件更新偏好",
+  },
+  he: {
+    projectActions: "פעולות פרויקט",
+    receiveUpdates: "קבלת עדכונים בדוא״ל",
+    preferenceOn: "פעיל לפרויקט הזה",
+    preferenceOnPaused: "פעיל לפרויקט הזה, אך מושהה בהגדרות החשבון",
+    preferenceOff: "כבוי לפרויקט הזה",
+    preferenceDefault: "שימוש בברירת המחדל של החשבון",
+    sendUpdate: "שליחת עדכון בדוא״ל",
+    sendUpdateDescription: "כתיבת עדכון לפרויקט הזה",
+    updateHistory: "היסטוריית עדכונים בדוא״ל",
+    updateHistoryDescription: "הצגת עדכונים שנשלחו עבור הפרויקט הזה",
+    saveError: "לא ניתן לשמור את העדפת העדכונים בדוא״ל",
+  },
+  ja: {
+    projectActions: "プロジェクト操作",
+    receiveUpdates: "メール更新を受け取る",
+    preferenceOn: "このプロジェクトでオン",
+    preferenceOnPaused:
+      "このプロジェクトでオンですが、アカウント設定で一時停止中",
+    preferenceOff: "このプロジェクトでオフ",
+    preferenceDefault: "アカウントの既定設定を使用",
+    sendUpdate: "メール更新を送信",
+    sendUpdateDescription: "このプロジェクトの更新を作成",
+    updateHistory: "メール更新履歴",
+    updateHistoryDescription: "このプロジェクトで送信した更新を表示",
+    saveError: "メール更新の設定を保存できませんでした",
+  },
+  ky: {
+    projectActions: "Долбоор аракеттери",
+    receiveUpdates: "Электрондук почта жаңыртууларын алуу",
+    preferenceOn: "Бул долбоор үчүн күйгүзүлгөн",
+    preferenceOnPaused:
+      "Бул долбоор үчүн күйгүзүлгөн, бирок аккаунтта токтотулган",
+    preferenceOff: "Бул долбоор үчүн өчүрүлгөн",
+    preferenceDefault: "Аккаунттун демейки жөндөөсү колдонулууда",
+    sendUpdate: "Электрондук жаңыртуу жөнөтүү",
+    sendUpdateDescription: "Бул долбоор үчүн жаңыртуу түзүү",
+    updateHistory: "Электрондук жаңыртуулардын тарыхы",
+    updateHistoryDescription: "Бул долбоор үчүн жөнөтүлгөн жаңыртууларды көрүү",
+    saveError: "Электрондук жаңыртуу жөндөөсүн сактоо мүмкүн болгон жок",
+  },
+  ru: {
+    projectActions: "Действия проекта",
+    receiveUpdates: "Получать обновления по почте",
+    preferenceOn: "Включено для этого проекта",
+    preferenceOnPaused: "Включено для проекта, но приостановлено в аккаунте",
+    preferenceOff: "Выключено для этого проекта",
+    preferenceDefault: "Используются настройки аккаунта",
+    sendUpdate: "Отправить обновление по почте",
+    sendUpdateDescription: "Подготовить обновление для этого проекта",
+    updateHistory: "История почтовых обновлений",
+    updateHistoryDescription: "Посмотреть обновления, отправленные для проекта",
+    saveError: "Не удалось сохранить настройку почтовых обновлений",
+  },
+};

--- a/services/agora/src/components/project/ProjectEmailUpdatesMenu.vue
+++ b/services/agora/src/components/project/ProjectEmailUpdatesMenu.vue
@@ -1,0 +1,211 @@
+<template>
+  <ZKButton
+    v-if="actions.length > 0"
+    button-type="icon"
+    flat
+    color="white"
+    icon="mdi-dots-horizontal"
+    :aria-label="t('projectActions')"
+    @click="showDialog = true"
+  />
+
+  <ZKActionDialog
+    v-model="showDialog"
+    :title="t('projectActions')"
+    :actions="actions"
+    @action-selected="handleActionSelected"
+  />
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from "pinia";
+import { useQuasar } from "quasar";
+import { createConversationUpdatePreferenceAction } from "src/components/conversationUpdates/conversationUpdatePreferenceAction";
+import ZKActionDialog from "src/components/ui-library/ZKActionDialog.vue";
+import ZKButton from "src/components/ui-library/ZKButton.vue";
+import { useComponentI18n } from "src/composables/ui/useComponentI18n";
+import type { ConversationEmailUpdateProjectSummaryResponse } from "src/shared/types/dto";
+import { useAuthenticationStore } from "src/stores/authentication";
+import type {
+  ContentAction,
+  ContentActionContext,
+} from "src/utils/actions/core/types";
+import { useBackendConversationEmailUpdatesApi } from "src/utils/api/conversationUpdates/conversationEmailUpdates";
+import { useNotify } from "src/utils/ui/notify";
+import { computed, ref, watch } from "vue";
+
+import {
+  type ProjectEmailUpdatesMenuTranslations,
+  projectEmailUpdatesMenuTranslations,
+} from "./ProjectEmailUpdatesMenu.i18n";
+
+const props = defineProps<{
+  projectSlug: string;
+}>();
+
+const $q = useQuasar();
+const notify = useNotify();
+const { t } = useComponentI18n<ProjectEmailUpdatesMenuTranslations>(
+  projectEmailUpdatesMenuTranslations
+);
+const emailUpdatesApi = useBackendConversationEmailUpdatesApi();
+const authenticationStore = useAuthenticationStore();
+const { isLoggedIn } = storeToRefs(authenticationStore);
+const showDialog = ref(false);
+const isSavingPreference = ref(false);
+const summary =
+  ref<
+    Extract<ConversationEmailUpdateProjectSummaryResponse, { success: true }>
+  >();
+let summaryRequestId = 0;
+
+const actionContext: ContentActionContext = {
+  isOwner: false,
+  isSiteModerator: false,
+  isConversationOwner: false,
+  isOrgMember: false,
+  isLoggedIn: true,
+  isEmbeddedMode: false,
+  targetType: "post",
+  targetId: "project",
+  targetAuthor: "",
+};
+
+const actions = computed<ContentAction[]>(() => {
+  const currentSummary = summary.value;
+  if (currentSummary === undefined) {
+    return [];
+  }
+
+  const projectActions: ContentAction[] = [];
+  const participantPreference = currentSummary.participantPreference;
+  if (participantPreference !== undefined) {
+    const preferenceEnabled = participantPreference.state === "enabled";
+    const description =
+      participantPreference.state === "enabled"
+        ? participantPreference.resolvedEnabled
+          ? t("preferenceOn")
+          : t("preferenceOnPaused")
+        : participantPreference.state === "disabled"
+          ? t("preferenceOff")
+          : t("preferenceDefault");
+    projectActions.push(
+      createConversationUpdatePreferenceAction({
+        id: "projectEmailUpdatePreference",
+        label: t("receiveUpdates"),
+        description,
+        disabled: isSavingPreference.value,
+        enabled: preferenceEnabled,
+        onToggle: () => {
+          void updatePreference(!preferenceEnabled);
+        },
+      })
+    );
+  }
+
+  if (currentSummary.authoringAction !== "none") {
+    const tab = currentSummary.authoringAction;
+    projectActions.push({
+      id: "projectEmailUpdateWorkspace",
+      label: tab === "compose" ? t("sendUpdate") : t("updateHistory"),
+      description:
+        tab === "compose"
+          ? t("sendUpdateDescription")
+          : t("updateHistoryDescription"),
+      icon: tab === "compose" ? "mdi-email-edit-outline" : "mdi-history",
+      trailingIcon: $q.lang.rtl ? "mdi-chevron-left" : "mdi-chevron-right",
+      to: {
+        path: "/email-updates/",
+        query: { tab, projectSlug: props.projectSlug },
+      },
+      isVisible: () => true,
+    });
+  }
+
+  return projectActions;
+});
+
+async function loadSummary(): Promise<void> {
+  const requestId = ++summaryRequestId;
+  if (!isLoggedIn.value) {
+    summary.value = undefined;
+    return;
+  }
+
+  try {
+    const response = await emailUpdatesApi.getProjectSummary({
+      projectSlug: props.projectSlug,
+    });
+    if (requestId !== summaryRequestId) {
+      return;
+    }
+    summary.value = response.success ? response : undefined;
+  } catch (error) {
+    console.error("Failed to load project Email Update actions", error);
+    if (requestId === summaryRequestId) {
+      summary.value = undefined;
+    }
+  }
+}
+
+async function updatePreference(enabled: boolean): Promise<void> {
+  if (isSavingPreference.value) {
+    return;
+  }
+
+  isSavingPreference.value = true;
+  try {
+    const response = await emailUpdatesApi.updatePreference({
+      operation: "set_project_preference",
+      projectSlug: props.projectSlug,
+      enabled,
+      source: "menu",
+    });
+    if (!response.success) {
+      notify.showNotifyMessage(t("saveError"));
+      return;
+    }
+    if (response.result.operation === "set_project_preference") {
+      const currentSummary = summary.value;
+      if (currentSummary?.participantPreference !== undefined) {
+        summary.value = {
+          ...currentSummary,
+          participantPreference: {
+            ...currentSummary.participantPreference,
+            state: response.result.state,
+          },
+        };
+      }
+    }
+  } catch (error) {
+    console.error("Failed to update project Email Update preference", error);
+    notify.showNotifyMessage(t("saveError"));
+  } finally {
+    isSavingPreference.value = false;
+  }
+}
+
+async function handleActionSelected(action: ContentAction): Promise<void> {
+  if (action.handler !== undefined) {
+    await action.handler(actionContext);
+  }
+}
+
+watch(
+  [() => props.projectSlug, isLoggedIn],
+  () => {
+    void loadSummary();
+  },
+  { immediate: true }
+);
+</script>
+
+<style scoped lang="scss">
+:deep(.quasarBtn) {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: rgba($ink-base, 0.78);
+  box-shadow: 0 0.25rem 1rem rgba(10, 7, 20, 0.14);
+}
+</style>

--- a/services/agora/src/components/project/ProjectPageView.vue
+++ b/services/agora/src/components/project/ProjectPageView.vue
@@ -35,17 +35,20 @@
             :text-direction="projectTextDirection"
           />
 
-          <div
-            v-if="consultationStatus !== 'none'"
-            class="project-page-view__consultation-pill"
-            :class="consultationStatusClass"
-          >
-            <ZKLiveStatusDot
-              class="project-page-view__consultation-dot"
-              :active="consultationStatus === 'live'"
-              tone="positive"
-            />
-            {{ consultationStatusLabel }}
+          <div class="project-page-view__banner-actions">
+            <div
+              v-if="consultationStatus !== 'none'"
+              class="project-page-view__consultation-pill"
+              :class="consultationStatusClass"
+            >
+              <ZKLiveStatusDot
+                class="project-page-view__consultation-dot"
+                :active="consultationStatus === 'live'"
+                tone="positive"
+              />
+              {{ consultationStatusLabel }}
+            </div>
+            <ProjectEmailUpdatesMenu :project-slug="project.slug" />
           </div>
         </div>
       </section>
@@ -226,6 +229,7 @@ import { computed } from "vue";
 import ProjectActivityCard from "./ProjectActivityCard.vue";
 import ProjectDetailsAside from "./ProjectDetailsAside.vue";
 import ProjectDocuments from "./ProjectDocuments.vue";
+import ProjectEmailUpdatesMenu from "./ProjectEmailUpdatesMenu.vue";
 import ProjectLanguageSelect from "./ProjectLanguageSelect.vue";
 import ProjectMobileDetails from "./ProjectMobileDetails.vue";
 import ProjectPageFooter from "./ProjectPageFooter.vue";
@@ -415,6 +419,12 @@ main {
   line-height: 1;
   box-shadow: 0 0.25rem 1rem rgba(10, 7, 20, 0.14);
   white-space: nowrap;
+}
+
+.project-page-view__banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
 }
 
 .project-page-view__consultation-dot {

--- a/services/agora/src/components/ui-library/ZKActionDialog.vue
+++ b/services/agora/src/components/ui-library/ZKActionDialog.vue
@@ -39,6 +39,27 @@
                 @update:model-value="handleActionClick(action)"
               />
             </div>
+            <SpaLink
+              v-else-if="action.to !== undefined"
+              :to="action.to"
+              class="action-item"
+              :class="getActionVariantClass(action)"
+              @click="handleNavigationClick(action)"
+            >
+              <q-icon :name="action.icon" size="20px" class="action-icon" />
+              <div class="action-content">
+                <div class="action-label">{{ action.label }}</div>
+                <div v-if="action.description" class="action-description">
+                  {{ action.description }}
+                </div>
+              </div>
+              <q-icon
+                v-if="action.trailingIcon !== undefined"
+                :name="action.trailingIcon"
+                size="20px"
+                class="action-trailing-icon"
+              />
+            </SpaLink>
             <button
               v-else
               type="button"
@@ -72,6 +93,7 @@
 import type { ContentAction } from "src/utils/actions/core/types";
 import { watch } from "vue";
 
+import SpaLink from "./SpaLink.vue";
 import ZKBottomDialogContainer from "./ZKBottomDialogContainer.vue";
 import ZKSwitch from "./ZKSwitch.vue";
 
@@ -115,6 +137,12 @@ const handleActionClick = (action: ContentAction): void => {
     return;
   }
   emit("actionSelected", action);
+  if (action.closeOnSelect !== false) {
+    showDialog.value = false;
+  }
+};
+
+const handleNavigationClick = (action: ContentAction): void => {
   if (action.closeOnSelect !== false) {
     showDialog.value = false;
   }
@@ -178,6 +206,7 @@ watch(showDialog, (newValue) => {
   padding: 0.75rem;
   border-radius: 8px;
   cursor: pointer;
+  text-decoration: none;
   border: 1px solid transparent;
   background: transparent;
   text-align: start;

--- a/services/agora/src/composables/conversation/draft/conversationDraft.schema.test.ts
+++ b/services/agora/src/composables/conversation/draft/conversationDraft.schema.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { zodSerializableConversationDraft } from "./conversationDraft.schema";
+import { createEmptyDraft } from "./conversationDraft.utils";
+
+describe("zodSerializableConversationDraft", () => {
+  it.each([undefined, true, false])(
+    "preserves the Email Updates override %s",
+    (conversationEmailUpdateEnabledOverride) => {
+      const draft = zodSerializableConversationDraft.parse({
+        ...createEmptyDraft(),
+        conversationEmailUpdateEnabledOverride,
+      });
+
+      expect(draft.conversationEmailUpdateEnabledOverride).toBe(
+        conversationEmailUpdateEnabledOverride
+      );
+    }
+  );
+});

--- a/services/agora/src/composables/conversation/draft/conversationDraft.schema.ts
+++ b/services/agora/src/composables/conversation/draft/conversationDraft.schema.ts
@@ -97,6 +97,7 @@ const zodConversationDraftBase = z.object({
   }),
   selectedProjectSlug: zodProjectSlug.optional(),
   inheritProjectLanguages: z.boolean().default(false),
+  conversationEmailUpdateEnabledOverride: z.boolean().optional(),
   seedOpinions: z.array(z.string()),
 
   // Publishing options

--- a/services/agora/src/composables/conversation/draft/conversationDraft.types.ts
+++ b/services/agora/src/composables/conversation/draft/conversationDraft.types.ts
@@ -62,6 +62,8 @@ export interface ConversationDraftBase {
   selectedProjectSlug?: string;
   /** Whether the conversation should use the selected project's language settings. */
   inheritProjectLanguages: boolean;
+  /** Per-conversation Email Updates setting; undefined inherits the scope default. */
+  conversationEmailUpdateEnabledOverride?: boolean;
   /** Initial opinion responses to seed the conversation */
   seedOpinions: string[];
 
@@ -69,7 +71,10 @@ export interface ConversationDraftBase {
   /** The broad conversation family. Ranking subtypes are represented by rankingMode. */
   conversationType: ConversationTypeConfig["conversationType"];
   /** Ranking subtype; currently only "bws" is supported. */
-  rankingMode?: Extract<ConversationTypeConfig, { conversationType: "ranking" }>["rankingMode"];
+  rankingMode?: Extract<
+    ConversationTypeConfig,
+    { conversationType: "ranking" }
+  >["rankingMode"];
 
   // Publishing Options
   postAs: PostAsSettings;

--- a/services/agora/src/composables/conversation/draft/conversationDraft.utils.ts
+++ b/services/agora/src/composables/conversation/draft/conversationDraft.utils.ts
@@ -107,6 +107,7 @@ export function createEmptyDraft(): ConversationDraft {
     },
     selectedProjectSlug: undefined,
     inheritProjectLanguages: false,
+    conversationEmailUpdateEnabledOverride: undefined,
     seedOpinions: [],
 
     // Conversation Type

--- a/services/agora/src/composables/conversation/draft/useConversationDraft.ts
+++ b/services/agora/src/composables/conversation/draft/useConversationDraft.ts
@@ -57,6 +57,7 @@ export interface UseConversationDraftReturn {
   multilingualSetting: Ref<ConversationMultilingualSetting>;
   selectedProjectSlug: Ref<string | undefined>;
   inheritProjectLanguages: Ref<boolean>;
+  conversationEmailUpdateEnabledOverride: Ref<boolean | undefined>;
   seedOpinions: Ref<string[]>;
   conversationType: Ref<ConversationType>;
   rankingMode: Ref<RankingMode | undefined>;
@@ -134,6 +135,9 @@ export function useConversationDraft(
     initialDraft.selectedProjectSlug
   );
   const inheritProjectLanguages = ref(initialDraft.inheritProjectLanguages);
+  const conversationEmailUpdateEnabledOverride = ref<boolean | undefined>(
+    initialDraft.conversationEmailUpdateEnabledOverride
+  );
   const seedOpinions = ref<string[]>([...initialDraft.seedOpinions]);
   const conversationType = ref<ConversationType>(initialDraft.conversationType);
   const rankingMode = ref<RankingMode | undefined>(
@@ -179,6 +183,8 @@ export function useConversationDraft(
       multilingualSetting: multilingualSetting.value,
       selectedProjectSlug: selectedProjectSlug.value,
       inheritProjectLanguages: inheritProjectLanguages.value,
+      conversationEmailUpdateEnabledOverride:
+        conversationEmailUpdateEnabledOverride.value,
       seedOpinions: [...seedOpinions.value],
       conversationType: conversationType.value,
       rankingMode: rankingMode.value,
@@ -205,6 +211,8 @@ export function useConversationDraft(
           newSnapshot.selectedProjectSlug;
         store.conversationDraft.inheritProjectLanguages =
           newSnapshot.inheritProjectLanguages;
+        store.conversationDraft.conversationEmailUpdateEnabledOverride =
+          newSnapshot.conversationEmailUpdateEnabledOverride;
         store.conversationDraft.seedOpinions = newSnapshot.seedOpinions;
         if (newSnapshot.conversationType === "ranking") {
           store.conversationDraft = {
@@ -439,6 +447,9 @@ export function useConversationDraft(
     const hasProjectSelectionChanges =
       selectedProjectSlug.value !== emptyDraft.selectedProjectSlug ||
       inheritProjectLanguages.value !== emptyDraft.inheritProjectLanguages;
+    const hasConversationEmailUpdateChanges =
+      conversationEmailUpdateEnabledOverride.value !==
+      emptyDraft.conversationEmailUpdateEnabledOverride;
 
     // Check seed opinions changes
     const hasSeedOpinionsChanges =
@@ -484,6 +495,7 @@ export function useConversationDraft(
       hasContentChanges ||
       hasMultilingualSettingChanges ||
       hasProjectSelectionChanges ||
+      hasConversationEmailUpdateChanges ||
       hasSeedOpinionsChanges ||
       hasConversationTypeChanges ||
       hasPostAsChanges ||
@@ -514,6 +526,8 @@ export function useConversationDraft(
     multilingualSetting.value = emptyDraft.multilingualSetting;
     selectedProjectSlug.value = emptyDraft.selectedProjectSlug;
     inheritProjectLanguages.value = emptyDraft.inheritProjectLanguages;
+    conversationEmailUpdateEnabledOverride.value =
+      emptyDraft.conversationEmailUpdateEnabledOverride;
     seedOpinions.value = [];
     conversationType.value = emptyDraft.conversationType;
     rankingMode.value = undefined;
@@ -598,6 +612,7 @@ export function useConversationDraft(
     multilingualSetting,
     selectedProjectSlug,
     inheritProjectLanguages,
+    conversationEmailUpdateEnabledOverride,
     seedOpinions,
     conversationType,
     rankingMode,

--- a/services/agora/src/composables/conversation/usePublishConversationDraft.ts
+++ b/services/agora/src/composables/conversation/usePublishConversationDraft.ts
@@ -77,6 +77,8 @@ function buildBaseCreateConversationRequest({
     participationMode: conversationDraft.participationMode,
     seedOpinionList: conversationDraft.seedOpinions,
     requiresEventTicket: conversationDraft.requiresEventTicket,
+    conversationEmailUpdateEnabledOverride:
+      conversationDraft.conversationEmailUpdateEnabledOverride,
   };
 }
 
@@ -235,9 +237,7 @@ export function usePublishConversationDraft() {
     }
   }
 
-  function showProjectTargetFailure(
-    reason: ProjectCreateFailureReason
-  ): void {
+  function showProjectTargetFailure(reason: ProjectCreateFailureReason): void {
     if (reason === "organization_not_available") {
       showNotifyMessage(t("organizationUnavailable"));
       return;

--- a/services/agora/src/composables/share/useShareActions.ts
+++ b/services/agora/src/composables/share/useShareActions.ts
@@ -121,7 +121,9 @@ export function useShareActions(): ShareActionsComposable {
     }
 
     try {
-      await action.handler(dialogStateRef.value.context);
+      if (action.handler !== undefined) {
+        await action.handler(dialogStateRef.value.context);
+      }
       // Close dialog after successful execution
       closeDialog();
     } catch (error) {

--- a/services/agora/src/pages/conversation/[conversationSlugId]/edit/index.vue
+++ b/services/agora/src/pages/conversation/[conversationSlugId]/edit/index.vue
@@ -73,7 +73,7 @@
             "
             :project-title="currentProjectLanguageProject?.title"
             :scope-default-enabled="conversationUpdatesScopeDefault"
-            :has-entitlement="
+            :can-configure="
               conversationUpdatesConfiguration?.canConfigure === true
             "
             @update:model-value="updateConversationUpdatesConfiguration"
@@ -725,6 +725,12 @@ onMounted(async () => {
       response.contentLanguageMetadata.detectedRawLanguageCode;
     autoDetectionStatus.value =
       response.contentLanguageMetadata.autoDetectionStatus;
+    if (response.postAsOrganizationSlug !== undefined) {
+      postAs.value = {
+        postAsOrganization: true,
+        organizationName: response.postAsOrganizationSlug,
+      };
+    }
 
     initializeFromData({
       title: response.conversationTitle,

--- a/services/agora/src/pages/conversation/new/create/index.vue
+++ b/services/agora/src/pages/conversation/new/create/index.vue
@@ -52,6 +52,21 @@
             v-model:override-multilingual-setting="multilingualSetting"
             :project-list="projectLanguageProjects"
           />
+          <CreateConversationUpdatesSettings
+            v-if="
+              conversationDraft.importSettings.importType === null &&
+              selectedEmailUpdatesConfiguration !== undefined
+            "
+            v-model="conversationEmailUpdateEnabledOverride"
+            :scope-kind="
+              selectedProjectSlug === undefined ? 'no-project' : 'project'
+            "
+            :project-title="selectedProjectOption?.projectTitle"
+            :scope-default-enabled="
+              selectedEmailUpdatesConfiguration.scopeDefaultEnabled
+            "
+            :can-configure="selectedEmailUpdatesConfiguration.canConfigure"
+          />
         </template>
       </NewConversationControlBar>
 
@@ -179,6 +194,7 @@ import BackButton from "src/components/navigation/buttons/BackButton.vue";
 import DefaultMenuBar from "src/components/navigation/header/DefaultMenuBar.vue";
 import type { CreateConversationProjectLanguageProject } from "src/components/newConversation/CreateConversationProjectLanguageSettings.vue";
 import CreateConversationProjectLanguageSettings from "src/components/newConversation/CreateConversationProjectLanguageSettings.vue";
+import CreateConversationUpdatesSettings from "src/components/newConversation/CreateConversationUpdatesSettings.vue";
 import PolisCsvUpload from "src/components/newConversation/import/csv/PolisCsvUpload.vue";
 import PolisUrlInput from "src/components/newConversation/import/url/PolisUrlInput.vue";
 import NewConversationControlBar from "src/components/newConversation/NewConversationControlBar.vue";
@@ -247,6 +263,7 @@ const {
   multilingualSetting,
   selectedProjectSlug,
   inheritProjectLanguages,
+  conversationEmailUpdateEnabledOverride,
   conversationType,
   rankingMode,
   isPrivate,
@@ -316,8 +333,38 @@ const {
   importConversation,
   importConversationFromCsv,
 } = useBackendPostApi();
-const projectLanguageProjects = ref<CreateConversationProjectLanguageProject[]>(
+type ConversationCreateProjectOptionsSuccess = Extract<
+  GetConversationCreateProjectOptionsResponse,
+  { success: true }
+>;
+type ConversationCreateProjectOption =
+  ConversationCreateProjectOptionsSuccess["projectList"][number];
+type ConversationCreateEmailUpdates =
+  ConversationCreateProjectOptionsSuccess["noProjectEmailUpdates"];
+
+const conversationCreateProjectOptions = ref<ConversationCreateProjectOption[]>(
   []
+);
+const noProjectEmailUpdates = ref<ConversationCreateEmailUpdates>();
+const projectLanguageProjects = computed<
+  CreateConversationProjectLanguageProject[]
+>(() =>
+  conversationCreateProjectOptions.value.map((project) => ({
+    slug: project.projectSlug,
+    title: project.projectTitle,
+    defaultLanguageCode: project.defaultLanguageCode,
+    languageSettings: project.languageSettings,
+  }))
+);
+const selectedProjectOption = computed(() =>
+  conversationCreateProjectOptions.value.find(
+    (project) => project.projectSlug === selectedProjectSlug.value
+  )
+);
+const selectedEmailUpdatesConfiguration = computed(() =>
+  selectedProjectSlug.value === undefined
+    ? noProjectEmailUpdates.value
+    : selectedProjectOption.value?.emailUpdates
 );
 let projectOptionsRequestId = 0;
 
@@ -368,8 +415,10 @@ watch(
     organizationList,
   }) => {
     const requestId = ++projectOptionsRequestId;
-    projectLanguageProjects.value = [];
+    conversationCreateProjectOptions.value = [];
+    noProjectEmailUpdates.value = undefined;
     selectedProjectSlug.value = undefined;
+    conversationEmailUpdateEnabledOverride.value = undefined;
     inheritProjectLanguages.value = false;
 
     if (
@@ -409,14 +458,21 @@ watch(
       return;
     }
 
-    projectLanguageProjects.value = response.projectList.map((project) => ({
-      slug: project.projectSlug,
-      title: project.projectTitle,
-      defaultLanguageCode: project.defaultLanguageCode,
-      languageSettings: project.languageSettings,
-    }));
+    conversationCreateProjectOptions.value = response.projectList;
+    noProjectEmailUpdates.value = response.noProjectEmailUpdates;
   },
   { immediate: true }
+);
+
+watch(
+  [
+    () => postAs.value.postAsOrganization,
+    () => postAs.value.organizationName,
+    selectedProjectSlug,
+  ],
+  () => {
+    conversationEmailUpdateEnabledOverride.value = undefined;
+  }
 );
 
 const hasActiveImport = computed(() => {

--- a/services/agora/src/pages/dev/conversation-updates.vue
+++ b/services/agora/src/pages/dev/conversation-updates.vue
@@ -1,0 +1,396 @@
+<template>
+  <Teleport v-if="isActive" to="#page-header">
+    <StandardMenuBar
+      title="Email Updates dev fixture"
+      :center-content="true"
+      fallback-route="/dev/component-testing"
+    />
+  </Teleport>
+
+  <main class="conversation-updates-dev">
+    <q-card flat bordered class="conversation-updates-dev__controls">
+      <q-card-section>
+        <p class="conversation-updates-dev__eyebrow">Local-only fixture</p>
+        <h1>Email Updates</h1>
+        <p>
+          Exercise the composer and recipient-facing states without sending or
+          writing to the API.
+        </p>
+      </q-card-section>
+      <q-card-actions>
+        <ZKButton
+          button-type="standardButton"
+          outline
+          color="primary"
+          label="Preference menu"
+          icon="mdi-dots-horizontal"
+          @click="showPreferenceDialog = true"
+        />
+        <SpaLink to="/email-updates/?tab=compose">
+          Open real workspace
+        </SpaLink>
+        <SpaLink to="/settings/account/email-updates/">
+          Open real preferences
+        </SpaLink>
+      </q-card-actions>
+      <q-card-section>
+        <ConversationUpdateOnboardingConsent
+          v-model="onboardingConsent"
+          scope-kind="project"
+        />
+      </q-card-section>
+    </q-card>
+
+    <section class="conversation-updates-dev__grid">
+      <ConversationUpdateComposerForm
+        v-model:selected-scope-id="selectedScopeId"
+        v-model:selected-conversation-ids="selectedConversationIds"
+        v-model:subject="subject"
+        v-model:body-html="bodyHtml"
+        v-model:body-plain-text="bodyPlainText"
+        v-model:content-confirmed="contentConfirmed"
+        :scopes="scopes"
+        :updates-disabled-conversation-ids="[]"
+        :test-pending="false"
+        :notice="notice"
+        :has-successful-test="hasSuccessfulTest"
+        :audience-estimate-available="true"
+        :related-conversation-owner-count="1"
+        @test="simulateTest"
+        @send="simulateSend"
+      />
+
+      <ConversationUpdateEmailPreview
+        :subject="subject"
+        :body-html="bodyHtml"
+        reply-to="facilitator@example.org"
+        scope-kind="project"
+        scope-href="/dev/project-page"
+        scope-label="River Commons"
+        :conversations="selectedConversations"
+        :audience-estimate="1842"
+      />
+    </section>
+
+    <ConversationUpdateHistoryList :records="historyRecords" />
+
+    <section class="conversation-updates-dev__recipient-preferences">
+      <div class="conversation-updates-dev__recipient-heading">
+        <div>
+          <p class="conversation-updates-dev__eyebrow">Auth-free email link</p>
+          <h2>Recipient preference manager</h2>
+          <p>
+            This is the same component recipients see after opening “Manage
+            preferences” from an email.
+          </p>
+        </div>
+        <q-btn-toggle
+          v-model="recipientPreferenceScenario"
+          unelevated
+          no-caps
+          toggle-color="primary"
+          color="white"
+          text-color="primary"
+          :options="recipientPreferenceScenarioOptions"
+        />
+      </div>
+      <ConversationUpdateAuthFreePreferenceManager
+        :items="recipientPreferenceItems"
+        :pending-key="undefined"
+        :error-key="undefined"
+        :successful-keys="recipientSuccessfulKeys"
+        :translate="translateRecipientPreference"
+        @opt-out="simulateRecipientOptOut"
+      />
+    </section>
+  </main>
+
+  <ZKActionDialog
+    v-model="showPreferenceDialog"
+    title="Conversation actions"
+    :actions="preferenceActions"
+    @action-selected="handlePreferenceAction"
+  />
+</template>
+
+<script setup lang="ts">
+import type { ManageOptOutItem } from "src/components/conversationUpdates/authFreePreferenceManager";
+import ConversationUpdateAuthFreePreferenceManager from "src/components/conversationUpdates/ConversationUpdateAuthFreePreferenceManager.vue";
+import ConversationUpdateComposerForm from "src/components/conversationUpdates/ConversationUpdateComposerForm.vue";
+import ConversationUpdateEmailPreview from "src/components/conversationUpdates/ConversationUpdateEmailPreview.vue";
+import ConversationUpdateHistoryList from "src/components/conversationUpdates/ConversationUpdateHistoryList.vue";
+import ConversationUpdateOnboardingConsent from "src/components/conversationUpdates/ConversationUpdateOnboardingConsent.vue";
+import { createConversationUpdatePreferenceAction } from "src/components/conversationUpdates/conversationUpdatePreferenceAction";
+import type {
+  ConversationUpdateHistoryRecord,
+  ConversationUpdateScopeSummary,
+} from "src/components/conversationUpdates/conversationUpdateTypes";
+import { StandardMenuBar } from "src/components/navigation/header/variants";
+import SpaLink from "src/components/ui-library/SpaLink.vue";
+import ZKActionDialog from "src/components/ui-library/ZKActionDialog.vue";
+import ZKButton from "src/components/ui-library/ZKButton.vue";
+import { usePageLayout } from "src/composables/layout/usePageLayout";
+import { useComponentI18n } from "src/composables/ui/useComponentI18n";
+import type {
+  ContentAction,
+  ContentActionContext,
+} from "src/utils/actions/core/types";
+import { computed, ref } from "vue";
+
+import {
+  type EmailUpdatePreferencesTranslations,
+  emailUpdatePreferencesTranslations,
+} from "../email-updates/preferences/[token].i18n";
+
+const { isActive } = usePageLayout({
+  enableDrawer: false,
+  enableFooter: false,
+  reducedWidth: false,
+  addBottomPadding: true,
+});
+const { t: translateRecipientPreference } =
+  useComponentI18n<EmailUpdatePreferencesTranslations>(
+    emailUpdatePreferencesTranslations
+  );
+
+type RecipientPreferenceScenario =
+  | "no-project-multiple"
+  | "no-project-single"
+  | "project-multiple"
+  | "project-single";
+const recipientPreferenceScenarioOptions: {
+  label: string;
+  value: RecipientPreferenceScenario;
+}[] = [
+  { label: "Project + multiple", value: "project-multiple" },
+  { label: "Project + one", value: "project-single" },
+  { label: "No Project + multiple", value: "no-project-multiple" },
+  { label: "No Project + one", value: "no-project-single" },
+];
+const recipientPreferenceScenario =
+  ref<RecipientPreferenceScenario>("project-multiple");
+const projectPreferenceItem: ManageOptOutItem = {
+  key: "project:river-commons",
+  title: "River Commons",
+  target: { kind: "project", projectSlug: "river-commons" },
+  type: "project",
+};
+const conversationPreferenceItems: readonly ManageOptOutItem[] = [
+  {
+    key: "conversation:river-plan",
+    title: "Choose the river restoration plan",
+    target: { kind: "conversation", conversationSlugId: "river-plan" },
+    type: "conversation",
+  },
+  {
+    key: "conversation:park-design",
+    title: "Prioritize the new park design",
+    target: { kind: "conversation", conversationSlugId: "park-design" },
+    type: "conversation",
+  },
+];
+const recipientPreferenceItems = computed<readonly ManageOptOutItem[]>(() => {
+  const selectedConversations = recipientPreferenceScenario.value.endsWith(
+    "multiple"
+  )
+    ? conversationPreferenceItems
+    : conversationPreferenceItems.slice(0, 1);
+  return recipientPreferenceScenario.value.startsWith("project")
+    ? [projectPreferenceItem, ...selectedConversations]
+    : selectedConversations;
+});
+const recipientSuccessfulKeys = ref<ReadonlySet<string>>(new Set());
+
+const conversations = [
+  {
+    id: "river-plan",
+    title: "Choose the river restoration plan",
+    href: "/dev/project-conversation-layout",
+    eligibleParticipantCount: 1240,
+    participationMode: "account_required",
+    ownerIds: ["facilitator-one"],
+  },
+  {
+    id: "park-design",
+    title: "Prioritize the new park design",
+    href: "/dev/project-conversation-layout",
+    eligibleParticipantCount: 602,
+    participationMode: "email_verification",
+    ownerIds: ["facilitator-two"],
+  },
+] satisfies ConversationUpdateScopeSummary["conversations"];
+const scopes = [
+  {
+    id: "river-commons",
+    kind: "project",
+    label: "River Commons",
+    href: "/dev/project-page",
+    contactEmail: "facilitator@example.org",
+    eligibleParticipantCap: 5000,
+    conversations,
+  },
+] satisfies readonly ConversationUpdateScopeSummary[];
+const historyRecords = [
+  {
+    id: "fixture-update",
+    subject: "What we heard in July",
+    bodyHtml:
+      "<p>Thank you for helping prioritize the next phase of the River Commons project.</p>",
+    scopeId: "river-commons",
+    scopeKind: "project",
+    scopeLabel: "River Commons",
+    scopeHref: "/dev/project-page",
+    conversations,
+    audienceEstimate: 1842,
+    ownerCopyCount: 1,
+    createdAtLabel: "July 18, 2026",
+    status: "completed",
+    reason: undefined,
+  },
+] satisfies readonly ConversationUpdateHistoryRecord[];
+
+const selectedScopeId = ref("river-commons");
+const selectedConversationIds = ref<readonly string[]>([
+  "river-plan",
+  "park-design",
+]);
+const subject = ref("What we heard and what happens next");
+const bodyHtml = ref(
+  "<p>Thank you for taking part. Your priorities are shaping the next project phase.</p>"
+);
+const bodyPlainText = ref(
+  "Thank you for taking part. Your priorities are shaping the next project phase."
+);
+const contentConfirmed = ref(false);
+const onboardingConsent = ref(true);
+const hasSuccessfulTest = ref(false);
+const notice = ref<string>();
+const showPreferenceDialog = ref(false);
+const preferenceEnabled = ref(false);
+const selectedConversations = computed(() => {
+  const selectedIds = new Set(selectedConversationIds.value);
+  return conversations.filter((conversation) =>
+    selectedIds.has(conversation.id)
+  );
+});
+const preferenceActions = computed(() => [
+  createConversationUpdatePreferenceAction({
+    id: "conversationEmailUpdates",
+    label: "Receive Email Updates",
+    enabled: preferenceEnabled.value,
+    description: preferenceEnabled.value
+      ? "On for this conversation"
+      : "Off for this conversation",
+    onToggle: () => {
+      preferenceEnabled.value = !preferenceEnabled.value;
+    },
+  }),
+]);
+const actionContext: ContentActionContext = {
+  isOwner: false,
+  isSiteModerator: false,
+  isConversationOwner: false,
+  isOrgMember: false,
+  isLoggedIn: true,
+  isEmbeddedMode: false,
+  targetType: "post",
+  targetId: "fixture",
+  targetAuthor: "Fixture",
+};
+
+function simulateTest(): void {
+  hasSuccessfulTest.value = true;
+  notice.value = "Simulated test delivered successfully. No request was sent.";
+}
+
+function simulateSend(): void {
+  notice.value = "Simulated review completed. No update was queued or sent.";
+}
+
+function simulateRecipientOptOut(item: ManageOptOutItem): void {
+  recipientSuccessfulKeys.value = new Set([
+    ...recipientSuccessfulKeys.value,
+    item.key,
+  ]);
+}
+
+async function handlePreferenceAction(action: ContentAction): Promise<void> {
+  if (action.handler !== undefined) {
+    await action.handler(actionContext);
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.conversation-updates-dev {
+  display: grid;
+  gap: 1.5rem;
+  width: min(78rem, calc(100% - 2rem));
+  margin: 0 auto;
+  padding-block: 1.5rem 3rem;
+}
+
+.conversation-updates-dev__controls {
+  border-radius: 1rem;
+
+  h1 {
+    margin: 0.2rem 0 0.5rem;
+    font-size: clamp(1.5rem, 4vw, 2.2rem);
+  }
+
+  p {
+    margin: 0;
+  }
+
+  :deep(.q-card__actions) {
+    align-items: center;
+    gap: 1rem;
+    padding: 0 1rem 1rem;
+  }
+}
+
+.conversation-updates-dev__eyebrow {
+  color: $primary;
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.conversation-updates-dev__grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.conversation-updates-dev__recipient-preferences {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid $grey-4;
+  border-radius: 1rem;
+  background: $color-background-default;
+}
+
+.conversation-updates-dev__recipient-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+
+  h2 {
+    margin: 0.2rem 0 0.5rem;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+@media (min-width: $breakpoint-md-min) {
+  .conversation-updates-dev__grid {
+    grid-template-columns: minmax(0, 1fr) minmax(22rem, 0.8fr);
+    align-items: start;
+  }
+}
+</style>

--- a/services/agora/src/pages/email-updates/actionPage.test.ts
+++ b/services/agora/src/pages/email-updates/actionPage.test.ts
@@ -1,3 +1,4 @@
+import { isManageOptOutDisabled } from "src/components/conversationUpdates/authFreePreferenceManager";
 import type { ConversationEmailUpdateActionResolveResponse } from "src/shared/types/dto";
 import { describe, expect, it } from "vitest";
 
@@ -6,7 +7,6 @@ import {
   getPreferencesResolution,
   getReportResolution,
   getUnsubscribeResolution,
-  isManageOptOutDisabled,
   optionalReportDetails,
   reportReasons,
 } from "./actionPage";

--- a/services/agora/src/pages/email-updates/actionPage.ts
+++ b/services/agora/src/pages/email-updates/actionPage.ts
@@ -1,5 +1,5 @@
+import type { ManageOptOutItem } from "src/components/conversationUpdates/authFreePreferenceManager";
 import type {
-  ConversationEmailUpdateActionManageOptOutRequest,
   ConversationEmailUpdateActionReportRequest,
   ConversationEmailUpdateActionResolveResponse,
 } from "src/shared/types/dto";
@@ -18,16 +18,7 @@ export type PreferencesResolution = Extract<
   { action: "manage_preferences" }
 >;
 export type ReportResolution = Extract<ResolveSuccess, { action: "report" }>;
-export type ManageOptOutTarget =
-  ConversationEmailUpdateActionManageOptOutRequest["target"];
 export type ReportReason = ConversationEmailUpdateActionReportRequest["reason"];
-
-export interface ManageOptOutItem {
-  key: string;
-  title: string;
-  target: ManageOptOutTarget;
-  type: "project" | "conversation";
-}
 
 export const reportReasons: readonly ReportReason[] = [
   "spam",
@@ -101,18 +92,6 @@ export function getManageOptOutItems(
 export function optionalReportDetails(details: string): string | undefined {
   const trimmedDetails = details.trim();
   return trimmedDetails.length > 0 ? trimmedDetails : undefined;
-}
-
-export function isManageOptOutDisabled({
-  itemKey,
-  pendingKey,
-  successfulKeys,
-}: {
-  itemKey: string;
-  pendingKey: string | undefined;
-  successfulKeys: ReadonlySet<string>;
-}): boolean {
-  return pendingKey !== undefined || successfulKeys.has(itemKey);
 }
 
 function getOrCreateMeta(name: string): HTMLMetaElement {

--- a/services/agora/src/pages/email-updates/preferences/[token].vue
+++ b/services/agora/src/pages/email-updates/preferences/[token].vue
@@ -19,60 +19,27 @@
       </section>
     </div>
 
-    <section v-else class="action-card">
-      <h1>{{ t("title") }}</h1>
-      <p class="action-description">{{ t("description") }}</p>
-
-      <ul class="preference-list">
-        <li v-for="item in state.items" :key="item.key" class="preference-item">
-          <div class="preference-copy">
-            <span class="preference-type">{{ t(item.type) }}</span>
-            <h2>{{ item.title }}</h2>
-            <span
-              v-if="successfulKeys.has(item.key)"
-              class="preference-success"
-              role="status"
-            >
-              {{ t("optedOut") }}
-            </span>
-            <span
-              v-else-if="errorKey === item.key"
-              class="action-error"
-              role="alert"
-            >
-              {{ t("submitFailed") }}
-            </span>
-          </div>
-          <div class="preference-action">
-            <ZKButton
-              button-type="standardButton"
-              outline
-              color="primary"
-              :disable="
-                isManageOptOutDisabled({
-                  itemKey: item.key,
-                  pendingKey,
-                  successfulKeys,
-                })
-              "
-              :loading="pendingKey === item.key"
-              :aria-label="t('optOutTarget', { title: item.title })"
-              @click="submitOptOut(item)"
-            >
-              {{ pendingKey === item.key ? t("optingOut") : t("optOut") }}
-            </ZKButton>
-          </div>
-        </li>
-      </ul>
-    </section>
+    <ConversationUpdateAuthFreePreferenceManager
+      v-else
+      :items="state.items"
+      :pending-key="pendingKey"
+      :error-key="errorKey"
+      :successful-keys="successfulKeys"
+      :translate="t"
+      @opt-out="submitOptOut"
+    />
   </main>
 </template>
 
 <script setup lang="ts">
+import {
+  isManageOptOutDisabled,
+  type ManageOptOutItem,
+} from "src/components/conversationUpdates/authFreePreferenceManager";
+import ConversationUpdateAuthFreePreferenceManager from "src/components/conversationUpdates/ConversationUpdateAuthFreePreferenceManager.vue";
 import { StandardMenuBar } from "src/components/navigation/header/variants";
 import PageLoadingSpinner from "src/components/ui/PageLoadingSpinner.vue";
 import SpaLink from "src/components/ui-library/SpaLink.vue";
-import ZKButton from "src/components/ui-library/ZKButton.vue";
 import { usePageLayout } from "src/composables/layout/usePageLayout";
 import { useComponentI18n } from "src/composables/ui/useComponentI18n";
 import { usePublicConversationEmailUpdateActionsApi } from "src/utils/api/conversationUpdates/publicConversationEmailUpdateActions";
@@ -83,8 +50,6 @@ import { useRoute } from "vue-router";
 import {
   getManageOptOutItems,
   getPreferencesResolution,
-  isManageOptOutDisabled,
-  type ManageOptOutItem,
   useEmailUpdateActionPageMetadata,
 } from "../actionPage";
 import {
@@ -182,44 +147,6 @@ async function submitOptOut(item: ManageOptOutItem): Promise<void> {
 <style scoped lang="scss">
 @use "../actionPageStyles";
 
-.preference-list {
-  display: grid;
-  gap: 0.8rem;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
-
-.preference-item {
-  display: grid;
-  gap: 1rem;
-  padding: 1rem;
-  border: 1px solid $grey-4;
-  border-radius: 14px;
-}
-
-.preference-copy {
-  display: grid;
-  gap: 0.3rem;
-}
-
-.preference-type {
-  color: $grey-7;
-  font-size: 0.8rem;
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.preference-success {
-  color: $positive;
-  font-weight: var(--font-weight-semibold);
-}
-
-.preference-action {
-  width: 8rem;
-}
-
 .visually-hidden {
   position: absolute;
   width: 1px;
@@ -230,12 +157,5 @@ async function submitOptOut(item: ManageOptOutItem): Promise<void> {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-}
-
-@media (min-width: $breakpoint-sm-min) {
-  .preference-item {
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: center;
-  }
 }
 </style>

--- a/services/agora/src/route-map.d.ts
+++ b/services/agora/src/route-map.d.ts
@@ -303,6 +303,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/dev/conversation-updates': RouteRecordInfo<
+      '/dev/conversation-updates',
+      '/dev/conversation-updates',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/dev/long-rich-text-disclosure': RouteRecordInfo<
       '/dev/long-rich-text-disclosure',
       '/dev/long-rich-text-disclosure',
@@ -1015,6 +1022,12 @@ declare module 'vue-router/auto-routes' {
     'src/pages/dev/conversation-project-context.vue': {
       routes:
         | '/dev/conversation-project-context'
+      views:
+        | never
+    }
+    'src/pages/dev/conversation-updates.vue': {
+      routes:
+        | '/dev/conversation-updates'
       views:
         | never
     }

--- a/services/agora/src/shared/types/dto.ts
+++ b/services/agora/src/shared/types/dto.ts
@@ -402,6 +402,12 @@ const zodConversationLanguageSettingsSource = z.enum([
     "conversation_override",
     "project_inherited",
 ]);
+const zodConversationCreateEmailUpdateConfiguration = z
+    .object({
+        canConfigure: z.boolean(),
+        scopeDefaultEnabled: z.boolean(),
+    })
+    .strict();
 const zodConversationCreateProjectOption = z
     .object({
         projectSlug: zodProjectSlug,
@@ -410,6 +416,12 @@ const zodConversationCreateProjectOption = z
         languageSettings: zodProjectLanguageSettings,
     })
     .strict();
+const zodConversationCreateProjectOptionWithEmailUpdates =
+    zodConversationCreateProjectOption
+        .extend({
+            emailUpdates: zodConversationCreateEmailUpdateConfiguration,
+        })
+        .strict();
 const zodProjectContentLocalizationInput = z
     .object({
         languageCode: ZodSupportedDisplayLanguageCodes,
@@ -1237,6 +1249,7 @@ export class Dto {
             multilingualSetting: zodConversationMultilingualSetting,
             seedOpinionList: z.array(zodOpinionContentInput).max(50),
             requiresEventTicket: zodEventSlug.optional(),
+            conversationEmailUpdateEnabledOverride: z.boolean().optional(),
         })
         .strict();
     static createNewConversationRequest = z.discriminatedUnion(
@@ -1554,6 +1567,7 @@ export class Dto {
                 aiLabelingEnabled: z.boolean(),
                 preferredOpinionGroupCount: zodPreferredOpinionGroupCount,
                 postAsOrganizationName: z.string().optional(),
+                postAsOrganizationSlug: zodOrganizationSlug.optional(),
                 surveyConfig: zodSurveyConfig.nullable().optional(),
                 createdAt: zodDateTimeFlexible,
                 updatedAt: zodDateTimeFlexible,
@@ -2337,14 +2351,19 @@ export class Dto {
             ),
         })
         .strict();
-    static conversationCreateProjectOption = zodConversationCreateProjectOption;
+    static conversationCreateProjectOption =
+        zodConversationCreateProjectOptionWithEmailUpdates;
     static getConversationCreateProjectOptionsResponse = z.discriminatedUnion(
         "success",
         [
             z
                 .object({
                     success: z.literal(true),
-                    projectList: z.array(Dto.conversationCreateProjectOption),
+                    projectList: z.array(
+                        zodConversationCreateProjectOptionWithEmailUpdates,
+                    ),
+                    noProjectEmailUpdates:
+                        zodConversationCreateEmailUpdateConfiguration,
                 })
                 .strict(),
             z
@@ -3476,6 +3495,39 @@ export class Dto {
                 })
                 .strict(),
         ]);
+    static conversationEmailUpdateProjectSummaryRequest = z
+        .object({
+            projectSlug: zodProjectSlug,
+        })
+        .strict();
+    static conversationEmailUpdateProjectSummaryResponse = z.discriminatedUnion(
+        "success",
+        [
+            z
+                .object({
+                    success: z.literal(true),
+                    authoringAction: z.enum(["none", "compose", "history"]),
+                    participantPreference: z
+                        .object({
+                            state: zodConversationEmailUpdatePreferenceState,
+                            resolvedEnabled: z.boolean(),
+                        })
+                        .strict()
+                        .optional(),
+                })
+                .strict(),
+            z
+                .object({
+                    success: z.literal(false),
+                    reason: z.enum([
+                        "project_not_found",
+                        "feature_not_available",
+                        "summary_unavailable",
+                    ]),
+                })
+                .strict(),
+        ],
+    );
     static conversationEmailUpdateActionResolveRequest = z
         .object({ token: zodConversationEmailUpdateActionToken })
         .strict();
@@ -4124,6 +4176,12 @@ export type ConversationEmailUpdateConversationSummaryRequest = z.infer<
 >;
 export type ConversationEmailUpdateConversationSummaryResponse = z.infer<
     typeof Dto.conversationEmailUpdateConversationSummaryResponse
+>;
+export type ConversationEmailUpdateProjectSummaryRequest = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryRequest
+>;
+export type ConversationEmailUpdateProjectSummaryResponse = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryResponse
 >;
 export type ConversationEmailUpdateSnsSimulatorRequest = z.infer<
     typeof Dto.conversationEmailUpdateSnsSimulatorRequest

--- a/services/agora/src/stores/newConversationDrafts.ts
+++ b/services/agora/src/stores/newConversationDrafts.ts
@@ -111,6 +111,9 @@ export const useNewPostDraftsStore = defineStore("newPostDrafts", () => {
     const hasProjectSelectionChanges =
       current.selectedProjectSlug !== emptyDraft.selectedProjectSlug ||
       current.inheritProjectLanguages !== emptyDraft.inheritProjectLanguages;
+    const hasConversationEmailUpdateChanges =
+      current.conversationEmailUpdateEnabledOverride !==
+      emptyDraft.conversationEmailUpdateEnabledOverride;
 
     // Check seed opinions changes
     const hasSeedOpinionsChanges =
@@ -147,16 +150,16 @@ export const useNewPostDraftsStore = defineStore("newPostDrafts", () => {
       JSON.stringify(current.importSettings.csvFileMetadata) !==
         JSON.stringify(emptyDraft.importSettings.csvFileMetadata);
 
-    const hasSurveyConfigChanges =
-      !areSurveyConfigsEqual({
-        left: current.surveyConfig,
-        right: emptyDraft.surveyConfig,
-      });
+    const hasSurveyConfigChanges = !areSurveyConfigsEqual({
+      left: current.surveyConfig,
+      right: emptyDraft.surveyConfig,
+    });
 
     return (
       hasContentChanges ||
       hasMultilingualSettingChanges ||
       hasProjectSelectionChanges ||
+      hasConversationEmailUpdateChanges ||
       hasSeedOpinionsChanges ||
       hasConversationTypeChanges ||
       hasPostAsChanges ||
@@ -203,10 +206,7 @@ export const useNewPostDraftsStore = defineStore("newPostDrafts", () => {
    */
   function hasContentThatWouldBeCleared(): boolean {
     const draft = conversationDraft.value;
-    return (
-      draft.title.trim() !== "" ||
-      draft.content.trim() !== ""
-    );
+    return draft.title.trim() !== "" || draft.content.trim() !== "";
   }
 
   /**
@@ -281,7 +281,8 @@ export const useNewPostDraftsStore = defineStore("newPostDrafts", () => {
 
   function canEvaluateCurrentActorRestrictions(): boolean {
     return (
-      conversationDraft.value.postAs.postAsOrganization || authStore.userId !== undefined
+      conversationDraft.value.postAs.postAsOrganization ||
+      authStore.userId !== undefined
     );
   }
 
@@ -312,7 +313,6 @@ export const useNewPostDraftsStore = defineStore("newPostDrafts", () => {
     ) {
       clearImportDraft();
     }
-
   }
 
   // ============================================================================

--- a/services/agora/src/utils/actions/core/types.ts
+++ b/services/agora/src/utils/actions/core/types.ts
@@ -1,3 +1,5 @@
+import type { RouteLocationRaw } from "vue-router";
+
 /**
  * Core TypeScript interfaces for the content action dialog system
  * This file defines all types used throughout the content action management system
@@ -38,10 +40,24 @@ export type ContentActionHandler = (
 ) => Promise<void> | void;
 
 // Complete content action with handler
-export interface ContentAction extends BaseContentAction {
-  handler: ContentActionHandler;
+interface ContentActionVisibility {
   isVisible: (context: ContentActionContext) => boolean;
 }
+
+interface CommonContentAction
+  extends BaseContentAction, ContentActionVisibility {}
+
+export interface HandlerContentAction extends CommonContentAction {
+  handler: ContentActionHandler;
+  to?: never;
+}
+
+export interface NavigationContentAction extends CommonContentAction {
+  handler?: never;
+  to: RouteLocationRaw;
+}
+
+export type ContentAction = HandlerContentAction | NavigationContentAction;
 
 // Content action categories for organization
 export type ContentActionCategory =
@@ -50,9 +66,9 @@ export type ContentActionCategory =
   | "social"
   | "sharing";
 
-export interface CategorizedContentAction extends ContentAction {
+export type CategorizedContentAction = ContentAction & {
   category: ContentActionCategory;
-}
+};
 
 // Content action dialog state management
 export interface ContentActionDialogState {

--- a/services/agora/src/utils/actions/definitions/content-actions.ts
+++ b/services/agora/src/utils/actions/definitions/content-actions.ts
@@ -166,7 +166,7 @@ export function useContentActions() {
     const isOrgMember =
       conversationOrganizationName !== "" &&
       profileData.value.organizationList.some(
-        (org) => org.name === conversationOrganizationName,
+        (org) => org.name === conversationOrganizationName
       );
 
     const context = createActionContext({
@@ -296,7 +296,9 @@ export function useContentActions() {
     if (!actionContext) return;
 
     try {
-      await action.handler(actionContext);
+      if (action.handler !== undefined) {
+        await action.handler(actionContext);
+      }
 
       // Close dialog after successful action (except for certain actions that should keep it open)
       const keepOpenActions = ["moderationHistory", "embedLink"];

--- a/services/agora/src/utils/api/conversationUpdates/conversationEmailUpdates.ts
+++ b/services/agora/src/utils/api/conversationUpdates/conversationEmailUpdates.ts
@@ -15,6 +15,8 @@ import {
   type ConversationEmailUpdatePreferencesResponse,
   type ConversationEmailUpdatePreferenceUpdateRequest,
   type ConversationEmailUpdatePreferenceUpdateResponse,
+  type ConversationEmailUpdateProjectSummaryRequest,
+  type ConversationEmailUpdateProjectSummaryResponse,
   type ConversationEmailUpdateSendRequest,
   type ConversationEmailUpdateSendResponse,
   type ConversationEmailUpdateSendTestRequest,
@@ -179,6 +181,16 @@ export function useBackendConversationEmailUpdatesApi() {
     });
   }
 
+  function getProjectSummary(
+    request: ConversationEmailUpdateProjectSummaryRequest
+  ): Promise<ConversationEmailUpdateProjectSummaryResponse> {
+    return post({
+      url: "/api/v1/project/email-update/summary/get",
+      body: Dto.conversationEmailUpdateProjectSummaryRequest.parse(request),
+      responseSchema: Dto.conversationEmailUpdateProjectSummaryResponse,
+    });
+  }
+
   return {
     getWorkspace,
     listHistory,
@@ -192,5 +204,6 @@ export function useBackendConversationEmailUpdatesApi() {
     getConfiguration,
     updateConfiguration,
     getConversationSummary,
+    getProjectSummary,
   };
 }

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -46,12 +46,22 @@ At this stage, you should have a docker container running, have access to the th
 ## Running the api
 
 ```bash
-# development
+# Development with fail-closed Email Updates defaults
 pnpm start:dev
+
+# Normal repository development with Email Updates and its SNS simulator enabled
+make dev-api
 
 # production mode
 pnpm build && pnpm start
 ```
+
+`make dev-api` explicitly sets `NODE_ENV=development`, enables Conversation
+Email Updates, disables its kill switch, and enables the development-only SNS
+simulator. Direct API startup keeps the application defaults: Email Updates
+disabled, kill switch active, and simulator disabled. The API rejects simulator
+startup outside development, so production and staging must configure their
+delivery gates explicitly and cannot inherit the local simulator behavior.
 
 ## Moderation
 

--- a/services/api/openapi-zkorum.json
+++ b/services/api/openapi-zkorum.json
@@ -3944,21 +3944,55 @@
                                                                     "targetLanguageCodes"
                                                                 ],
                                                                 "additionalProperties": false
+                                                            },
+                                                            "emailUpdates": {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "canConfigure": {
+                                                                        "type": "boolean"
+                                                                    },
+                                                                    "scopeDefaultEnabled": {
+                                                                        "type": "boolean"
+                                                                    }
+                                                                },
+                                                                "required": [
+                                                                    "canConfigure",
+                                                                    "scopeDefaultEnabled"
+                                                                ],
+                                                                "additionalProperties": false
                                                             }
                                                         },
                                                         "required": [
                                                             "projectSlug",
                                                             "projectTitle",
                                                             "defaultLanguageCode",
-                                                            "languageSettings"
+                                                            "languageSettings",
+                                                            "emailUpdates"
                                                         ],
                                                         "additionalProperties": false
                                                     }
+                                                },
+                                                "noProjectEmailUpdates": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "canConfigure": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "scopeDefaultEnabled": {
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "canConfigure",
+                                                        "scopeDefaultEnabled"
+                                                    ],
+                                                    "additionalProperties": false
                                                 }
                                             },
                                             "required": [
                                                 "success",
-                                                "projectList"
+                                                "projectList",
+                                                "noProjectEmailUpdates"
                                             ],
                                             "additionalProperties": false
                                         },
@@ -17030,6 +17064,9 @@
                                                     "devconnect-2025"
                                                 ]
                                             },
+                                            "conversationEmailUpdateEnabledOverride": {
+                                                "type": "boolean"
+                                            },
                                             "conversationType": {
                                                 "type": "string",
                                                 "enum": [
@@ -17391,6 +17428,9 @@
                                                 "enum": [
                                                     "devconnect-2025"
                                                 ]
+                                            },
+                                            "conversationEmailUpdateEnabledOverride": {
+                                                "type": "boolean"
                                             },
                                             "conversationType": {
                                                 "type": "string",
@@ -20626,6 +20666,11 @@
                                                 },
                                                 "postAsOrganizationName": {
                                                     "type": "string"
+                                                },
+                                                "postAsOrganizationSlug": {
+                                                    "type": "string",
+                                                    "maxLength": 65,
+                                                    "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
                                                 },
                                                 "surveyConfig": {
                                                     "nullable": true,
@@ -38883,6 +38928,113 @@
                                                     "type": "string",
                                                     "enum": [
                                                         "conversation_not_found",
+                                                        "feature_not_available",
+                                                        "summary_unavailable"
+                                                    ]
+                                                }
+                                            },
+                                            "required": [
+                                                "success",
+                                                "reason"
+                                            ],
+                                            "additionalProperties": false
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/project/email-update/summary/get": {
+            "post": {
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "projectSlug": {
+                                        "type": "string",
+                                        "maxLength": 65,
+                                        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+                                    }
+                                },
+                                "required": [
+                                    "projectSlug"
+                                ],
+                                "additionalProperties": false
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Default Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "success": {
+                                                    "type": "boolean",
+                                                    "enum": [
+                                                        true
+                                                    ]
+                                                },
+                                                "authoringAction": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "none",
+                                                        "compose",
+                                                        "history"
+                                                    ]
+                                                },
+                                                "participantPreference": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "state": {
+                                                            "type": "string",
+                                                            "enum": [
+                                                                "disabled",
+                                                                "enabled",
+                                                                "undisclosed"
+                                                            ]
+                                                        },
+                                                        "resolvedEnabled": {
+                                                            "type": "boolean"
+                                                        }
+                                                    },
+                                                    "required": [
+                                                        "state",
+                                                        "resolvedEnabled"
+                                                    ],
+                                                    "additionalProperties": false
+                                                }
+                                            },
+                                            "required": [
+                                                "success",
+                                                "authoringAction"
+                                            ],
+                                            "additionalProperties": false
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "success": {
+                                                    "type": "boolean",
+                                                    "enum": [
+                                                        false
+                                                    ]
+                                                },
+                                                "reason": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "project_not_found",
                                                         "feature_not_available",
                                                         "summary_unavailable"
                                                     ]

--- a/services/api/src/index.ts
+++ b/services/api/src/index.ts
@@ -87,8 +87,10 @@ import { createExportWorker } from "@/service/conversationExport/core.js";
 import type { ValkeyRef } from "@/service/valkeyRef.js";
 import { validateS3Access } from "./service/s3.js";
 import {
+    canConfigureConversationEmailUpdatesForOrganization,
     getConversationCreateProjectOptions,
     getProjectLanguageSettings,
+    hasProjectParticipantContactEmail,
     resolveConversationCreateTargetResult,
 } from "@/service/projectAccess.js";
 import {
@@ -3886,6 +3888,35 @@ server.after(() => {
                 });
             }
             if (
+                createConversationRequest.conversationEmailUpdateEnabledOverride !==
+                undefined
+            ) {
+                const canConfigureEmailUpdates =
+                    await canConfigureConversationEmailUpdatesForOrganization({
+                        db,
+                        userId: deviceStatus.userId,
+                        organizationId:
+                            createTargetResult.target.organizationId,
+                        now: nowZeroMs(),
+                    });
+                if (!canConfigureEmailUpdates) {
+                    throw server.httpErrors.forbidden(
+                        "Missing conversation_email_update access",
+                    );
+                }
+                if (
+                    createConversationRequest.conversationEmailUpdateEnabledOverride &&
+                    !(await hasProjectParticipantContactEmail({
+                        db,
+                        projectId: createTargetResult.target.projectId,
+                    }))
+                ) {
+                    throw server.httpErrors.badRequest(
+                        "Email Updates require a participant contact email",
+                    );
+                }
+            }
+            if (
                 createConversationRequest.languageSettingsSource ===
                     "project_inherited" &&
                 createConversationRequest.projectSlug === undefined
@@ -6951,6 +6982,24 @@ server.after(() => {
         handler: async (request) => {
             const userId = await requireAuthenticatedUserId(request);
             return conversationEmailUpdateService.getConversationSummary({
+                userId,
+                request: request.body,
+            });
+        },
+    });
+
+    server.withTypeProvider<ZodTypeProvider>().route({
+        method: "POST",
+        url: `/api/${apiVersion}/project/email-update/summary/get`,
+        schema: {
+            body: Dto.conversationEmailUpdateProjectSummaryRequest,
+            response: {
+                200: Dto.conversationEmailUpdateProjectSummaryResponse,
+            },
+        },
+        handler: async (request) => {
+            const userId = await requireAuthenticatedUserId(request);
+            return conversationEmailUpdateService.getProjectSummary({
                 userId,
                 request: request.body,
             });

--- a/services/api/src/service/administrator/organizationCapability.test.ts
+++ b/services/api/src/service/administrator/organizationCapability.test.ts
@@ -2,6 +2,7 @@ import { drizzle, type PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { GenericContainer, type StartedTestContainer } from "testcontainers";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { canConfigureConversationEmailUpdatesForOrganization } from "../projectAccess.js";
 import {
     addUserOrganizationMapping,
     getOrganizationMembers,
@@ -78,6 +79,14 @@ describe("organization membership baseline capabilities", () => {
                     "organization_membership_id",
                     "capability"
                 ) WHERE "deleted_at" IS NULL;
+            CREATE TABLE "premium_feature_entitlement" (
+                "id" integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                "organization_id" integer NOT NULL,
+                "feature" text NOT NULL,
+                "starts_at" timestamp NOT NULL,
+                "expires_at" timestamp,
+                "revoked_at" timestamp
+            );
             INSERT INTO "user" ("id", "username")
             VALUES ('00000000-0000-4000-8000-000000000001', 'author');
             INSERT INTO "organization" ("id", "slug", "directory_visibility")
@@ -120,6 +129,31 @@ describe("organization membership baseline capabilities", () => {
                 AND "deleted_at" IS NULL
         `;
         expect(emailUpdateCapabilities).toHaveLength(1);
+        const now = new Date("2026-08-24T12:00:00.000Z");
+        await expect(
+            canConfigureConversationEmailUpdatesForOrganization({
+                db,
+                userId: "00000000-0000-4000-8000-000000000001",
+                organizationId: 1,
+                now,
+            }),
+        ).resolves.toBe(false);
+
+        await client`
+            INSERT INTO "premium_feature_entitlement" (
+                "organization_id",
+                "feature",
+                "starts_at"
+            ) VALUES (1, 'conversation_email_update', '2026-08-01T00:00:00.000Z')
+        `;
+        await expect(
+            canConfigureConversationEmailUpdatesForOrganization({
+                db,
+                userId: "00000000-0000-4000-8000-000000000001",
+                organizationId: 1,
+                now,
+            }),
+        ).resolves.toBe(true);
         await expect(
             getOrganizationMembers({
                 db,

--- a/services/api/src/service/conversationCreateDto.test.ts
+++ b/services/api/src/service/conversationCreateDto.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { Dto } from "@/shared/types/dto.js";
+
+function buildRequest(
+    conversationEmailUpdateEnabledOverride: boolean | undefined,
+) {
+    return {
+        conversationTitle: "Create-time Email Updates",
+        conversationBody: undefined,
+        projectSlug: undefined,
+        languageSettingsSource: "conversation_override",
+        postAsOrganization: "agora-foundation",
+        isIndexed: true,
+        participationMode: "account_required",
+        multilingualSetting: {
+            additionalLanguageCodes: [],
+            dynamicTranslationEnabled: false,
+        },
+        seedOpinionList: [],
+        requiresEventTicket: undefined,
+        conversationEmailUpdateEnabledOverride,
+        conversationType: "polis",
+        aiLabelingEnabled: true,
+        preferredOpinionGroupCount: null,
+        surveyConfig: undefined,
+    };
+}
+
+describe("conversation creation DTO", () => {
+    it.each([undefined, true, false])(
+        "preserves the Email Updates override %s",
+        (conversationEmailUpdateEnabledOverride) => {
+            const request = Dto.createNewConversationRequest.parse(
+                buildRequest(conversationEmailUpdateEnabledOverride),
+            );
+
+            expect(request.conversationEmailUpdateEnabledOverride).toBe(
+                conversationEmailUpdateEnabledOverride,
+            );
+        },
+    );
+
+    it("returns create-time settings for No Project and listed projects", () => {
+        const response = Dto.getConversationCreateProjectOptionsResponse.parse({
+            success: true,
+            noProjectEmailUpdates: {
+                canConfigure: true,
+                scopeDefaultEnabled: false,
+            },
+            projectList: [
+                {
+                    projectSlug: "public-plan",
+                    projectTitle: "Public Plan",
+                    defaultLanguageCode: "en",
+                    languageSettings: {
+                        dynamicTranslationEnabled: false,
+                        targetLanguageCodes: [],
+                    },
+                    emailUpdates: {
+                        canConfigure: true,
+                        scopeDefaultEnabled: true,
+                    },
+                },
+            ],
+        });
+
+        expect(response).toMatchObject({
+            success: true,
+            noProjectEmailUpdates: {
+                canConfigure: true,
+                scopeDefaultEnabled: false,
+            },
+            projectList: [
+                {
+                    emailUpdates: {
+                        canConfigure: true,
+                        scopeDefaultEnabled: true,
+                    },
+                },
+            ],
+        });
+    });
+});

--- a/services/api/src/service/conversationEmailUpdate.test.ts
+++ b/services/api/src/service/conversationEmailUpdate.test.ts
@@ -2,9 +2,36 @@ import { describe, expect, it } from "vitest";
 import {
     buildConversationEmailPreferenceGroups,
     resolveCompleteOwnerSnapshots,
+    resolveConversationEmailUpdateAuthoringAction,
     type RequiredOwnerSnapshot,
 } from "./conversationEmailUpdate.js";
 import { resolveConversationEmailPreference } from "./conversationEmailUpdatePolicy.js";
+
+describe("resolveConversationEmailUpdateAuthoringAction", () => {
+    it("keeps the workspace visible when sending is currently blocked", () => {
+        expect(
+            resolveConversationEmailUpdateAuthoringAction({
+                canAccessWorkspace: true,
+                hasHistory: false,
+            }),
+        ).toBe("compose");
+    });
+
+    it("falls back to history without current authoring access", () => {
+        expect(
+            resolveConversationEmailUpdateAuthoringAction({
+                canAccessWorkspace: false,
+                hasHistory: true,
+            }),
+        ).toBe("history");
+        expect(
+            resolveConversationEmailUpdateAuthoringAction({
+                canAccessWorkspace: false,
+                hasHistory: false,
+            }),
+        ).toBe("none");
+    });
+});
 
 describe("resolveConversationEmailPreference", () => {
     it("keeps lower-level choices intact while globally paused", () => {

--- a/services/api/src/service/conversationEmailUpdate.ts
+++ b/services/api/src/service/conversationEmailUpdate.ts
@@ -69,6 +69,8 @@ import type {
     ConversationEmailUpdatePreferenceUpdateResponse,
     ConversationEmailUpdatePreferencesRequest,
     ConversationEmailUpdatePreferencesResponse,
+    ConversationEmailUpdateProjectSummaryRequest,
+    ConversationEmailUpdateProjectSummaryResponse,
     ConversationEmailUpdateScope,
     ConversationEmailUpdateSelection,
     ConversationEmailUpdateSendRequest,
@@ -90,6 +92,19 @@ import {
 import { normalizeUserRichTextInput } from "./richText.js";
 
 const NO_PROJECT_TITLE = "No Project";
+
+export function resolveConversationEmailUpdateAuthoringAction({
+    canAccessWorkspace,
+    hasHistory,
+}: {
+    canAccessWorkspace: boolean;
+    hasHistory: boolean;
+}): "none" | "compose" | "history" {
+    if (canAccessWorkspace) {
+        return "compose";
+    }
+    return hasHistory ? "history" : "none";
+}
 
 interface AuthenticatedRequest<Request> {
     userId: string;
@@ -133,6 +148,9 @@ export interface ConversationEmailUpdateService {
     getConversationSummary: (
         params: AuthenticatedRequest<ConversationEmailUpdateConversationSummaryRequest>,
     ) => Promise<ConversationEmailUpdateConversationSummaryResponse>;
+    getProjectSummary: (
+        params: AuthenticatedRequest<ConversationEmailUpdateProjectSummaryRequest>,
+    ) => Promise<ConversationEmailUpdateProjectSummaryResponse>;
 }
 
 type AuthorizedConversationDao = Awaited<
@@ -352,10 +370,12 @@ async function listAuthorizedConversations({
     db,
     userId,
     now,
+    projectId,
 }: {
     db: PostgresJsDatabase;
     userId: string;
     now: Date;
+    projectId?: number;
 }) {
     const authorizedProject = db
         .selectDistinctOn([projectTable.id], {
@@ -437,7 +457,14 @@ async function listAuthorizedConversations({
                 ),
             ),
         )
-        .where(isNull(projectTable.deletedAt))
+        .where(
+            and(
+                isNull(projectTable.deletedAt),
+                projectId === undefined
+                    ? undefined
+                    : eq(projectTable.id, projectId),
+            ),
+        )
         .orderBy(
             projectTable.id,
             projectOrganizationOwnershipTable.organizationId,
@@ -1645,6 +1672,34 @@ async function queryVisibleHistoryRows({
         .limit(limit);
 }
 
+async function hasVisibleHistory({
+    db,
+    userId,
+    context,
+}: {
+    db: PostgresJsDatabase;
+    userId: string;
+    context: HistoryContext;
+}): Promise<boolean> {
+    const rows = await db
+        .select({ id: conversationEmailUpdateDeliveryTable.id })
+        .from(conversationEmailUpdateDeliveryTable)
+        .innerJoin(
+            conversationEmailUpdateTable,
+            eq(
+                conversationEmailUpdateTable.id,
+                conversationEmailUpdateDeliveryTable.updateId,
+            ),
+        )
+        .innerJoin(
+            projectTable,
+            eq(projectTable.id, conversationEmailUpdateDeliveryTable.projectId),
+        )
+        .where(historyAccessPredicate({ db, userId, context }))
+        .limit(1);
+    return rows.length > 0;
+}
+
 function getPreferenceScopeKind({
     autoProvisionedForOrganizationId,
     directoryVisibility,
@@ -2027,6 +2082,9 @@ async function queryProjectConfigurationRows({
         .select({
             project_id: projectTable.id,
             project_slug: projectTable.slug,
+            directory_visibility: projectTable.directoryVisibility,
+            auto_provisioned_for_organization_id:
+                projectTable.autoProvisionedForOrganizationId,
             default_enabled: projectTable.conversationEmailUpdateDefaultEnabled,
             contact_email: projectContactTable.email,
             safety_blocked: exists(
@@ -2347,33 +2405,30 @@ async function getConversationConfigurationRow({
     return rows.at(0);
 }
 
-async function isSiteOrgAdmin({
-    db,
-    userId,
-}: {
-    db: PostgresJsDatabase;
-    userId: string;
-}): Promise<boolean> {
-    const rows = await db
-        .select({ allowed: userTable.isSiteOrgAdmin })
-        .from(userTable)
-        .where(and(eq(userTable.id, userId), eq(userTable.isDeleted, false)))
-        .limit(1);
-    return rows.at(0)?.allowed ?? false;
-}
-
-async function hasConversationEditCapability({
+async function hasConversationEmailUpdateCapability({
     db,
     userId,
     projectId,
+    now,
 }: {
     db: PostgresJsDatabase;
     userId: string;
     projectId: number;
+    now: Date;
 }): Promise<boolean> {
     const rows = await db
         .select({ id: projectOrganizationOwnershipTable.id })
         .from(projectOrganizationOwnershipTable)
+        .innerJoin(
+            organizationTable,
+            and(
+                eq(
+                    organizationTable.id,
+                    projectOrganizationOwnershipTable.organizationId,
+                ),
+                isNull(organizationTable.deletedAt),
+            ),
+        )
         .innerJoin(
             organizationMembershipTable,
             and(
@@ -2386,6 +2441,13 @@ async function hasConversationEditCapability({
             ),
         )
         .innerJoin(
+            userTable,
+            and(
+                eq(userTable.id, organizationMembershipTable.userId),
+                eq(userTable.isDeleted, false),
+            ),
+        )
+        .innerJoin(
             organizationMembershipAllProjectCapabilityTable,
             and(
                 eq(
@@ -2394,10 +2456,29 @@ async function hasConversationEditCapability({
                 ),
                 eq(
                     organizationMembershipAllProjectCapabilityTable.capability,
-                    "conversation_edit",
+                    "conversation_email_update",
                 ),
                 isNull(
                     organizationMembershipAllProjectCapabilityTable.deletedAt,
+                ),
+            ),
+        )
+        .innerJoin(
+            premiumFeatureEntitlementTable,
+            and(
+                eq(
+                    premiumFeatureEntitlementTable.organizationId,
+                    projectOrganizationOwnershipTable.organizationId,
+                ),
+                eq(
+                    premiumFeatureEntitlementTable.feature,
+                    "conversation_email_update",
+                ),
+                lte(premiumFeatureEntitlementTable.startsAt, now),
+                isNull(premiumFeatureEntitlementTable.revokedAt),
+                or(
+                    isNull(premiumFeatureEntitlementTable.expiresAt),
+                    gt(premiumFeatureEntitlementTable.expiresAt, now),
                 ),
             ),
         )
@@ -2666,20 +2747,25 @@ export function createConversationEmailUpdateService({
         try {
             const now = new Date();
             if (request.target === "project") {
-                const [row, canConfigure] = await Promise.all([
-                    getProjectConfigurationRow({
-                        db: database,
-                        projectSlug: request.projectSlug,
-                        now,
-                    }),
-                    isSiteOrgAdmin({ db: database, userId }),
-                ]);
+                const row = await getProjectConfigurationRow({
+                    db: database,
+                    projectSlug: request.projectSlug,
+                    now,
+                });
                 if (row === undefined) {
                     return { success: false, reason: "target_not_found" };
                 }
                 if (!row.feature_available) {
                     return { success: false, reason: "feature_not_available" };
                 }
+                const canConfigure = await hasConversationEmailUpdateCapability(
+                    {
+                        db: database,
+                        userId,
+                        projectId: row.project_id,
+                        now,
+                    },
+                );
                 return {
                     success: true,
                     configuration: {
@@ -2704,10 +2790,11 @@ export function createConversationEmailUpdateService({
             if (!row.feature_available) {
                 return { success: false, reason: "feature_not_available" };
             }
-            const canConfigure = await hasConversationEditCapability({
+            const canConfigure = await hasConversationEmailUpdateCapability({
                 db: database,
                 userId,
                 projectId: row.project_id,
+                now,
             });
             return mapConfiguration({
                 row,
@@ -3939,10 +4026,13 @@ export function createConversationEmailUpdateService({
                                 reason: "target_not_found",
                             };
                         }
-                        const allowed = await isSiteOrgAdmin({
-                            db: tx,
-                            userId,
-                        });
+                        const allowed =
+                            await hasConversationEmailUpdateCapability({
+                                db: tx,
+                                userId,
+                                projectId: row.project_id,
+                                now,
+                            });
                         if (!row.feature_available || !allowed) {
                             return {
                                 success: false,
@@ -4010,11 +4100,13 @@ export function createConversationEmailUpdateService({
                                 reason: "target_not_found",
                             };
                         }
-                        const allowed = await hasConversationEditCapability({
-                            db: tx,
-                            userId,
-                            projectId: row.project_id,
-                        });
+                        const allowed =
+                            await hasConversationEmailUpdateCapability({
+                                db: tx,
+                                userId,
+                                projectId: row.project_id,
+                                now,
+                            });
                         if (!row.feature_available || !allowed) {
                             return {
                                 success: false,
@@ -4109,13 +4201,8 @@ export function createConversationEmailUpdateService({
                             now,
                         }),
                     ]);
-                const canCompose = accessRows.some(
-                    (access) =>
-                        access.conversation_id === row.conversation_id &&
-                        isSendingEnabled({
-                            row: access,
-                            operationallyEnabled: sendingEnabled,
-                        }),
+                const canAccessWorkspace = accessRows.some(
+                    (access) => access.conversation_id === row.conversation_id,
                 );
                 const conversationPreference =
                     preferenceRows.conversationRows.find(
@@ -4144,11 +4231,11 @@ export function createConversationEmailUpdateService({
                     });
                 return {
                     success: true,
-                    authoringAction: canCompose
-                        ? "compose"
-                        : row.has_history
-                          ? "history"
-                          : "none",
+                    authoringAction:
+                        resolveConversationEmailUpdateAuthoringAction({
+                            canAccessWorkspace,
+                            hasHistory: row.has_history,
+                        }),
                     participantPreference:
                         primaryEmail === undefined
                             ? undefined
@@ -4180,6 +4267,122 @@ export function createConversationEmailUpdateService({
                                                         conversationSlugId:
                                                             row.conversation_slug_id,
                                                     },
+                                      }),
+                              },
+                };
+            } catch {
+                return { success: false, reason: "summary_unavailable" };
+            }
+        },
+
+        getProjectSummary: async ({ userId, request }) => {
+            try {
+                const now = new Date();
+                const configuration = await getProjectConfigurationRow({
+                    db,
+                    projectSlug: request.projectSlug,
+                    now,
+                });
+                if (
+                    configuration?.directory_visibility !== "listed" ||
+                    configuration.auto_provisioned_for_organization_id !== null
+                ) {
+                    return { success: false, reason: "project_not_found" };
+                }
+
+                const [
+                    accessRows,
+                    hasHistory,
+                    primaryEmail,
+                    globalPreferenceRows,
+                    projectPreferenceRows,
+                ] = await Promise.all([
+                    listAuthorizedConversations({
+                        db,
+                        userId,
+                        now,
+                        projectId: configuration.project_id,
+                    }),
+                    hasVisibleHistory({
+                        db,
+                        userId,
+                        context: {
+                            kind: "project",
+                            projectSlug: request.projectSlug,
+                        },
+                    }),
+                    getPrimaryEmail({ db, userId }),
+                    db
+                        .select({
+                            pausedAt:
+                                conversationEmailUpdateUserGlobalSettingTable.pausedAt,
+                        })
+                        .from(conversationEmailUpdateUserGlobalSettingTable)
+                        .where(
+                            eq(
+                                conversationEmailUpdateUserGlobalSettingTable.userId,
+                                userId,
+                            ),
+                        )
+                        .limit(1),
+                    db
+                        .select({
+                            enabled:
+                                conversationEmailUpdateUserProjectPreferenceTable.enabled,
+                        })
+                        .from(conversationEmailUpdateUserProjectPreferenceTable)
+                        .where(
+                            and(
+                                eq(
+                                    conversationEmailUpdateUserProjectPreferenceTable.userId,
+                                    userId,
+                                ),
+                                eq(
+                                    conversationEmailUpdateUserProjectPreferenceTable.projectId,
+                                    configuration.project_id,
+                                ),
+                            ),
+                        )
+                        .limit(1),
+                ]);
+                const canAccessWorkspace = accessRows.length > 0;
+                if (!configuration.feature_available && !hasHistory) {
+                    return {
+                        success: false,
+                        reason: "feature_not_available",
+                    };
+                }
+
+                const projectPreference = projectPreferenceRows.at(0)?.enabled;
+                const globalPaused =
+                    globalPreferenceRows.length > 0 &&
+                    globalPreferenceRows.at(0)?.pausedAt !== null;
+                const state =
+                    projectPreference === undefined
+                        ? "undisclosed"
+                        : projectPreference
+                          ? "enabled"
+                          : "disabled";
+                return {
+                    success: true,
+                    authoringAction:
+                        resolveConversationEmailUpdateAuthoringAction({
+                            canAccessWorkspace,
+                            hasHistory,
+                        }),
+                    participantPreference:
+                        primaryEmail === undefined ||
+                        !configuration.feature_available ||
+                        configuration.safety_blocked
+                            ? undefined
+                            : {
+                                  state,
+                                  resolvedEnabled:
+                                      resolveConversationEmailPreference({
+                                          globalPaused,
+                                          projectEnabled: projectPreference,
+                                          conversationEnabled: undefined,
+                                          scopeKind: "project",
                                       }),
                               },
                 };

--- a/services/api/src/service/post.ts
+++ b/services/api/src/service/post.ts
@@ -331,6 +331,8 @@ export async function createNewPost({
                 isImporting: isImporting,
                 languageSettingsSource,
                 requiresEventTicket: requiresEventTicket,
+                conversationEmailUpdateEnabledOverride:
+                    request.conversationEmailUpdateEnabledOverride,
                 currentContentId: null,
                 createdAt: now,
                 updatedAt: now,

--- a/services/api/src/service/postEdit.ts
+++ b/services/api/src/service/postEdit.ts
@@ -120,6 +120,7 @@ export async function getConversationForEdit({
             preferredOpinionGroupCount:
                 polisConversationConfigTable.preferredOpinionGroupCount,
             postAsOrganizationName: organizationTable.displayName,
+            postAsOrganizationSlug: organizationTable.slug,
             autoProvisionedForUserId:
                 organizationTable.autoProvisionedForUserId,
             createdAt: conversationTable.createdAt,
@@ -308,6 +309,11 @@ export async function getConversationForEdit({
         postAsOrganizationName: toUnionUndefined(
             conversation.autoProvisionedForUserId === null
                 ? conversation.postAsOrganizationName
+                : null,
+        ),
+        postAsOrganizationSlug: toUnionUndefined(
+            conversation.autoProvisionedForUserId === null
+                ? conversation.postAsOrganizationSlug
                 : null,
         ),
         surveyConfig,

--- a/services/api/src/service/projectAccess.ts
+++ b/services/api/src/service/projectAccess.ts
@@ -10,6 +10,7 @@ import {
     organizationMembershipTable,
     organizationTable,
     premiumFeatureEntitlementTable,
+    projectContactTable,
     projectContentTable,
     projectOrganizationOwnershipTable,
     projectTable,
@@ -539,7 +540,14 @@ export async function getConversationCreateProjectOptions({
     postAsOrganizationSlug: string | undefined;
 }): Promise<GetConversationCreateProjectOptionsResponse> {
     if (postAsOrganizationSlug === undefined || postAsOrganizationSlug === "") {
-        return { success: true, projectList: [] };
+        return {
+            success: true,
+            projectList: [],
+            noProjectEmailUpdates: {
+                canConfigure: false,
+                scopeDefaultEnabled: false,
+            },
+        };
     }
 
     const organizationRows = await db
@@ -566,52 +574,98 @@ export async function getConversationCreateProjectOptions({
         return { success: false, reason: "organization_not_available" };
     }
 
-    const projectIdsWithCreate = new Set(
-        await getProjectIdsWithCapability({
+    const [
+        projectIdsWithCreateRows,
+        canConfigureEmailUpdates,
+        projectRows,
+        noProjectRows,
+    ] = await Promise.all([
+        getProjectIdsWithCapability({
             db,
             userId,
             capability: "conversation_create",
         }),
-    );
-
-    const projectRows = await db
-        .select({
-            projectId: projectTable.id,
-            projectSlug: projectTable.slug,
-            projectTitle: projectTable.title,
-            sourceLanguageCode: projectContentTable.sourceLanguageCode,
-            dynamicTranslationEnabled: projectTable.dynamicTranslationEnabled,
-        })
-        .from(projectTable)
-        .innerJoin(
-            projectOrganizationOwnershipTable,
-            and(
-                eq(
-                    projectOrganizationOwnershipTable.projectId,
-                    projectTable.id,
+        canConfigureConversationEmailUpdatesForOrganization({
+            db,
+            userId,
+            organizationId: organization.organizationId,
+            now: new Date(),
+        }),
+        db
+            .select({
+                projectId: projectTable.id,
+                projectSlug: projectTable.slug,
+                projectTitle: projectTable.title,
+                sourceLanguageCode: projectContentTable.sourceLanguageCode,
+                dynamicTranslationEnabled:
+                    projectTable.dynamicTranslationEnabled,
+                conversationEmailUpdateDefaultEnabled:
+                    projectTable.conversationEmailUpdateDefaultEnabled,
+                participantContactEmail: projectContactTable.email,
+            })
+            .from(projectTable)
+            .innerJoin(
+                projectOrganizationOwnershipTable,
+                and(
+                    eq(
+                        projectOrganizationOwnershipTable.projectId,
+                        projectTable.id,
+                    ),
+                    isNull(projectOrganizationOwnershipTable.deletedAt),
                 ),
-                isNull(projectOrganizationOwnershipTable.deletedAt),
+            )
+            .innerJoin(
+                organizationTable,
+                eq(
+                    organizationTable.id,
+                    projectOrganizationOwnershipTable.organizationId,
+                ),
+            )
+            .leftJoin(
+                projectContentTable,
+                eq(projectContentTable.id, projectTable.currentContentId),
+            )
+            .leftJoin(
+                projectContactTable,
+                and(
+                    eq(projectContactTable.projectId, projectTable.id),
+                    isNull(projectContactTable.deletedAt),
+                ),
+            )
+            .where(
+                and(
+                    eq(organizationTable.id, organization.organizationId),
+                    isNull(organizationTable.deletedAt),
+                    eq(projectTable.directoryVisibility, "listed"),
+                    isNull(projectTable.deletedAt),
+                ),
             ),
-        )
-        .innerJoin(
-            organizationTable,
-            eq(
-                organizationTable.id,
-                projectOrganizationOwnershipTable.organizationId,
-            ),
-        )
-        .leftJoin(
-            projectContentTable,
-            eq(projectContentTable.id, projectTable.currentContentId),
-        )
-        .where(
-            and(
-                eq(organizationTable.id, organization.organizationId),
-                isNull(organizationTable.deletedAt),
-                eq(projectTable.directoryVisibility, "listed"),
-                isNull(projectTable.deletedAt),
-            ),
-        );
+        db
+            .select({
+                conversationEmailUpdateDefaultEnabled:
+                    projectTable.conversationEmailUpdateDefaultEnabled,
+                participantContactEmail: projectContactTable.email,
+            })
+            .from(projectTable)
+            .leftJoin(
+                projectContactTable,
+                and(
+                    eq(projectContactTable.projectId, projectTable.id),
+                    isNull(projectContactTable.deletedAt),
+                ),
+            )
+            .where(
+                and(
+                    eq(
+                        projectTable.autoProvisionedForOrganizationId,
+                        organization.organizationId,
+                    ),
+                    isNull(projectTable.deletedAt),
+                ),
+            )
+            .limit(1),
+    ]);
+    const projectIdsWithCreate = new Set(projectIdsWithCreateRows);
 
     const availableProjectRows = projectRows.filter((project) =>
         projectIdsWithCreate.has(project.projectId),
@@ -661,6 +715,15 @@ export async function getConversationCreateProjectOptions({
 
     return {
         success: true,
+        noProjectEmailUpdates: {
+            canConfigure:
+                canConfigureEmailUpdates &&
+                noProjectRows.at(0)?.participantContactEmail !== undefined &&
+                noProjectRows.at(0)?.participantContactEmail !== null,
+            scopeDefaultEnabled:
+                noProjectRows.at(0)?.conversationEmailUpdateDefaultEnabled ??
+                false,
+        },
         projectList: availableProjectRows.map((project) => ({
             projectSlug: project.projectSlug,
             projectTitle: project.projectTitle,
@@ -673,8 +736,113 @@ export async function getConversationCreateProjectOptions({
                 targetLanguageCodes:
                     targetLanguageCodesByProjectId.get(project.projectId) ?? [],
             },
+            emailUpdates: {
+                canConfigure:
+                    canConfigureEmailUpdates &&
+                    project.participantContactEmail !== null,
+                scopeDefaultEnabled:
+                    project.conversationEmailUpdateDefaultEnabled,
+            },
         })),
     };
+}
+
+export async function canConfigureConversationEmailUpdatesForOrganization({
+    db,
+    userId,
+    organizationId,
+    now,
+}: {
+    db: PostgresDatabase;
+    userId: string;
+    organizationId: number;
+    now: Date;
+}): Promise<boolean> {
+    const rows = await db
+        .select({ entitlementId: premiumFeatureEntitlementTable.id })
+        .from(organizationMembershipTable)
+        .innerJoin(
+            organizationTable,
+            and(
+                eq(
+                    organizationTable.id,
+                    organizationMembershipTable.organizationId,
+                ),
+                isNull(organizationTable.deletedAt),
+            ),
+        )
+        .innerJoin(
+            userTable,
+            and(
+                eq(userTable.id, organizationMembershipTable.userId),
+                eq(userTable.isDeleted, false),
+            ),
+        )
+        .innerJoin(
+            organizationMembershipAllProjectCapabilityTable,
+            and(
+                eq(
+                    organizationMembershipAllProjectCapabilityTable.organizationMembershipId,
+                    organizationMembershipTable.id,
+                ),
+                eq(
+                    organizationMembershipAllProjectCapabilityTable.capability,
+                    "conversation_email_update",
+                ),
+                isNull(
+                    organizationMembershipAllProjectCapabilityTable.deletedAt,
+                ),
+            ),
+        )
+        .innerJoin(
+            premiumFeatureEntitlementTable,
+            and(
+                eq(
+                    premiumFeatureEntitlementTable.organizationId,
+                    organizationMembershipTable.organizationId,
+                ),
+                eq(
+                    premiumFeatureEntitlementTable.feature,
+                    "conversation_email_update",
+                ),
+                lte(premiumFeatureEntitlementTable.startsAt, now),
+                isNull(premiumFeatureEntitlementTable.revokedAt),
+                or(
+                    isNull(premiumFeatureEntitlementTable.expiresAt),
+                    gt(premiumFeatureEntitlementTable.expiresAt, now),
+                ),
+            ),
+        )
+        .where(
+            and(
+                eq(organizationMembershipTable.userId, userId),
+                eq(organizationMembershipTable.organizationId, organizationId),
+                isNull(organizationMembershipTable.deletedAt),
+            ),
+        )
+        .limit(1);
+
+    return rows.length === 1;
+}
+
+export async function hasProjectParticipantContactEmail({
+    db,
+    projectId,
+}: {
+    db: PostgresDatabase;
+    projectId: number;
+}): Promise<boolean> {
+    const rows = await db
+        .select({ id: projectContactTable.id })
+        .from(projectContactTable)
+        .where(
+            and(
+                eq(projectContactTable.projectId, projectId),
+                isNull(projectContactTable.deletedAt),
+            ),
+        )
+        .limit(1);
+    return rows.length === 1;
 }
 
 export async function getProjectLanguageSettings({

--- a/services/api/src/shared/types/dto.ts
+++ b/services/api/src/shared/types/dto.ts
@@ -402,6 +402,12 @@ const zodConversationLanguageSettingsSource = z.enum([
     "conversation_override",
     "project_inherited",
 ]);
+const zodConversationCreateEmailUpdateConfiguration = z
+    .object({
+        canConfigure: z.boolean(),
+        scopeDefaultEnabled: z.boolean(),
+    })
+    .strict();
 const zodConversationCreateProjectOption = z
     .object({
         projectSlug: zodProjectSlug,
@@ -410,6 +416,12 @@ const zodConversationCreateProjectOption = z
         languageSettings: zodProjectLanguageSettings,
     })
     .strict();
+const zodConversationCreateProjectOptionWithEmailUpdates =
+    zodConversationCreateProjectOption
+        .extend({
+            emailUpdates: zodConversationCreateEmailUpdateConfiguration,
+        })
+        .strict();
 const zodProjectContentLocalizationInput = z
     .object({
         languageCode: ZodSupportedDisplayLanguageCodes,
@@ -1237,6 +1249,7 @@ export class Dto {
             multilingualSetting: zodConversationMultilingualSetting,
             seedOpinionList: z.array(zodOpinionContentInput).max(50),
             requiresEventTicket: zodEventSlug.optional(),
+            conversationEmailUpdateEnabledOverride: z.boolean().optional(),
         })
         .strict();
     static createNewConversationRequest = z.discriminatedUnion(
@@ -1554,6 +1567,7 @@ export class Dto {
                 aiLabelingEnabled: z.boolean(),
                 preferredOpinionGroupCount: zodPreferredOpinionGroupCount,
                 postAsOrganizationName: z.string().optional(),
+                postAsOrganizationSlug: zodOrganizationSlug.optional(),
                 surveyConfig: zodSurveyConfig.nullable().optional(),
                 createdAt: zodDateTimeFlexible,
                 updatedAt: zodDateTimeFlexible,
@@ -2337,14 +2351,19 @@ export class Dto {
             ),
         })
         .strict();
-    static conversationCreateProjectOption = zodConversationCreateProjectOption;
+    static conversationCreateProjectOption =
+        zodConversationCreateProjectOptionWithEmailUpdates;
     static getConversationCreateProjectOptionsResponse = z.discriminatedUnion(
         "success",
         [
             z
                 .object({
                     success: z.literal(true),
-                    projectList: z.array(Dto.conversationCreateProjectOption),
+                    projectList: z.array(
+                        zodConversationCreateProjectOptionWithEmailUpdates,
+                    ),
+                    noProjectEmailUpdates:
+                        zodConversationCreateEmailUpdateConfiguration,
                 })
                 .strict(),
             z
@@ -3476,6 +3495,39 @@ export class Dto {
                 })
                 .strict(),
         ]);
+    static conversationEmailUpdateProjectSummaryRequest = z
+        .object({
+            projectSlug: zodProjectSlug,
+        })
+        .strict();
+    static conversationEmailUpdateProjectSummaryResponse = z.discriminatedUnion(
+        "success",
+        [
+            z
+                .object({
+                    success: z.literal(true),
+                    authoringAction: z.enum(["none", "compose", "history"]),
+                    participantPreference: z
+                        .object({
+                            state: zodConversationEmailUpdatePreferenceState,
+                            resolvedEnabled: z.boolean(),
+                        })
+                        .strict()
+                        .optional(),
+                })
+                .strict(),
+            z
+                .object({
+                    success: z.literal(false),
+                    reason: z.enum([
+                        "project_not_found",
+                        "feature_not_available",
+                        "summary_unavailable",
+                    ]),
+                })
+                .strict(),
+        ],
+    );
     static conversationEmailUpdateActionResolveRequest = z
         .object({ token: zodConversationEmailUpdateActionToken })
         .strict();
@@ -4124,6 +4176,12 @@ export type ConversationEmailUpdateConversationSummaryRequest = z.infer<
 >;
 export type ConversationEmailUpdateConversationSummaryResponse = z.infer<
     typeof Dto.conversationEmailUpdateConversationSummaryResponse
+>;
+export type ConversationEmailUpdateProjectSummaryRequest = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryRequest
+>;
+export type ConversationEmailUpdateProjectSummaryResponse = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryResponse
 >;
 export type ConversationEmailUpdateSnsSimulatorRequest = z.infer<
     typeof Dto.conversationEmailUpdateSnsSimulatorRequest

--- a/services/conversation-email-update-worker/src/shared/types/dto.ts
+++ b/services/conversation-email-update-worker/src/shared/types/dto.ts
@@ -402,6 +402,12 @@ const zodConversationLanguageSettingsSource = z.enum([
     "conversation_override",
     "project_inherited",
 ]);
+const zodConversationCreateEmailUpdateConfiguration = z
+    .object({
+        canConfigure: z.boolean(),
+        scopeDefaultEnabled: z.boolean(),
+    })
+    .strict();
 const zodConversationCreateProjectOption = z
     .object({
         projectSlug: zodProjectSlug,
@@ -410,6 +416,12 @@ const zodConversationCreateProjectOption = z
         languageSettings: zodProjectLanguageSettings,
     })
     .strict();
+const zodConversationCreateProjectOptionWithEmailUpdates =
+    zodConversationCreateProjectOption
+        .extend({
+            emailUpdates: zodConversationCreateEmailUpdateConfiguration,
+        })
+        .strict();
 const zodProjectContentLocalizationInput = z
     .object({
         languageCode: ZodSupportedDisplayLanguageCodes,
@@ -1237,6 +1249,7 @@ export class Dto {
             multilingualSetting: zodConversationMultilingualSetting,
             seedOpinionList: z.array(zodOpinionContentInput).max(50),
             requiresEventTicket: zodEventSlug.optional(),
+            conversationEmailUpdateEnabledOverride: z.boolean().optional(),
         })
         .strict();
     static createNewConversationRequest = z.discriminatedUnion(
@@ -1554,6 +1567,7 @@ export class Dto {
                 aiLabelingEnabled: z.boolean(),
                 preferredOpinionGroupCount: zodPreferredOpinionGroupCount,
                 postAsOrganizationName: z.string().optional(),
+                postAsOrganizationSlug: zodOrganizationSlug.optional(),
                 surveyConfig: zodSurveyConfig.nullable().optional(),
                 createdAt: zodDateTimeFlexible,
                 updatedAt: zodDateTimeFlexible,
@@ -2337,14 +2351,19 @@ export class Dto {
             ),
         })
         .strict();
-    static conversationCreateProjectOption = zodConversationCreateProjectOption;
+    static conversationCreateProjectOption =
+        zodConversationCreateProjectOptionWithEmailUpdates;
     static getConversationCreateProjectOptionsResponse = z.discriminatedUnion(
         "success",
         [
             z
                 .object({
                     success: z.literal(true),
-                    projectList: z.array(Dto.conversationCreateProjectOption),
+                    projectList: z.array(
+                        zodConversationCreateProjectOptionWithEmailUpdates,
+                    ),
+                    noProjectEmailUpdates:
+                        zodConversationCreateEmailUpdateConfiguration,
                 })
                 .strict(),
             z
@@ -3476,6 +3495,39 @@ export class Dto {
                 })
                 .strict(),
         ]);
+    static conversationEmailUpdateProjectSummaryRequest = z
+        .object({
+            projectSlug: zodProjectSlug,
+        })
+        .strict();
+    static conversationEmailUpdateProjectSummaryResponse = z.discriminatedUnion(
+        "success",
+        [
+            z
+                .object({
+                    success: z.literal(true),
+                    authoringAction: z.enum(["none", "compose", "history"]),
+                    participantPreference: z
+                        .object({
+                            state: zodConversationEmailUpdatePreferenceState,
+                            resolvedEnabled: z.boolean(),
+                        })
+                        .strict()
+                        .optional(),
+                })
+                .strict(),
+            z
+                .object({
+                    success: z.literal(false),
+                    reason: z.enum([
+                        "project_not_found",
+                        "feature_not_available",
+                        "summary_unavailable",
+                    ]),
+                })
+                .strict(),
+        ],
+    );
     static conversationEmailUpdateActionResolveRequest = z
         .object({ token: zodConversationEmailUpdateActionToken })
         .strict();
@@ -4124,6 +4176,12 @@ export type ConversationEmailUpdateConversationSummaryRequest = z.infer<
 >;
 export type ConversationEmailUpdateConversationSummaryResponse = z.infer<
     typeof Dto.conversationEmailUpdateConversationSummaryResponse
+>;
+export type ConversationEmailUpdateProjectSummaryRequest = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryRequest
+>;
+export type ConversationEmailUpdateProjectSummaryResponse = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryResponse
 >;
 export type ConversationEmailUpdateSnsSimulatorRequest = z.infer<
     typeof Dto.conversationEmailUpdateSnsSimulatorRequest

--- a/services/load-testing/src/api/api.ts
+++ b/services/load-testing/src/api/api.ts
@@ -2661,6 +2661,7 @@ export interface ApiV1ConversationCreatePostRequestOneOf {
     'multilingualSetting': ApiV1ConversationCreatePostRequestOneOfMultilingualSetting;
     'seedOpinionList': Array<string>;
     'requiresEventTicket'?: ApiV1ConversationCreatePostRequestOneOfRequiresEventTicketEnum;
+    'conversationEmailUpdateEnabledOverride'?: boolean;
     'conversationType': ApiV1ConversationCreatePostRequestOneOfConversationTypeEnum;
     'aiLabelingEnabled'?: boolean;
     'preferredOpinionGroupCount'?: number | null;
@@ -2703,6 +2704,7 @@ export interface ApiV1ConversationCreatePostRequestOneOf1 {
     'multilingualSetting': ApiV1ConversationCreatePostRequestOneOfMultilingualSetting;
     'seedOpinionList': Array<string>;
     'requiresEventTicket'?: ApiV1ConversationCreatePostRequestOneOf1RequiresEventTicketEnum;
+    'conversationEmailUpdateEnabledOverride'?: boolean;
     'conversationType': ApiV1ConversationCreatePostRequestOneOf1ConversationTypeEnum;
     'rankingMode': ApiV1ConversationCreatePostRequestOneOf1RankingModeEnum;
     'externalSourceConfig'?: ApiV1ConversationCreatePostRequestOneOf1ExternalSourceConfig | null;
@@ -5059,13 +5061,14 @@ export interface ApiV1ConversationGetForEditPost200ResponseOneOf {
     'languageSetting': ApiV1ConversationFetchRecentPost200ResponseFeedItemListInnerConversationDataMetadataOneOfLanguageSetting;
     'multilingualSetting': ApiV1ConversationCreatePostRequestOneOfMultilingualSetting;
     'languageSettingsSource': ApiV1ConversationGetForEditPost200ResponseOneOfLanguageSettingsSourceEnum;
-    'projectLanguageProject'?: ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInner;
+    'projectLanguageProject'?: ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProject;
     'isIndexed': boolean;
     'participationMode': ApiV1ConversationGetForEditPost200ResponseOneOfParticipationModeEnum;
     'requiresEventTicket'?: ApiV1ConversationGetForEditPost200ResponseOneOfRequiresEventTicketEnum;
     'aiLabelingEnabled': boolean;
     'preferredOpinionGroupCount': number | null;
     'postAsOrganizationName'?: string;
+    'postAsOrganizationSlug'?: string;
     'surveyConfig'?: ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig | null;
     'createdAt': string;
     'updatedAt': string;
@@ -5159,6 +5162,29 @@ export const ApiV1ConversationGetForEditPost200ResponseOneOfEditPermissionsRestr
 } as const;
 
 export type ApiV1ConversationGetForEditPost200ResponseOneOfEditPermissionsRestrictedPremiumFeaturesEnum = typeof ApiV1ConversationGetForEditPost200ResponseOneOfEditPermissionsRestrictedPremiumFeaturesEnum[keyof typeof ApiV1ConversationGetForEditPost200ResponseOneOfEditPermissionsRestrictedPremiumFeaturesEnum];
+
+export interface ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProject {
+    'projectSlug': string;
+    'projectTitle': string;
+    'defaultLanguageCode': ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum;
+    'languageSettings': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerLanguageSettings;
+}
+
+export const ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum = {
+    En: 'en',
+    Es: 'es',
+    Fr: 'fr',
+    ZhHant: 'zh-Hant',
+    ZhHans: 'zh-Hans',
+    Ja: 'ja',
+    Ar: 'ar',
+    Fa: 'fa',
+    He: 'he',
+    Ky: 'ky',
+    Ru: 'ru',
+} as const;
+
+export type ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum = typeof ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum[keyof typeof ApiV1ConversationGetForEditPost200ResponseOneOfProjectLanguageProjectDefaultLanguageCodeEnum];
 
 export interface ApiV1ConversationGetForEditPost200ResponseOneOfSurveyConfig {
     'isOptional': boolean;
@@ -6641,6 +6667,7 @@ export type ApiV1ProjectCreateOptionsListPost200Response = ApiV1ProjectCreateOpt
 export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOf {
     'success': boolean;
     'projectList': Array<ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInner>;
+    'noProjectEmailUpdates': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerEmailUpdates;
 }
 export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOf1 {
     'success': boolean;
@@ -6659,6 +6686,7 @@ export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInn
     'projectTitle': string;
     'defaultLanguageCode': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum;
     'languageSettings': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerLanguageSettings;
+    'emailUpdates': ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerEmailUpdates;
 }
 
 export const ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum = {
@@ -6677,6 +6705,10 @@ export const ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDe
 
 export type ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum = typeof ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum[keyof typeof ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerDefaultLanguageCodeEnum];
 
+export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerEmailUpdates {
+    'canConfigure': boolean;
+    'scopeDefaultEnabled': boolean;
+}
 export interface ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerLanguageSettings {
     'dynamicTranslationEnabled': boolean;
     'targetLanguageCodes': Array<ApiV1ProjectCreateOptionsListPost200ResponseOneOfProjectListInnerLanguageSettingsTargetLanguageCodesEnum>;
@@ -6747,6 +6779,51 @@ export const ApiV1ProjectDocumentAccessPostRequestModeEnum = {
 } as const;
 
 export type ApiV1ProjectDocumentAccessPostRequestModeEnum = typeof ApiV1ProjectDocumentAccessPostRequestModeEnum[keyof typeof ApiV1ProjectDocumentAccessPostRequestModeEnum];
+
+/**
+ * @type ApiV1ProjectEmailUpdateSummaryGetPost200Response
+ */
+export type ApiV1ProjectEmailUpdateSummaryGetPost200Response = ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf | ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1;
+
+export interface ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf {
+    'success': boolean;
+    'authoringAction': ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum;
+    'participantPreference'?: ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreference;
+}
+
+export const ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum = {
+    None: 'none',
+    Compose: 'compose',
+    History: 'history',
+} as const;
+
+export type ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum = typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum[keyof typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfAuthoringActionEnum];
+
+export interface ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1 {
+    'success': boolean;
+    'reason': ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum;
+}
+
+export const ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum = {
+    ProjectNotFound: 'project_not_found',
+    FeatureNotAvailable: 'feature_not_available',
+    SummaryUnavailable: 'summary_unavailable',
+} as const;
+
+export type ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum = typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum[keyof typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOf1ReasonEnum];
+
+export interface ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreference {
+    'state': ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum;
+    'resolvedEnabled': boolean;
+}
+
+export const ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum = {
+    Disabled: 'disabled',
+    Enabled: 'enabled',
+    Undisclosed: 'undisclosed',
+} as const;
+
+export type ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum = typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum[keyof typeof ApiV1ProjectEmailUpdateSummaryGetPost200ResponseOneOfParticipantPreferenceStateEnum];
 
 export interface ApiV1ProjectPageActivitiesFetchPost200Response {
     'activities': Array<ApiV1ProjectPageFetchPost200ResponseActivitiesInner>;
@@ -12081,6 +12158,44 @@ export const DefaultApiAxiosParamCreator = function (configuration?: Configurati
         },
         /**
          * 
+         * @param {ApiV1AdministratorProjectGetProjectDetailsPostRequest} apiV1AdministratorProjectGetProjectDetailsPostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiV1ProjectEmailUpdateSummaryGetPost: async (apiV1AdministratorProjectGetProjectDetailsPostRequest: ApiV1AdministratorProjectGetProjectDetailsPostRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'apiV1AdministratorProjectGetProjectDetailsPostRequest' is not null or undefined
+            assertParamExists('apiV1ProjectEmailUpdateSummaryGetPost', 'apiV1AdministratorProjectGetProjectDetailsPostRequest', apiV1AdministratorProjectGetProjectDetailsPostRequest)
+            const localVarPath = `/api/v1/project/email-update/summary/get`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+            localVarHeaderParameter['Accept'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(apiV1AdministratorProjectGetProjectDetailsPostRequest, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @param {ApiV1ProjectPageFetchPostRequest} apiV1ProjectPageFetchPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -14722,6 +14837,18 @@ export const DefaultApiFp = function(configuration?: Configuration) {
         },
         /**
          * 
+         * @param {ApiV1AdministratorProjectGetProjectDetailsPostRequest} apiV1AdministratorProjectGetProjectDetailsPostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest: ApiV1AdministratorProjectGetProjectDetailsPostRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ApiV1ProjectEmailUpdateSummaryGetPost200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['DefaultApi.apiV1ProjectEmailUpdateSummaryGetPost']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @param {ApiV1ProjectPageFetchPostRequest} apiV1ProjectPageFetchPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -16101,6 +16228,15 @@ export const DefaultApiFactory = function (configuration?: Configuration, basePa
         },
         /**
          * 
+         * @param {ApiV1AdministratorProjectGetProjectDetailsPostRequest} apiV1AdministratorProjectGetProjectDetailsPostRequest 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest: ApiV1AdministratorProjectGetProjectDetailsPostRequest, options?: RawAxiosRequestConfig): AxiosPromise<ApiV1ProjectEmailUpdateSummaryGetPost200Response> {
+            return localVarFp.apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @param {ApiV1ProjectPageFetchPostRequest} apiV1ProjectPageFetchPostRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -17464,6 +17600,16 @@ export class DefaultApi extends BaseAPI {
      */
     public apiV1ProjectDocumentAccessPost(apiV1ProjectDocumentAccessPostRequest: ApiV1ProjectDocumentAccessPostRequest, options?: RawAxiosRequestConfig) {
         return DefaultApiFp(this.configuration).apiV1ProjectDocumentAccessPost(apiV1ProjectDocumentAccessPostRequest, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {ApiV1AdministratorProjectGetProjectDetailsPostRequest} apiV1AdministratorProjectGetProjectDetailsPostRequest 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest: ApiV1AdministratorProjectGetProjectDetailsPostRequest, options?: RawAxiosRequestConfig) {
+        return DefaultApiFp(this.configuration).apiV1ProjectEmailUpdateSummaryGetPost(apiV1AdministratorProjectGetProjectDetailsPostRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/services/load-testing/src/shared/types/dto.ts
+++ b/services/load-testing/src/shared/types/dto.ts
@@ -402,6 +402,12 @@ const zodConversationLanguageSettingsSource = z.enum([
     "conversation_override",
     "project_inherited",
 ]);
+const zodConversationCreateEmailUpdateConfiguration = z
+    .object({
+        canConfigure: z.boolean(),
+        scopeDefaultEnabled: z.boolean(),
+    })
+    .strict();
 const zodConversationCreateProjectOption = z
     .object({
         projectSlug: zodProjectSlug,
@@ -410,6 +416,12 @@ const zodConversationCreateProjectOption = z
         languageSettings: zodProjectLanguageSettings,
     })
     .strict();
+const zodConversationCreateProjectOptionWithEmailUpdates =
+    zodConversationCreateProjectOption
+        .extend({
+            emailUpdates: zodConversationCreateEmailUpdateConfiguration,
+        })
+        .strict();
 const zodProjectContentLocalizationInput = z
     .object({
         languageCode: ZodSupportedDisplayLanguageCodes,
@@ -1237,6 +1249,7 @@ export class Dto {
             multilingualSetting: zodConversationMultilingualSetting,
             seedOpinionList: z.array(zodOpinionContentInput).max(50),
             requiresEventTicket: zodEventSlug.optional(),
+            conversationEmailUpdateEnabledOverride: z.boolean().optional(),
         })
         .strict();
     static createNewConversationRequest = z.discriminatedUnion(
@@ -1554,6 +1567,7 @@ export class Dto {
                 aiLabelingEnabled: z.boolean(),
                 preferredOpinionGroupCount: zodPreferredOpinionGroupCount,
                 postAsOrganizationName: z.string().optional(),
+                postAsOrganizationSlug: zodOrganizationSlug.optional(),
                 surveyConfig: zodSurveyConfig.nullable().optional(),
                 createdAt: zodDateTimeFlexible,
                 updatedAt: zodDateTimeFlexible,
@@ -2337,14 +2351,19 @@ export class Dto {
             ),
         })
         .strict();
-    static conversationCreateProjectOption = zodConversationCreateProjectOption;
+    static conversationCreateProjectOption =
+        zodConversationCreateProjectOptionWithEmailUpdates;
     static getConversationCreateProjectOptionsResponse = z.discriminatedUnion(
         "success",
         [
             z
                 .object({
                     success: z.literal(true),
-                    projectList: z.array(Dto.conversationCreateProjectOption),
+                    projectList: z.array(
+                        zodConversationCreateProjectOptionWithEmailUpdates,
+                    ),
+                    noProjectEmailUpdates:
+                        zodConversationCreateEmailUpdateConfiguration,
                 })
                 .strict(),
             z
@@ -3476,6 +3495,39 @@ export class Dto {
                 })
                 .strict(),
         ]);
+    static conversationEmailUpdateProjectSummaryRequest = z
+        .object({
+            projectSlug: zodProjectSlug,
+        })
+        .strict();
+    static conversationEmailUpdateProjectSummaryResponse = z.discriminatedUnion(
+        "success",
+        [
+            z
+                .object({
+                    success: z.literal(true),
+                    authoringAction: z.enum(["none", "compose", "history"]),
+                    participantPreference: z
+                        .object({
+                            state: zodConversationEmailUpdatePreferenceState,
+                            resolvedEnabled: z.boolean(),
+                        })
+                        .strict()
+                        .optional(),
+                })
+                .strict(),
+            z
+                .object({
+                    success: z.literal(false),
+                    reason: z.enum([
+                        "project_not_found",
+                        "feature_not_available",
+                        "summary_unavailable",
+                    ]),
+                })
+                .strict(),
+        ],
+    );
     static conversationEmailUpdateActionResolveRequest = z
         .object({ token: zodConversationEmailUpdateActionToken })
         .strict();
@@ -4124,6 +4176,12 @@ export type ConversationEmailUpdateConversationSummaryRequest = z.infer<
 >;
 export type ConversationEmailUpdateConversationSummaryResponse = z.infer<
     typeof Dto.conversationEmailUpdateConversationSummaryResponse
+>;
+export type ConversationEmailUpdateProjectSummaryRequest = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryRequest
+>;
+export type ConversationEmailUpdateProjectSummaryResponse = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryResponse
 >;
 export type ConversationEmailUpdateSnsSimulatorRequest = z.infer<
     typeof Dto.conversationEmailUpdateSnsSimulatorRequest

--- a/services/shared/src/types/dto.ts
+++ b/services/shared/src/types/dto.ts
@@ -401,6 +401,12 @@ const zodConversationLanguageSettingsSource = z.enum([
     "conversation_override",
     "project_inherited",
 ]);
+const zodConversationCreateEmailUpdateConfiguration = z
+    .object({
+        canConfigure: z.boolean(),
+        scopeDefaultEnabled: z.boolean(),
+    })
+    .strict();
 const zodConversationCreateProjectOption = z
     .object({
         projectSlug: zodProjectSlug,
@@ -409,6 +415,12 @@ const zodConversationCreateProjectOption = z
         languageSettings: zodProjectLanguageSettings,
     })
     .strict();
+const zodConversationCreateProjectOptionWithEmailUpdates =
+    zodConversationCreateProjectOption
+        .extend({
+            emailUpdates: zodConversationCreateEmailUpdateConfiguration,
+        })
+        .strict();
 const zodProjectContentLocalizationInput = z
     .object({
         languageCode: ZodSupportedDisplayLanguageCodes,
@@ -1236,6 +1248,7 @@ export class Dto {
             multilingualSetting: zodConversationMultilingualSetting,
             seedOpinionList: z.array(zodOpinionContentInput).max(50),
             requiresEventTicket: zodEventSlug.optional(),
+            conversationEmailUpdateEnabledOverride: z.boolean().optional(),
         })
         .strict();
     static createNewConversationRequest = z.discriminatedUnion(
@@ -1553,6 +1566,7 @@ export class Dto {
                 aiLabelingEnabled: z.boolean(),
                 preferredOpinionGroupCount: zodPreferredOpinionGroupCount,
                 postAsOrganizationName: z.string().optional(),
+                postAsOrganizationSlug: zodOrganizationSlug.optional(),
                 surveyConfig: zodSurveyConfig.nullable().optional(),
                 createdAt: zodDateTimeFlexible,
                 updatedAt: zodDateTimeFlexible,
@@ -2336,14 +2350,19 @@ export class Dto {
             ),
         })
         .strict();
-    static conversationCreateProjectOption = zodConversationCreateProjectOption;
+    static conversationCreateProjectOption =
+        zodConversationCreateProjectOptionWithEmailUpdates;
     static getConversationCreateProjectOptionsResponse = z.discriminatedUnion(
         "success",
         [
             z
                 .object({
                     success: z.literal(true),
-                    projectList: z.array(Dto.conversationCreateProjectOption),
+                    projectList: z.array(
+                        zodConversationCreateProjectOptionWithEmailUpdates,
+                    ),
+                    noProjectEmailUpdates:
+                        zodConversationCreateEmailUpdateConfiguration,
                 })
                 .strict(),
             z
@@ -3475,6 +3494,39 @@ export class Dto {
                 })
                 .strict(),
         ]);
+    static conversationEmailUpdateProjectSummaryRequest = z
+        .object({
+            projectSlug: zodProjectSlug,
+        })
+        .strict();
+    static conversationEmailUpdateProjectSummaryResponse = z.discriminatedUnion(
+        "success",
+        [
+            z
+                .object({
+                    success: z.literal(true),
+                    authoringAction: z.enum(["none", "compose", "history"]),
+                    participantPreference: z
+                        .object({
+                            state: zodConversationEmailUpdatePreferenceState,
+                            resolvedEnabled: z.boolean(),
+                        })
+                        .strict()
+                        .optional(),
+                })
+                .strict(),
+            z
+                .object({
+                    success: z.literal(false),
+                    reason: z.enum([
+                        "project_not_found",
+                        "feature_not_available",
+                        "summary_unavailable",
+                    ]),
+                })
+                .strict(),
+        ],
+    );
     static conversationEmailUpdateActionResolveRequest = z
         .object({ token: zodConversationEmailUpdateActionToken })
         .strict();
@@ -4123,6 +4175,12 @@ export type ConversationEmailUpdateConversationSummaryRequest = z.infer<
 >;
 export type ConversationEmailUpdateConversationSummaryResponse = z.infer<
     typeof Dto.conversationEmailUpdateConversationSummaryResponse
+>;
+export type ConversationEmailUpdateProjectSummaryRequest = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryRequest
+>;
+export type ConversationEmailUpdateProjectSummaryResponse = z.infer<
+    typeof Dto.conversationEmailUpdateProjectSummaryResponse
 >;
 export type ConversationEmailUpdateSnsSimulatorRequest = z.infer<
     typeof Dto.conversationEmailUpdateSnsSimulatorRequest


### PR DESCRIPTION
## Summary
- add backend-authoritative create-time Email Updates configuration with inherited or explicit conversation settings
- add project participant preference and facilitator Compose/History actions, while keeping authorized workspaces visible when sending is blocked
- show immutable organization identity while editing and render dialog navigation through SpaLink
- extract and reuse the auth-free recipient preference manager in a restored dev fixture covering project/no-project and single/multiple-conversation emails
- align normal API development with the worker simulated-success scenario while retaining fail-closed direct and production defaults

## Review
- correctness: centralized project-scoped capability and entitlement checks, reset draft overrides when scope changes, require participant contact before enabling, and preserve history-only access
- type safety: model handler and navigation actions as a discriminated union, parse shared DTO boundaries, and keep draft/create project option types correlated
- clean code: reuse preference actions and the auth-free preference manager; remove duplicated route markup and read-after-write refreshes
- security: keep simulator startup development-only and production defaults disabled with the kill switch active
- performance: scope project authorization/preference queries and use an existence query for history summaries
- dead code: remove superseded configuration authorization helpers and duplicate auth-free preference UI

## Verification
- API: typecheck, lint, 59 files / 562 tests
- Agora: vue-tsc, lint with 11 pre-existing warnings, 99 files / 618 tests
- Conversation Email Update worker: production build, typecheck, lint, 26 files / 148 tests
- OpenAPI and generated clients regenerated
- browser checked /dev/conversation-updates with zero runtime errors and verified project/multiple plus no-project/single recipient scenarios
- simulated delivery exercise intentionally not run; it will be run manually

Deploy: agora, api