### PR TITLE
fix(agora): align project branding and legal links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ dev-sync:
 	$(LOG_RUNNER) --service shared -- $(MAKE) dev-sync-raw
 
 dev-sync-raw:
-	watchman-make -p 'services/shared/src/**/*.ts' -t sync
+	watchman-make -p 'services/shared/src/**/*.ts' 'services/shared/src/**/*.vue' -t sync
 
 dev-sync-app-api:
 	$(LOG_RUNNER) --service shared-app-api -- $(MAKE) dev-sync-app-api-raw

--- a/services/agora/src/components/project/ProjectAttributionSection.test.ts
+++ b/services/agora/src/components/project/ProjectAttributionSection.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { type App, createApp, h } from "vue";
+
+import ProjectAttributionSection from "./ProjectAttributionSection.vue";
+
+let app: App | undefined;
+
+afterEach(() => {
+  app?.unmount();
+  document.body.replaceChildren();
+});
+
+describe("ProjectAttributionSection", () => {
+  it("preserves uploaded logo proportions and uses shared initials only without an image", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    app = createApp(() =>
+      h(ProjectAttributionSection, {
+        title: "Project Owners",
+        languageCode: "en",
+        entries: [
+          {
+            displayName: "Wide Logo",
+            imageUrl: "https://example.com/logo.png",
+            accentColor: "#5538ee",
+            role: "project_owner",
+            websiteUrl: undefined,
+          },
+          {
+            displayName: "  Agora Citizen Network  ",
+            imageUrl: undefined,
+            accentColor: "#5538ee",
+            role: "project_owner",
+            websiteUrl: undefined,
+          },
+        ],
+      })
+    );
+    app.component("QIcon", { render: () => null });
+    app.mount(container);
+
+    expect(container.querySelectorAll("img")).toHaveLength(1);
+    const image = container.querySelector("img");
+    expect(image?.src).toBe("https://example.com/logo.png");
+    expect(image?.alt).toBe("Wide Logo");
+    expect(image?.style.height).toBe("48px");
+    expect(image?.style.width).toBe("");
+    expect(image?.style.borderRadius).toBe("");
+    expect(image?.style.backgroundColor).toBe("");
+
+    const avatar = container.querySelector<HTMLElement>(
+      'span[aria-label="  Agora Citizen Network  "]'
+    );
+    expect(avatar?.textContent?.trim()).toBe("ACN");
+    expect(avatar?.style.width).toBe("48px");
+    expect(avatar?.style.borderRadius).toBe("50%");
+    expect(avatar?.style.backgroundColor).toBe("rgb(85, 56, 238)");
+    expect(
+      container.querySelector(".project-attribution-section__logo")
+    ).toBeNull();
+  });
+});

--- a/services/agora/src/components/project/ProjectAttributionSection.vue
+++ b/services/agora/src/components/project/ProjectAttributionSection.vue
@@ -20,13 +20,13 @@
           :organization-image-url="entry.imageUrl"
           :organization-name="entry.displayName"
         />
-        <div
+        <BrandAvatar
           v-else
-          class="project-attribution-section__logo"
-          :style="logoStyle(entry.accentColor)"
-        >
-          {{ entry.initials }}
-        </div>
+          :name="entry.displayName"
+          :image-url="entry.imageUrl"
+          :size="48"
+          :color="entry.accentColor"
+        />
 
         <div class="project-attribution-section__body">
           <div class="project-attribution-section__name">
@@ -48,6 +48,7 @@
 
 <script setup lang="ts">
 import OrganizationImage from "src/components/account/OrganizationImage.vue";
+import BrandAvatar from "src/shared/branding/BrandAvatar.vue";
 import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
 import { computed } from "vue";
 
@@ -58,12 +59,7 @@ import { getSafeProjectWebHref } from "./projectUrlSafety";
 
 type ProjectAttributionSectionEntry = Pick<
   ProjectAttribution,
-  | "accentColor"
-  | "displayName"
-  | "imageUrl"
-  | "initials"
-  | "role"
-  | "websiteUrl"
+  "accentColor" | "displayName" | "imageUrl" | "role" | "websiteUrl"
 >;
 
 const props = defineProps<{
@@ -109,10 +105,6 @@ function entryLinkAttributes(
       params: { name: entry.displayName },
     }),
   };
-}
-
-function logoStyle(color: string): { backgroundColor: string } {
-  return { backgroundColor: color };
 }
 </script>
 
