### PR TITLE
fix(agora): preserve project logo shapes

### DIFF
--- a/services/agora/src/components/project/ProjectAttributionSection.vue
+++ b/services/agora/src/components/project/ProjectAttributionSection.vue
@@ -14,26 +14,18 @@
         }"
         v-bind="entryLinkAttributes(entry)"
       >
+        <OrganizationImage
+          v-if="entry.imageUrl !== undefined"
+          height="48px"
+          :organization-image-url="entry.imageUrl"
+          :organization-name="entry.displayName"
+        />
         <div
+          v-else
           class="project-attribution-section__logo"
-          :class="{
-            'project-attribution-section__logo--image':
-              entry.imageUrl !== undefined,
-          }"
-          :style="
-            entry.imageUrl === undefined
-              ? logoStyle(entry.accentColor)
-              : undefined
-          "
+          :style="logoStyle(entry.accentColor)"
         >
-          <OrganizationImage
-            v-if="entry.imageUrl !== undefined"
-            class="project-attribution-section__logo-image"
-            height="100%"
-            :organization-image-url="entry.imageUrl"
-            :organization-name="entry.displayName"
-          />
-          <template v-else>{{ entry.initials }}</template>
+          {{ entry.initials }}
         </div>
 
         <div class="project-attribution-section__body">
@@ -195,21 +187,6 @@ function logoStyle(color: string): { backgroundColor: string } {
   font-size: 0.78rem;
   font-weight: var(--font-weight-bold);
   letter-spacing: 0.02em;
-}
-
-.project-attribution-section__logo--image {
-  padding: 0;
-  border: 1px solid $sky-lighter;
-  background: white;
-  color: inherit;
-}
-
-.project-attribution-section__logo-image {
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  display: block;
-  object-fit: contain;
 }
 
 .project-attribution-section__body {


### PR DESCRIPTION
## Summary
- Render attribution logos directly with OrganizationImage on both project and project conversation pages.
- Preserve natural image proportions and transparency instead of applying a circular white mask.
- Retain the committed initials fallback and remove unused image-mask CSS.
- Include only the logo fix in one file; leave unrelated work out of this PR.

## Verification
- Frontend vue-tsc --noEmit, targeted ESLint/Prettier, and all 24 project tests passed in the original working tree.
- Isolated PR patch passed Prettier and git diff --check; it retains the main-branch initials fallback rather than depending on the uncommitted BrandAvatar refactor.
- Browser appearance has not been verified.

Deploy: agora