### PR TITLE
fix(api): install Valkey TLS trust store

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -28,7 +28,7 @@ RUN pnpm build
 # ---- Production ----
 FROM node:24.14.1-trixie-slim
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends tini && \
+    apt-get install -y --no-install-recommends ca-certificates tini && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --chown=node:node --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
## Summary
- install the system CA bundle explicitly in the API runtime image
- allow Valkey GLIDE 2.5's platform verifier to authenticate the ElastiCache TLS endpoint
- prevent repeated Queue Valkey fallback to in-memory mode

## Verification
- built the complete API image as `agora-api:ca-trust-verification`
- confirmed Debian installed and populated `ca-certificates` with 150 trusted certificates
- confirmed the production image build still passes its OpenCC import smoke test
- ran `git diff --check`

Deploy: api