@@ -172,21 +164,6 @@ function logoStyle(color: string): { backgroundColor: string } {
     outline: 2px solid rgba($primary, 0.45);
     outline-offset: 2px;
   }
-}
-
-.project-attribution-section__logo {
-  width: 3rem;
-  height: 3rem;
-  box-sizing: border-box;
-  display: grid;
-  place-items: center;
-  flex: none;
-  overflow: hidden;
-  border-radius: 50%;
-  color: white;
-  font-size: 0.78rem;
-  font-weight: var(--font-weight-bold);
-  letter-spacing: 0.02em;
 }
 
 .project-attribution-section__body {

--- a/services/agora/src/components/project/ProjectPageFooter.i18n.ts
+++ b/services/agora/src/components/project/ProjectPageFooter.i18n.ts
@@ -1,0 +1,79 @@
+import type { SupportedDisplayLanguageCodes } from "src/shared/languages";
+
+export interface ProjectPageFooterTranslations {
+  poweredBy: string;
+  homeAriaLabel: string;
+  termsOfService: string;
+  privacyPolicy: string;
+}
+
+export const projectPageFooterTranslations: Readonly<
+  Record<SupportedDisplayLanguageCodes, ProjectPageFooterTranslations>
+> = {
+  en: {
+    poweredBy: "Powered by",
+    homeAriaLabel: "Go to Agora Citizen Network home",
+    termsOfService: "Terms of Service",
+    privacyPolicy: "Privacy Policy",
+  },
+  es: {
+    poweredBy: "Con tecnología de",
+    homeAriaLabel: "Ir al inicio de Agora Citizen Network",
+    termsOfService: "Términos de servicio",
+    privacyPolicy: "Política de privacidad",
+  },
+  fr: {
+    poweredBy: "Propulsé par",
+    homeAriaLabel: "Aller à l'accueil d'Agora Citizen Network",
+    termsOfService: "Conditions d'utilisation",
+    privacyPolicy: "Politique de confidentialité",
+  },
+  "zh-Hans": {
+    poweredBy: "技术支持",
+    homeAriaLabel: "前往 Agora Citizen Network 首页",
+    termsOfService: "服务条款",
+    privacyPolicy: "隐私政策",
+  },
+  "zh-Hant": {
+    poweredBy: "技術支援",
+    homeAriaLabel: "前往 Agora Citizen Network 首頁",
+    termsOfService: "服務條款",
+    privacyPolicy: "隱私政策",
+  },
+  ja: {
+    poweredBy: "提供",
+    homeAriaLabel: "Agora Citizen Network ホームへ移動",
+    termsOfService: "利用規約",
+    privacyPolicy: "プライバシーポリシー",
+  },
+  ar: {
+    poweredBy: "مدعوم من",
+    homeAriaLabel: "الانتقال إلى الصفحة الرئيسية لـ Agora Citizen Network",
+    termsOfService: "شروط الخدمة",
+    privacyPolicy: "سياسة الخصوصية",
+  },
+  fa: {
+    poweredBy: "قدرت‌گرفته از",
+    homeAriaLabel: "رفتن به صفحه اصلی Agora Citizen Network",
+    termsOfService: "شرایط استفاده",
+    privacyPolicy: "سیاست حریم خصوصی",
+  },
+  he: {
+    poweredBy: "מופעל על ידי",
+    homeAriaLabel: "מעבר לדף הבית של Agora Citizen Network",
+    termsOfService: "תנאי שימוש",
+    privacyPolicy: "מדיניות פרטיות",
+  },
+  ky: {
+    poweredBy: "Түзгөн",
+    homeAriaLabel: "Agora Citizen Network башкы бетине өтүү",
+    termsOfService: "Кызмат көрсөтүү шарттары",
+    privacyPolicy: "Купуялык саясаты",
+  },
+  ru: {
+    poweredBy: "Работает на",
+    homeAriaLabel: "Перейти на главную Agora Citizen Network",
+    termsOfService: "Условия использования",
+    privacyPolicy: "Политика конфиденциальности",
+  },
+};

--- a/services/agora/src/components/project/ProjectPageFooter.test.ts
+++ b/services/agora/src/components/project/ProjectPageFooter.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { type App, createApp, h, nextTick, ref } from "vue";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+import { projectPageFooterTranslations } from "./ProjectPageFooter.i18n";
+import ProjectPageFooter from "./ProjectPageFooter.vue";
+
+let app: App | undefined;
+
+afterEach(() => {
+  app?.unmount();
+  document.body.replaceChildren();
+});
+
+describe("ProjectPageFooter", () => {
+  it("renders localized legal links in separate tabs with a decorative middle dot", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/", component: { render: () => null } },
+        {
+          path: "/legal/terms",
+          name: "/legal/terms/",
+          component: { render: () => null },
+        },
+        {
+          path: "/legal/privacy",
+          name: "/legal/privacy/",
+          component: { render: () => null },
+        },
+      ],
+    });
+    await router.push("/");
+    const languageCode = ref("fr");
+    const container = document.createElement("div");
+    document.body.append(container);
+    app = createApp(() =>
+      h(ProjectPageFooter, { languageCode: languageCode.value })
+    );
+    app.use(router);
+    app.mount(container);
+
+    expect(container.querySelectorAll("a")).toHaveLength(3);
+    expect(container.textContent).not.toContain("appartient aux porteurs");
+    expect(container.querySelector('[aria-hidden="true"]')?.textContent).toBe(
+      "\u00b7"
+    );
+
+    for (const [locale, translations] of Object.entries(
+      projectPageFooterTranslations
+    )) {
+      languageCode.value = locale;
+      await nextTick();
+      for (const { href, label } of [
+        { href: "/legal/terms", label: translations.termsOfService },
+        { href: "/legal/privacy", label: translations.privacyPolicy },
+      ]) {
+        const link = container.querySelector(`a[href="${href}"]`);
+        expect(link?.textContent?.trim()).toBe(label);
+        expect(link?.getAttribute("target")).toBe("_blank");
+        expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+        expect(link?.querySelector(".gradientColor")).not.toBeNull();
+        const event = new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+        });
+        link?.dispatchEvent(event);
+        expect(event.defaultPrevented).toBe(false);
+        expect(router.currentRoute.value.path).toBe("/");
+      }
+    }
+
+    languageCode.value = "unsupported";
+    await nextTick();
+    expect(container.textContent).toContain("Terms of Service");
+    expect(container.textContent).toContain("Privacy Policy");
+  });
+});

--- a/services/agora/src/components/project/ProjectPageFooter.vue
+++ b/services/agora/src/components/project/ProjectPageFooter.vue
@@ -80,13 +80,14 @@ function t(key: keyof ProjectPageFooterTranslations): string {
 }
 
 .project-page-footer__legal-links {
+  align-items: center;
   column-gap: 0.5rem;
 }
 
 .project-page-footer__separator {
-  @media (max-width: 599px) {
-    display: none;
-  }
+  font-size: 1.25rem;
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
 }
 
 .project-page-footer__link {

--- a/services/agora/src/components/project/ProjectPageFooter.vue
+++ b/services/agora/src/components/project/ProjectPageFooter.vue
@@ -2,32 +2,60 @@
   <footer class="project-page-footer">
     <span class="project-page-footer__line">
       <span>{{ t("poweredBy") }}</span>
-      <SpaLink to="/" class="project-page-footer__brand-link" :aria-label="t('homeAriaLabel')">
+      <SpaLink
+        to="/"
+        class="project-page-footer__link"
+        :aria-label="t('homeAriaLabel')"
+      >
         <ZKStyledText text="Agora Citizen Network" :add-gradient="true" />
       </SpaLink>
     </span>
-    <span>{{ t("contentOwnedByProjectOwners") }}</span>
+    <span class="project-page-footer__line project-page-footer__legal-links">
+      <SpaLink
+        :to="{ name: '/legal/terms/' }"
+        class="project-page-footer__link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <ZKStyledText :text="t('termsOfService')" :add-gradient="true" />
+      </SpaLink>
+      <span class="project-page-footer__separator" aria-hidden="true">&middot;</span>
+      <SpaLink
+        :to="{ name: '/legal/privacy/' }"
+        class="project-page-footer__link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <ZKStyledText :text="t('privacyPolicy')" :add-gradient="true" />
+      </SpaLink>
+    </span>
   </footer>
 </template>
 
 <script setup lang="ts">
 import SpaLink from "src/components/ui-library/SpaLink.vue";
 import ZKStyledText from "src/components/ui-library/ZKStyledText.vue";
+import { parseSupportedDisplayLanguageOrUndefined } from "src/shared/languages";
+import { computed } from "vue";
 
 import {
-  type ProjectPageTranslations,
-  translateProjectPageText,
-} from "./projectPageI18n";
+  type ProjectPageFooterTranslations,
+  projectPageFooterTranslations,
+} from "./ProjectPageFooter.i18n";
 
 const props = defineProps<{
   languageCode: string;
 }>();
 
-function t(key: keyof ProjectPageTranslations): string {
-  return translateProjectPageText({
-    languageCode: props.languageCode,
-    key,
-  });
+const translations = computed(
+  () =>
+    projectPageFooterTranslations[
+      parseSupportedDisplayLanguageOrUndefined(props.languageCode) ?? "en"
+    ]
+);
+
+function t(key: keyof ProjectPageFooterTranslations): string {
+  return translations.value[key];
 }
 </script>
 
@@ -51,7 +79,17 @@ function t(key: keyof ProjectPageTranslations): string {
   gap: 0.25rem;
 }
 
-.project-page-footer__brand-link {
+.project-page-footer__legal-links {
+  column-gap: 0.5rem;
+}
+
+.project-page-footer__separator {
+  @media (max-width: 599px) {
+    display: none;
+  }
+}
+
+.project-page-footer__link {
   display: inline-block;
   font-weight: var(--font-weight-bold);
   transition: transform 0.15s ease-out;

--- a/services/agora/src/components/project/projectPageI18n.ts
+++ b/services/agora/src/components/project/projectPageI18n.ts
@@ -65,9 +65,6 @@ export interface ProjectPageTranslations {
   projectOwnersTitle: string;
   partnersTitle: string;
   projectContactTitle: string;
-  poweredBy: string;
-  homeAriaLabel: string;
-  contentOwnedByProjectOwners: string;
   activityStatisticsAriaLabel: string;
   conversationType: string;
   voteType: string;
@@ -128,10 +125,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "Project Owners",
     partnersTitle: "Partners",
     projectContactTitle: "Contact",
-    poweredBy: "Powered by",
-    homeAriaLabel: "Go to Agora Citizen Network home",
-    contentOwnedByProjectOwners:
-      "Project content is owned by the Project Owners",
     activityStatisticsAriaLabel: "Activity statistics",
     conversationType: "Conversation",
     voteType: "Vote",
@@ -188,10 +181,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "Responsables del proyecto",
     partnersTitle: "Socios",
     projectContactTitle: "Contacto",
-    poweredBy: "Con tecnología de",
-    homeAriaLabel: "Ir al inicio de Agora Citizen Network",
-    contentOwnedByProjectOwners:
-      "El contenido del proyecto pertenece a sus responsables",
     activityStatisticsAriaLabel: "Estadísticas de la actividad",
     conversationType: "Conversación",
     voteType: "Votación",
@@ -248,10 +237,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "Porteurs du projet",
     partnersTitle: "Partenaires",
     projectContactTitle: "Contact",
-    poweredBy: "Propulsé par",
-    homeAriaLabel: "Aller à l'accueil d'Agora Citizen Network",
-    contentOwnedByProjectOwners:
-      "Le contenu du projet appartient aux porteurs du projet",
     activityStatisticsAriaLabel: "Statistiques de l'activité",
     conversationType: "Conversation",
     voteType: "Vote",
@@ -307,9 +292,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "项目负责人",
     partnersTitle: "合作伙伴",
     projectContactTitle: "联系人",
-    poweredBy: "技术支持",
-    homeAriaLabel: "前往 Agora Citizen Network 首页",
-    contentOwnedByProjectOwners: "项目内容归项目负责人所有",
     activityStatisticsAriaLabel: "活动统计",
     conversationType: "对话",
     voteType: "投票",
@@ -365,9 +347,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "專案負責人",
     partnersTitle: "合作夥伴",
     projectContactTitle: "聯絡人",
-    poweredBy: "技術支援",
-    homeAriaLabel: "前往 Agora Citizen Network 首頁",
-    contentOwnedByProjectOwners: "專案內容歸專案負責人所有",
     activityStatisticsAriaLabel: "活動統計",
     conversationType: "對話",
     voteType: "投票",
@@ -424,10 +403,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "プロジェクトオーナー",
     partnersTitle: "パートナー",
     projectContactTitle: "連絡先",
-    poweredBy: "提供",
-    homeAriaLabel: "Agora Citizen Network ホームへ移動",
-    contentOwnedByProjectOwners:
-      "プロジェクトのコンテンツはプロジェクトオーナーに帰属します",
     activityStatisticsAriaLabel: "アクティビティ統計",
     conversationType: "会話",
     voteType: "投票",
@@ -483,9 +458,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "مالكو المشروع",
     partnersTitle: "الشركاء",
     projectContactTitle: "جهة الاتصال",
-    poweredBy: "مدعوم من",
-    homeAriaLabel: "الانتقال إلى الصفحة الرئيسية لـ Agora Citizen Network",
-    contentOwnedByProjectOwners: "محتوى المشروع مملوك لمالكي المشروع",
     activityStatisticsAriaLabel: "إحصاءات النشاط",
     conversationType: "محادثة",
     voteType: "تصويت",
@@ -541,9 +513,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "مالکان پروژه",
     partnersTitle: "شرکا",
     projectContactTitle: "تماس",
-    poweredBy: "قدرت‌گرفته از",
-    homeAriaLabel: "رفتن به صفحه اصلی Agora Citizen Network",
-    contentOwnedByProjectOwners: "محتوای پروژه متعلق به مالکان پروژه است",
     activityStatisticsAriaLabel: "آمار فعالیت",
     conversationType: "گفت‌وگو",
     voteType: "رأی‌گیری",
@@ -599,9 +568,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "בעלי הפרויקט",
     partnersTitle: "שותפים",
     projectContactTitle: "איש קשר",
-    poweredBy: "מופעל על ידי",
-    homeAriaLabel: "מעבר לדף הבית של Agora Citizen Network",
-    contentOwnedByProjectOwners: "תוכן הפרויקט שייך לבעלי הפרויקט",
     activityStatisticsAriaLabel: "סטטיסטיקות פעילות",
     conversationType: "שיחה",
     voteType: "הצבעה",
@@ -657,9 +623,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "Долбоор ээлери",
     partnersTitle: "Өнөктөштөр",
     projectContactTitle: "Байланыш",
-    poweredBy: "Түзгөн",
-    homeAriaLabel: "Agora Citizen Network башкы бетине өтүү",
-    contentOwnedByProjectOwners: "Долбоордун мазмуну Долбоор ээлерине таандык",
     activityStatisticsAriaLabel: "Иш-чара статистикасы",
     conversationType: "Талкуу",
     voteType: "Добуш берүү",
@@ -716,10 +679,6 @@ export const projectPageTranslations: Readonly<
     projectOwnersTitle: "Владельцы проекта",
     partnersTitle: "Партнеры",
     projectContactTitle: "Контакт",
-    poweredBy: "Работает на",
-    homeAriaLabel: "Перейти на главную Agora Citizen Network",
-    contentOwnedByProjectOwners:
-      "Содержание проекта принадлежит владельцам проекта",
     activityStatisticsAriaLabel: "Статистика активности",
     conversationType: "Обсуждение",
     voteType: "Голосование",

--- a/services/agora/src/shared/branding/BrandAvatar.vue
+++ b/services/agora/src/shared/branding/BrandAvatar.vue
@@ -1,0 +1,48 @@
+<!-- WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY DIRECTLY! -->
+<template>
+    <img
+        v-if="imageUrl !== undefined"
+        :src="imageUrl"
+        :alt="name"
+        :width="size"
+        :height="size"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            borderRadius: '50%',
+            objectFit: 'contain',
+            backgroundColor: '#ffffff',
+            verticalAlign: 'middle',
+        }"
+    />
+    <span
+        v-else
+        :aria-label="name"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            lineHeight: `${size}px`,
+            borderRadius: '50%',
+            textAlign: 'center',
+            backgroundColor: color,
+            color: '#ffffff',
+            fontFamily: 'Arial,sans-serif',
+            fontSize: `${Math.round(size / 3)}px`,
+            fontWeight: '700',
+            verticalAlign: 'middle',
+        }"
+        >{{ getBrandInitials(name) }}</span
+    >
+</template>
+
+<script setup lang="ts">
+import { getBrandInitials } from "./emailBranding";
+defineProps<{
+    name: string;
+    imageUrl: string | undefined;
+    size: number;
+    color: string;
+}>();
+</script>

--- a/services/agora/src/shared/branding/emailBranding.ts
+++ b/services/agora/src/shared/branding/emailBranding.ts
@@ -1,0 +1,29 @@
+/** **** WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY THIS FILE DIRECTLY! **** **/
+import { z } from "zod";
+
+export const zodEmailBranding = z
+    .object({
+        name: z.string().trim().min(1).max(500),
+        imageUrl: z.url().optional(),
+        bannerImageUrl: z.url().optional(),
+        palette: z.enum(["blue", "purple", "green"]),
+    })
+    .strict();
+
+export type EmailBranding = z.infer<typeof zodEmailBranding>;
+
+export const projectBrandPalettes = {
+    blue: { start: "#1d4f9f", end: "#6b4eff" },
+    purple: { start: "#5538ee", end: "#d8639a" },
+    green: { start: "#177a41", end: "#4f92f6" },
+} satisfies Record<EmailBranding["palette"], { start: string; end: string }>;
+
+export function getBrandInitials(name: string): string {
+    return name
+        .trim()
+        .split(/\s+/u)
+        .slice(0, 3)
+        .map((part) => part.at(0) ?? "")
+        .join("")
+        .toUpperCase();
+}

--- a/services/api/src/shared/branding/BrandAvatar.vue
+++ b/services/api/src/shared/branding/BrandAvatar.vue
@@ -1,0 +1,48 @@
+<!-- WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY DIRECTLY! -->
+<template>
+    <img
+        v-if="imageUrl !== undefined"
+        :src="imageUrl"
+        :alt="name"
+        :width="size"
+        :height="size"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            borderRadius: '50%',
+            objectFit: 'contain',
+            backgroundColor: '#ffffff',
+            verticalAlign: 'middle',
+        }"
+    />
+    <span
+        v-else
+        :aria-label="name"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            lineHeight: `${size}px`,
+            borderRadius: '50%',
+            textAlign: 'center',
+            backgroundColor: color,
+            color: '#ffffff',
+            fontFamily: 'Arial,sans-serif',
+            fontSize: `${Math.round(size / 3)}px`,
+            fontWeight: '700',
+            verticalAlign: 'middle',
+        }"
+        >{{ getBrandInitials(name) }}</span
+    >
+</template>
+
+<script setup lang="ts">
+import { getBrandInitials } from "./emailBranding";
+defineProps<{
+    name: string;
+    imageUrl: string | undefined;
+    size: number;
+    color: string;
+}>();
+</script>

--- a/services/api/src/shared/branding/emailBranding.ts
+++ b/services/api/src/shared/branding/emailBranding.ts
@@ -1,0 +1,29 @@
+/** **** WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY THIS FILE DIRECTLY! **** **/
+import { z } from "zod";
+
+export const zodEmailBranding = z
+    .object({
+        name: z.string().trim().min(1).max(500),
+        imageUrl: z.url().optional(),
+        bannerImageUrl: z.url().optional(),
+        palette: z.enum(["blue", "purple", "green"]),
+    })
+    .strict();
+
+export type EmailBranding = z.infer<typeof zodEmailBranding>;
+
+export const projectBrandPalettes = {
+    blue: { start: "#1d4f9f", end: "#6b4eff" },
+    purple: { start: "#5538ee", end: "#d8639a" },
+    green: { start: "#177a41", end: "#4f92f6" },
+} satisfies Record<EmailBranding["palette"], { start: string; end: string }>;
+
+export function getBrandInitials(name: string): string {
+    return name
+        .trim()
+        .split(/\s+/u)
+        .slice(0, 3)
+        .map((part) => part.at(0) ?? "")
+        .join("")
+        .toUpperCase();
+}

--- a/services/conversation-email-update-worker/src/shared/branding/BrandAvatar.vue
+++ b/services/conversation-email-update-worker/src/shared/branding/BrandAvatar.vue
@@ -1,0 +1,48 @@
+<!-- WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY DIRECTLY! -->
+<template>
+    <img
+        v-if="imageUrl !== undefined"
+        :src="imageUrl"
+        :alt="name"
+        :width="size"
+        :height="size"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            borderRadius: '50%',
+            objectFit: 'contain',
+            backgroundColor: '#ffffff',
+            verticalAlign: 'middle',
+        }"
+    />
+    <span
+        v-else
+        :aria-label="name"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            lineHeight: `${size}px`,
+            borderRadius: '50%',
+            textAlign: 'center',
+            backgroundColor: color,
+            color: '#ffffff',
+            fontFamily: 'Arial,sans-serif',
+            fontSize: `${Math.round(size / 3)}px`,
+            fontWeight: '700',
+            verticalAlign: 'middle',
+        }"
+        >{{ getBrandInitials(name) }}</span
+    >
+</template>
+
+<script setup lang="ts">
+import { getBrandInitials } from "./emailBranding";
+defineProps<{
+    name: string;
+    imageUrl: string | undefined;
+    size: number;
+    color: string;
+}>();
+</script>

--- a/services/conversation-email-update-worker/src/shared/branding/emailBranding.ts
+++ b/services/conversation-email-update-worker/src/shared/branding/emailBranding.ts
@@ -1,0 +1,29 @@
+/** **** WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY THIS FILE DIRECTLY! **** **/
+import { z } from "zod";
+
+export const zodEmailBranding = z
+    .object({
+        name: z.string().trim().min(1).max(500),
+        imageUrl: z.url().optional(),
+        bannerImageUrl: z.url().optional(),
+        palette: z.enum(["blue", "purple", "green"]),
+    })
+    .strict();
+
+export type EmailBranding = z.infer<typeof zodEmailBranding>;
+
+export const projectBrandPalettes = {
+    blue: { start: "#1d4f9f", end: "#6b4eff" },
+    purple: { start: "#5538ee", end: "#d8639a" },
+    green: { start: "#177a41", end: "#4f92f6" },
+} satisfies Record<EmailBranding["palette"], { start: string; end: string }>;
+
+export function getBrandInitials(name: string): string {
+    return name
+        .trim()
+        .split(/\s+/u)
+        .slice(0, 3)
+        .map((part) => part.at(0) ?? "")
+        .join("")
+        .toUpperCase();
+}

--- a/services/load-testing/src/shared/branding/BrandAvatar.vue
+++ b/services/load-testing/src/shared/branding/BrandAvatar.vue
@@ -1,0 +1,48 @@
+<!-- WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY DIRECTLY! -->
+<template>
+    <img
+        v-if="imageUrl !== undefined"
+        :src="imageUrl"
+        :alt="name"
+        :width="size"
+        :height="size"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            borderRadius: '50%',
+            objectFit: 'contain',
+            backgroundColor: '#ffffff',
+            verticalAlign: 'middle',
+        }"
+    />
+    <span
+        v-else
+        :aria-label="name"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            lineHeight: `${size}px`,
+            borderRadius: '50%',
+            textAlign: 'center',
+            backgroundColor: color,
+            color: '#ffffff',
+            fontFamily: 'Arial,sans-serif',
+            fontSize: `${Math.round(size / 3)}px`,
+            fontWeight: '700',
+            verticalAlign: 'middle',
+        }"
+        >{{ getBrandInitials(name) }}</span
+    >
+</template>
+
+<script setup lang="ts">
+import { getBrandInitials } from "./emailBranding";
+defineProps<{
+    name: string;
+    imageUrl: string | undefined;
+    size: number;
+    color: string;
+}>();
+</script>

--- a/services/load-testing/src/shared/branding/emailBranding.ts
+++ b/services/load-testing/src/shared/branding/emailBranding.ts
@@ -1,0 +1,29 @@
+/** **** WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY THIS FILE DIRECTLY! **** **/
+import { z } from "zod";
+
+export const zodEmailBranding = z
+    .object({
+        name: z.string().trim().min(1).max(500),
+        imageUrl: z.url().optional(),
+        bannerImageUrl: z.url().optional(),
+        palette: z.enum(["blue", "purple", "green"]),
+    })
+    .strict();
+
+export type EmailBranding = z.infer<typeof zodEmailBranding>;
+
+export const projectBrandPalettes = {
+    blue: { start: "#1d4f9f", end: "#6b4eff" },
+    purple: { start: "#5538ee", end: "#d8639a" },
+    green: { start: "#177a41", end: "#4f92f6" },
+} satisfies Record<EmailBranding["palette"], { start: string; end: string }>;
+
+export function getBrandInitials(name: string): string {
+    return name
+        .trim()
+        .split(/\s+/u)
+        .slice(0, 3)
+        .map((part) => part.at(0) ?? "")
+        .join("")
+        .toUpperCase();
+}

--- a/services/shared/scripts/rsync_and_sed.sh
+++ b/services/shared/scripts/rsync_and_sed.sh
@@ -46,6 +46,16 @@ for service in "${ALL_SERVICES[@]}"; do
             fi
         fi
     done
+    find "$TARGET_DIR" -name "*.vue" -print0 | while read -r -d $'\0' file; do
+        VUE_COMMENT="<!-- WARNING: GENERATED FROM SHARED DIRECTORY, DO NOT MODIFY DIRECTLY! -->"
+        if ! grep -qF "$VUE_COMMENT" "$file"; then
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                sed -i '' "1s;^;$VUE_COMMENT\n;" "$file"
+            else
+                sed -i "1i $VUE_COMMENT" "$file"
+            fi
+        fi
+    done
 done
 
 echo "✓ Universal sync complete!"

--- a/services/shared/src/branding/BrandAvatar.vue
+++ b/services/shared/src/branding/BrandAvatar.vue
@@ -1,0 +1,47 @@
+<template>
+    <img
+        v-if="imageUrl !== undefined"
+        :src="imageUrl"
+        :alt="name"
+        :width="size"
+        :height="size"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            borderRadius: '50%',
+            objectFit: 'contain',
+            backgroundColor: '#ffffff',
+            verticalAlign: 'middle',
+        }"
+    />
+    <span
+        v-else
+        :aria-label="name"
+        :style="{
+            display: 'inline-block',
+            width: `${size}px`,
+            height: `${size}px`,
+            lineHeight: `${size}px`,
+            borderRadius: '50%',
+            textAlign: 'center',
+            backgroundColor: color,
+            color: '#ffffff',
+            fontFamily: 'Arial,sans-serif',
+            fontSize: `${Math.round(size / 3)}px`,
+            fontWeight: '700',
+            verticalAlign: 'middle',
+        }"
+        >{{ getBrandInitials(name) }}</span
+    >
+</template>
+
+<script setup lang="ts">
+import { getBrandInitials } from "./emailBranding";
+defineProps<{
+    name: string;
+    imageUrl: string | undefined;
+    size: number;
+    color: string;
+}>();
+</script>

--- a/services/shared/src/branding/emailBranding.ts
+++ b/services/shared/src/branding/emailBranding.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const zodEmailBranding = z
+    .object({
+        name: z.string().trim().min(1).max(500),
+        imageUrl: z.url().optional(),
+        bannerImageUrl: z.url().optional(),
+        palette: z.enum(["blue", "purple", "green"]),
+    })
+    .strict();
+
+export type EmailBranding = z.infer<typeof zodEmailBranding>;
+
+export const projectBrandPalettes = {
+    blue: { start: "#1d4f9f", end: "#6b4eff" },
+    purple: { start: "#5538ee", end: "#d8639a" },
+    green: { start: "#177a41", end: "#4f92f6" },
+} satisfies Record<EmailBranding["palette"], { start: string; end: string }>;
+
+export function getBrandInitials(name: string): string {
+    return name
+        .trim()
+        .split(/\s+/u)
+        .slice(0, 3)
+        .map((part) => part.at(0) ?? "")
+        .join("")
+        .toUpperCase();
+}


### PR DESCRIPTION
## Summary
- Reuse BrandAvatar for project attribution initials while preserving uploaded logo proportions and transparency through OrganizationImage.
- Remove obsolete logoStyle logic, fallback CSS, and ownership translations. Preserve the still-used mobile initials contract and separate contact-avatar rendering.
- Include canonical branding dependencies, generated service copies, and universal shared Vue sync/watch support.
- Replace the ownership sentence with Terms of Service and Privacy Policy links using SpaLink and ZKStyledText, opening in separate tabs.
- Keep footer translations in their own typed file using the same legal wording as Settings in all 11 supported languages.
- Keep a larger middle dot visible at every screen size, inheriting the same muted color as Powered by. Allow the links to wrap naturally when there is insufficient space.

## Verification
- Frontend vue-tsc --noEmit -p tsconfig.json passed.
- Targeted ESLint passed.
- Three focused tests passed, covering attribution rendering, legal links, and project translations.
- Browser verification at 1440px, 390px, and 320px confirmed separator visibility, matching text colors, natural wrapping, and no horizontal overflow.
- Both legal links opened separate tabs without leaving the project page.
- Legal labels match Settings in all 11 languages without runtime translation imports between components.

## Scope
This dedicated branch is based on the latest upstream main, c389c4ed, and contains only the reviewed refactor, required dependencies/tooling, and final legal-footer changes. Unrelated staged and working-tree changes remain local.

Supersedes #1241, which used the fork main branch and did not contain the final separator adjustment.

Deploy: agora