### PR TITLE
feat(scripts): add empty-account merge utility

### DIFF
--- a/scripts/merge-empty-email-account.md
+++ b/scripts/merge-empty-email-account.md
@@ -1,0 +1,124 @@
+# Merge an empty email account into an existing account
+
+[`merge-empty-email-account.sql`](merge-empty-email-account.sql) is a standalone,
+reusable PostgreSQL utility for attaching an empty account's primary email login
+to an account you want to keep. It uses the deployed database's foreign keys to
+check source-account activity, rather than calling the guest-only API merge.
+
+## Maintenance window
+
+This utility is **maintenance-only**. PostgreSQL cannot see votes waiting in
+an API's memory or Valkey. A foreign-key lock also does not stop a delayed write
+from attaching data to a soft-deleted user after the merge commits.
+
+Before either a dry run or an apply:
+
+1. Pause incoming application traffic and administrative writes, and let
+   already-admitted requests finish. Keep the API instances running initially
+   so their vote buffers can flush.
+2. When using Valkey, check both vote-buffer counts with your existing Valkey
+   connection. Both must reach zero; do not delete pending data to empty them.
+
+   ```text
+   ZCARD queue:votes:index
+   HLEN queue:votes:data
+   ```
+
+3. Gracefully stop all API instances and other database writers. The API's
+   `voteBuffer.shutdown()` waits for an in-flight flush and performs a final
+   flush. Check for successful completion on every instance and resolve any
+   flush errors. A forced process stop does not establish this precondition,
+   particularly when the buffer is in-memory only.
+4. With writers stopped, recheck that both Valkey counts are zero, if Valkey is
+   used. Set `writers_paused_and_buffers_drained := true` only after these steps.
+   This setting is an **operator assertion**, not an automated buffer check.
+5. Keep writers paused through the dry run, apply, and commit/rollback. Resume
+   services and traffic only after the database transaction is finished.
+
+If draining reveals source-account activity, the utility aborts. That account
+needs a data-aware merge rather than this empty-account operation.
+
+## Run in a SQL editor
+
+1. Follow the maintenance procedure and connect to the writer database in a
+   fresh transaction. Open the SQL file in an unsaved editor buffer.
+2. Independently verify the accounts, then set `keep_username` and `source_email`
+   in the configuration block. Optionally set `expected_database`, verified
+   account UUIDs, and retained-phone conditions.
+3. Run the **entire statement** with `dry_run := true`. Check the editor's
+   **Messages/Notices** output for `DRY RUN passed`. Utility notices do not print
+   usernames, email addresses, phone metadata, or user IDs.
+4. Change `dry_run := false` and rerun the entire statement. Commit if your editor
+   has autocommit disabled. A failure aborts the statement atomically; if your
+   editor leaves a transaction aborted, roll it back before retrying.
+
+Keep account-specific configuration and execution output out of repository
+files, commits, PRs, screenshots, and shared logs. PostgreSQL/editor diagnostics
+may include submitted SQL, so handle them as private operational data.
+
+With `psql`, configure a private copy outside the repository, then run:
+
+```sh
+psql "$CONNECTION_STRING" -v ON_ERROR_STOP=1 -f /private/path/merge-empty-email-account.sql
+```
+
+## Preconditions
+
+- Both accounts are active and distinct; the retained username must match exactly.
+- The source email is its account's sole email row and an active primary login.
+- The retained account has no active email and, by default, has an active phone.
+- Optional phone hash, calling code, and last-two-digit checks must match the
+  **same** active phone row. The database stores a peppered hash, not the full
+  phone number. Calling code and suffix are corroborating metadata, not proof
+  of a full-number match.
+- The source has no moderator/admin role, imported status, or content counters.
+- All other foreign-key references to the source must be absent, including
+  statements, votes, conversations, memberships, additional credentials, and
+  email-update activity. The error lists blocking tables and counts.
+- Language preferences are allowed to remain on the retired account by default.
+  Set `retained_preference_tables := ARRAY[]::text[]` to require their absence too.
+  These preferences are not copied over the retained account's preferences.
+
+The emptiness check includes deleted/historical rows. If it finds activity, that
+account needs an explicitly designed data merge; increasing an allowed count
+would strand that data. References without database foreign keys cannot be
+discovered automatically; the utility explicitly handles the non-FK OTP tables.
+
+## Effects
+
+- Keeps the destination UUID, username, phone, content, and existing sessions.
+- Moves the email credential, preserving its ID and verification metadata.
+- Moves the source devices to the destination and expires their sessions. Those
+  devices must sign in again; email login now resolves to the retained account.
+- Expires pending source-account OTP attempts and attempts for the moved email.
+- Soft-deletes the source account and records the same `identity_changed` outbox
+  event used by the API's session handling.
+
+The dry run exercises the writes and database constraints inside a rolled-back
+subtransaction, forcing deferred constraints to run before rollback. No merge
+rows persist, though PostgreSQL sequence numbers may advance. Run it in a fresh
+transaction and commit/rollback promptly to release the account locks. Session
+and OTP expiry use UTC whole-second timestamps, matching the API regardless of
+the SQL editor's timezone.
+
+An already-linked email returns without writes only after checking the active
+account, primary email, configured UUIDs, and phone conditions. The
+`expected_source_user_id` assertion always refers to the **current** owner of the
+email. Consequently, a rerun pinned to the original source UUID fails after a
+successful merge. Independently verify the result before clearing that assertion
+to check the already-linked state. The utility does not infer historical merge
+provenance from an email's current owner.
+
+## Verify the utility
+
+From `services/api`, run:
+
+```sh
+pnpm test run tests/mergeEmptyEmailAccount.test.ts
+```
+
+The TypeScript tests reuse the generated auth fixture and the API's
+`authStateChangedPayload` schema. They start and remove their own PostgreSQL 16
+Docker container and exercise rollback, successful transfer, repeat execution,
+maintenance/identity guards, timezone-independent expiry, activity discovery,
+credential conflicts, and immediate/deferred composite email foreign keys.

--- a/scripts/merge-empty-email-account.sql
+++ b/scripts/merge-empty-email-account.sql
@@ -1,0 +1,200 @@
+-- Move the sole email credential of an empty account to an existing account.
+-- Run this entire DO statement on the writer database (SQL editor or psql).
+-- Edit only the configuration below. Read NOTICE output after the dry run,
+-- optionally pin independently verified user IDs, then set dry_run := false.
+-- With editor autocommit disabled, COMMIT is still required after a real run.
+-- See merge-empty-email-account.md for conditions and session behavior.
+
+DO $merge$
+DECLARE
+    -- Configuration: username is exact; email is normalized to lowercase.
+    keep_username text := 'REPLACE_WITH_USERNAME';
+    source_email text := 'REPLACE_WITH_EMAIL';
+    dry_run boolean := true;
+    -- SQL cannot inspect in-memory/Valkey work. Follow the maintenance procedure
+    -- in the companion document before setting this operator assertion to true.
+    writers_paused_and_buffers_drained boolean := false;
+    expected_database text := NULL; -- Optional current_database() check.
+    expected_keep_user_id uuid := NULL;
+    expected_source_user_id uuid := NULL;
+    require_keep_phone boolean := true;
+    expected_phone_hash text := NULL; -- Optional full, peppered phone hash.
+    expected_phone_calling_code text := NULL; -- Optional calling-code metadata.
+    expected_phone_last_two_digits integer := NULL; -- Optional suffix metadata.
+    -- These preferences may stay attached to the retired account. Use an empty
+    -- array to require their absence too. Other user references always block.
+    retained_preference_tables text[] := ARRAY[
+        'user_display_language', 'user_spoken_languages'
+    ];
+
+    keep_user public."user"%ROWTYPE;
+    source_user public."user"%ROWTYPE;
+    source_email_id public.email.id%TYPE;
+    source_user_id public."user".id%TYPE;
+    reference record;
+    reference_count bigint;
+    blockers text[] := ARRAY[]::text[];
+    moved_devices integer;
+    changed_rows integer;
+    -- Drizzle interprets timestamp-without-time-zone values as UTC. Match the
+    -- API's nowZeroMs() precision so expired sessions are immediately invalid.
+    changed_at public.device.session_expiry%TYPE :=
+        date_trunc('second', clock_timestamp() AT TIME ZONE 'UTC');
+BEGIN
+    PERFORM set_config('lock_timeout', '5s', true);
+    IF writers_paused_and_buffers_drained IS DISTINCT FROM true THEN
+        RAISE EXCEPTION 'Maintenance required: pause writers and drain buffers before running this utility';
+    END IF;
+    IF expected_database IS NOT NULL AND current_database() <> expected_database THEN
+        RAISE EXCEPTION 'Connected database does not match expected_database';
+    END IF;
+    IF pg_is_in_recovery() THEN
+        RAISE EXCEPTION 'Run this utility on the writer database';
+    END IF;
+    IF keep_username = 'REPLACE_WITH_USERNAME' OR btrim(keep_username) = ''
+        OR source_email = 'REPLACE_WITH_EMAIL' OR btrim(source_email) = ''
+        OR keep_username IS NULL OR source_email IS NULL OR dry_run IS NULL
+        OR require_keep_phone IS NULL THEN
+        RAISE EXCEPTION 'Set keep_username, source_email, and non-null boolean options';
+    END IF;
+    source_email := lower(btrim(source_email));
+    IF expected_phone_last_two_digits NOT BETWEEN 0 AND 99 THEN
+        RAISE EXCEPTION 'expected_phone_last_two_digits must be between 0 and 99';
+    END IF;
+    IF retained_preference_tables IS NULL OR NOT retained_preference_tables <@
+        ARRAY['user_display_language', 'user_spoken_languages']::text[] THEN
+        RAISE EXCEPTION 'Only language preference tables may be retained';
+    END IF;
+
+    SELECT * INTO STRICT keep_user FROM public."user" WHERE username = keep_username;
+    SELECT id, user_id INTO STRICT source_email_id, source_user_id
+    FROM public.email WHERE email = source_email AND NOT is_deleted;
+    -- Match the API's user-lock ordering and prevent new FK references while
+    -- checking whether the source is empty. Recheck credentials after locking.
+    PERFORM id FROM public."user"
+    WHERE id IN (keep_user.id, source_user_id) ORDER BY id FOR UPDATE;
+    SELECT * INTO STRICT keep_user FROM public."user" WHERE id = keep_user.id;
+    SELECT * INTO STRICT source_user FROM public."user" WHERE id = source_user_id;
+    IF keep_user.username <> keep_username OR keep_user.is_deleted OR source_user.is_deleted THEN
+        RAISE EXCEPTION 'Both accounts must be active and the retained username must still match';
+    END IF;
+    IF (expected_keep_user_id IS NOT NULL AND keep_user.id <> expected_keep_user_id)
+        OR (expected_source_user_id IS NOT NULL AND source_user.id <> expected_source_user_id) THEN
+        RAISE EXCEPTION 'Resolved account IDs do not match the configured IDs';
+    END IF;
+    PERFORM id FROM public.email
+    WHERE user_id IN (keep_user.id, source_user.id) ORDER BY id FOR UPDATE;
+    IF NOT EXISTS (
+        SELECT 1 FROM public.email
+        WHERE id = source_email_id AND user_id = source_user.id
+            AND email = source_email AND NOT is_deleted AND type = 'primary'
+    ) THEN
+        RAISE EXCEPTION 'Source email must still be an active primary credential on the source account';
+    END IF;
+    PERFORM id FROM public.phone WHERE user_id = keep_user.id ORDER BY id FOR UPDATE;
+    IF (require_keep_phone OR expected_phone_hash IS NOT NULL
+        OR expected_phone_calling_code IS NOT NULL OR expected_phone_last_two_digits IS NOT NULL)
+        AND NOT EXISTS (
+            SELECT 1 FROM public.phone
+            WHERE user_id = keep_user.id AND NOT is_deleted
+                AND (expected_phone_hash IS NULL OR phone_hash = expected_phone_hash)
+                AND (expected_phone_calling_code IS NULL OR "countryCallingCode" = expected_phone_calling_code)
+                AND (expected_phone_last_two_digits IS NULL OR last_two_digits = expected_phone_last_two_digits)
+        ) THEN
+        RAISE EXCEPTION 'Retained account has no active phone matching the configured conditions';
+    END IF;
+    IF keep_user.id = source_user.id THEN
+        RAISE NOTICE 'Already linked: configured email belongs to the active retained account; identity and phone checks passed';
+        RETURN;
+    END IF;
+    IF (SELECT count(*) FROM public.email WHERE user_id = source_user.id) <> 1 THEN
+        RAISE EXCEPTION 'Source must have exactly one email row, including deleted credentials';
+    END IF;
+    IF EXISTS (SELECT 1 FROM public.email WHERE user_id = keep_user.id AND NOT is_deleted) THEN
+        RAISE EXCEPTION 'Retained account already has an active email; resolve that conflict separately';
+    END IF;
+    IF source_user.is_site_moderator OR source_user.is_site_org_admin OR source_user.is_imported
+        OR source_user.active_conversation_count <> 0 OR source_user.total_conversation_count <> 0
+        OR source_user.total_opinion_count <> 0 THEN
+        RAISE EXCEPTION 'Source has elevated roles, imported status, or nonzero content counters';
+    END IF;
+
+    -- Discover actual deployed FKs rather than assuming a fixed list of activity
+    -- tables. This also catches additional credentials and new feature tables.
+    FOR reference IN
+        SELECT DISTINCT ns.nspname AS schema_name, tbl.relname AS table_name,
+            col.attname AS column_name
+        FROM pg_constraint fk
+        JOIN pg_class tbl ON tbl.oid = fk.conrelid
+        JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+        CROSS JOIN LATERAL generate_subscripts(fk.conkey, 1) AS key(position)
+        JOIN pg_attribute col ON col.attrelid = fk.conrelid AND col.attnum = fk.conkey[key.position]
+        JOIN pg_attribute target ON target.attrelid = fk.confrelid AND target.attnum = fk.confkey[key.position]
+        WHERE fk.contype = 'f' AND fk.confrelid = 'public."user"'::regclass AND target.attname = 'id'
+        ORDER BY schema_name, table_name, column_name
+    LOOP
+        IF reference.schema_name = 'public' AND reference.column_name = 'user_id'
+            AND (reference.table_name IN ('email', 'device')
+                OR reference.table_name = ANY(retained_preference_tables)) THEN
+            CONTINUE;
+        END IF;
+        EXECUTE format('SELECT count(*) FROM %I.%I WHERE %I = $1',
+            reference.schema_name, reference.table_name, reference.column_name)
+        INTO reference_count USING source_user.id;
+        IF reference_count > 0 THEN
+            blockers := array_append(blockers, format('%I.%I.%I: %s row(s)',
+                reference.schema_name, reference.table_name, reference.column_name, reference_count));
+        END IF;
+    END LOOP;
+    IF cardinality(blockers) > 0 THEN
+        RAISE EXCEPTION 'Source account is not empty: %', array_to_string(blockers, '; ');
+    END IF;
+
+    RAISE NOTICE 'Account identity, credential, and empty-source checks passed';
+
+    -- The nested block rolls back the actual writes in dry-run mode, exercising
+    -- deployed constraints/triggers as well as the preconditions above.
+    BEGIN
+        UPDATE public.email SET user_id = keep_user.id, updated_at = changed_at
+        WHERE id = source_email_id AND user_id = source_user.id AND NOT is_deleted;
+        GET DIAGNOSTICS changed_rows = ROW_COUNT;
+        IF changed_rows <> 1 THEN
+            RAISE EXCEPTION 'Expected to transfer exactly one email, transferred %', changed_rows;
+        END IF;
+
+        UPDATE public.device
+        SET user_id = keep_user.id, session_expiry = changed_at, updated_at = changed_at
+        WHERE user_id = source_user.id;
+        GET DIAGNOSTICS moved_devices = ROW_COUNT;
+
+        -- OTP attempts are intentionally not FK-linked to users. Invalidate
+        -- pending attempts that could otherwise finish against the old identity.
+        UPDATE public.auth_attempt_email SET code_expiry = changed_at, updated_at = changed_at
+        WHERE user_id = source_user.id OR email = source_email;
+        UPDATE public.auth_attempt_phone SET code_expiry = changed_at, updated_at = changed_at
+        WHERE user_id = source_user.id;
+
+        UPDATE public."user"
+        SET is_deleted = true, deleted_at = changed_at, updated_at = changed_at
+        WHERE id = source_user.id;
+        INSERT INTO public.realtime_event_outbox (event_type, payload, created_at)
+        VALUES ('auth_state_changed', jsonb_build_object(
+            'userIds', jsonb_build_array(source_user.id, keep_user.id),
+            'reason', 'identity_changed'
+        ), changed_at);
+
+        -- Force deferred FK/constraint triggers before a dry-run rollback;
+        -- otherwise dry run could pass while the real transaction cannot commit.
+        SET CONSTRAINTS ALL IMMEDIATE;
+
+        IF dry_run THEN
+            RAISE EXCEPTION USING ERRCODE = 'ZX001', MESSAGE = 'dry run rollback';
+        END IF;
+    EXCEPTION WHEN SQLSTATE 'ZX001' THEN
+        RAISE NOTICE 'DRY RUN passed; all merge writes rolled back. Would move and expire % device(s).', moved_devices;
+    END;
+    IF NOT dry_run THEN
+        RAISE NOTICE 'MERGED. Moved and expired % device(s). Commit if editor autocommit is disabled.', moved_devices;
+    END IF;
+END
+$merge$;

--- a/services/api/tests/mergeEmptyEmailAccount.test.ts
+++ b/services/api/tests/mergeEmptyEmailAccount.test.ts
@@ -1,0 +1,467 @@
+// Run from services/api: pnpm vitest run tests/mergeEmptyEmailAccount.test.ts
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { setTimeout } from "node:timers/promises";
+import { afterAll, beforeAll, beforeEach, test } from "vitest";
+import { authStateChangedPayload } from "../src/service/authSession.js";
+import { readDbFixtureSql } from "./dbFixture.js";
+
+const keepId = "00000000-0000-4000-8000-000000000001";
+const sourceId = "00000000-0000-4000-8000-000000000002";
+const script = await readFile(
+    new URL("../../../scripts/merge-empty-email-account.sql", import.meta.url),
+    "utf8",
+);
+const schema = readDbFixtureSql("auth-otp.sql");
+let container: string | undefined;
+
+function executeSql(input: string): { output: string; messages: string } {
+    assert.ok(container);
+    const result = spawnSync(
+        "docker",
+        [
+            "exec",
+            "-i",
+            container,
+            "psql",
+            "-X",
+            "-U",
+            "postgres",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-Atq",
+        ],
+        {
+            input,
+            encoding: "utf8",
+            stdio: ["pipe", "pipe", "pipe"],
+            timeout: 20_000,
+        },
+    );
+    if (result.error !== undefined) throw result.error;
+    if (result.status !== 0) throw new Error(result.stderr);
+    return { output: result.stdout.trim(), messages: result.stderr };
+}
+
+function sql(input: string): string {
+    return executeSql(input).output;
+}
+
+function merge({
+    apply = false,
+    maintenanceConfirmed = true,
+    replacements = [],
+}: {
+    apply?: boolean;
+    maintenanceConfirmed?: boolean;
+    replacements?: readonly (readonly [string, string])[];
+} = {}): ReturnType<typeof executeSql> {
+    let query = script
+        .replace("'REPLACE_WITH_USERNAME'", "'kept-test-account'")
+        .replace("'REPLACE_WITH_EMAIL'", "'SOURCE@EXAMPLE.COM'")
+        .replace(
+            "dry_run boolean := true",
+            `dry_run boolean := ${String(!apply)}`,
+        )
+        .replace(
+            "writers_paused_and_buffers_drained boolean := false",
+            `writers_paused_and_buffers_drained boolean := ${String(maintenanceConfirmed)}`,
+        );
+    for (const [from, to] of replacements) {
+        assert.ok(query.includes(from));
+        query = query.replace(from, to);
+    }
+    return executeSql(query);
+}
+
+function snapshot(): string {
+    return sql(`
+    SELECT jsonb_build_object(
+      'users', (SELECT jsonb_agg(to_jsonb(u) ORDER BY id) FROM public."user" u),
+      'emails', (SELECT jsonb_agg(to_jsonb(e) ORDER BY id) FROM email e),
+      'devices', (SELECT jsonb_agg(to_jsonb(d) ORDER BY did_write) FROM device d),
+      'phones', (SELECT jsonb_agg(to_jsonb(p) ORDER BY id) FROM phone p),
+      'attempts', (SELECT jsonb_agg(to_jsonb(a) ORDER BY did_write) FROM auth_attempt_email a),
+      'phone_attempts', (SELECT jsonb_agg(to_jsonb(a) ORDER BY did_write) FROM auth_attempt_phone a),
+      'events', (SELECT jsonb_agg(to_jsonb(o) ORDER BY id) FROM realtime_event_outbox o)
+    );
+  `);
+}
+
+beforeAll(async () => {
+    container = execFileSync(
+        "docker",
+        [
+            "run",
+            "--detach",
+            "--rm",
+            "-e",
+            "POSTGRES_PASSWORD=test-only",
+            "postgres:16",
+        ],
+        { encoding: "utf8", timeout: 120_000 },
+    ).trim();
+    for (let attempt = 0; attempt < 60; attempt++) {
+        try {
+            sql("SELECT 1");
+            return;
+        } catch {
+            await setTimeout(500);
+        }
+    }
+    throw new Error("Isolated PostgreSQL container did not become ready");
+}, 120_000);
+
+afterAll(() => {
+    if (container)
+        execFileSync("docker", ["stop", container], {
+            stdio: "pipe",
+            timeout: 30_000,
+        });
+}, 30_000);
+
+beforeEach(() => {
+    // The generated auth fixture omits FKs. Add the relationships needed to test
+    // catalog discovery, including a future activity table and composite email FK.
+    sql(`
+    DROP SCHEMA public CASCADE;
+    CREATE SCHEMA public;
+    ${schema}
+    ALTER TABLE email ADD FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ALTER TABLE device ADD FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ALTER TABLE phone ADD FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ALTER TABLE zk_passport ADD FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    ALTER TABLE user_display_language ADD FOREIGN KEY (user_id) REFERENCES public."user"(id);
+    CREATE TABLE future_activity (author_id uuid REFERENCES public."user"(id));
+    CREATE TABLE email_delivery (
+      recipient_id uuid, email_id integer,
+      FOREIGN KEY (recipient_id, email_id) REFERENCES email(user_id, id)
+    );
+    INSERT INTO public."user" (id, username) VALUES
+      ('${keepId}', 'kept-test-account'), ('${sourceId}', 'source-test-account');
+    INSERT INTO email (email, type, user_id, email_reachability)
+      VALUES ('source@example.com', 'primary', '${sourceId}', 'safe');
+    INSERT INTO phone (user_id, last_two_digits, "countryCallingCode", phone_hash)
+      VALUES ('${keepId}', 23, '1', 'test-phone-hash');
+    INSERT INTO device (did_write, user_id, user_agent, session_expiry) VALUES
+      ('keep-device', '${keepId}', 'test', now() + interval '1 day'),
+      ('source-device', '${sourceId}', 'test', now() + interval '1 day');
+    INSERT INTO auth_attempt_email (did_write, type, email, user_id, user_agent, code, code_expiry, last_otp_sent_at)
+      VALUES ('source-device', 'login_known_device', 'source@example.com', '${sourceId}', 'test', 123456, now() + interval '1 day', now());
+    INSERT INTO auth_attempt_phone (did_write, type, user_id, user_agent, code, code_expiry, last_otp_sent_at, last_two_digits, "countryCallingCode", phone_hash)
+      VALUES ('source-device', 'register', '${sourceId}', 'test', 123456, now() + interval '1 day', now(), 23, '1', 'pending-test-phone');
+    INSERT INTO user_display_language (user_id, language_code) VALUES ('${sourceId}', 'fr');
+  `);
+});
+
+test("dry run rolls back all merge writes", () => {
+    const original = snapshot();
+    merge();
+    assert.equal(snapshot(), original);
+});
+
+test("apply retains identity, moves login, expires sessions and OTPs, and is repeatable", () => {
+    const retained = sql(
+        `SELECT to_jsonb(u) FROM public."user" u WHERE id = '${keepId}'`,
+    );
+    const keepSession = sql(
+        "SELECT to_jsonb(d) FROM device d WHERE did_write = 'keep-device'",
+    );
+    merge({ apply: true });
+    assert.equal(
+        sql(`SELECT to_jsonb(u) FROM public."user" u WHERE id = '${keepId}'`),
+        retained,
+    );
+    assert.equal(
+        sql("SELECT to_jsonb(d) FROM device d WHERE did_write = 'keep-device'"),
+        keepSession,
+    );
+    assert.equal(
+        sql("SELECT user_id FROM email WHERE email = 'source@example.com'"),
+        keepId,
+    );
+    assert.equal(sql("SELECT email_reachability FROM email"), "safe");
+    assert.equal(
+        sql(
+            `SELECT is_deleted AND deleted_at IS NOT NULL FROM public."user" WHERE id = '${sourceId}'`,
+        ),
+        "t",
+    );
+    assert.equal(
+        sql("SELECT user_id FROM device WHERE did_write = 'source-device'"),
+        keepId,
+    );
+    assert.equal(
+        sql(
+            "SELECT session_expiry <= now() FROM device WHERE did_write = 'source-device'",
+        ),
+        "t",
+    );
+    assert.equal(
+        sql("SELECT code_expiry <= now() FROM auth_attempt_email"),
+        "t",
+    );
+    assert.equal(
+        sql("SELECT code_expiry <= now() FROM auth_attempt_phone"),
+        "t",
+    );
+    const rawPayload: unknown = JSON.parse(
+        sql("SELECT payload FROM realtime_event_outbox"),
+    );
+    assert.deepEqual(authStateChangedPayload.parse(rawPayload), {
+        reason: "identity_changed",
+        userIds: [sourceId, keepId],
+    });
+    const merged = snapshot();
+    merge({ apply: true });
+    assert.equal(snapshot(), merged);
+});
+
+test("discovers activity in a new table even when content counters are zero", () => {
+    sql(`INSERT INTO future_activity VALUES ('${sourceId}')`);
+    const original = snapshot();
+    assert.throws(
+        () => merge({ apply: true }),
+        /future_activity.author_id: 1 row/,
+    );
+    assert.equal(snapshot(), original);
+});
+
+test("rejects another credential on the source", () => {
+    sql(`INSERT INTO phone (user_id, last_two_digits, "countryCallingCode", phone_hash)
+    VALUES ('${sourceId}', 12, '33', 'another-phone')`);
+    assert.throws(() => merge(), /phone.user_id: 1 row/);
+});
+
+test("rejects a destination email conflict", () => {
+    sql(
+        `INSERT INTO email (email, type, user_id) VALUES ('keep@example.com', 'primary', '${keepId}')`,
+    );
+    assert.throws(() => merge(), /already has an active email/);
+});
+
+test("checks configured identity and phone conditions", () => {
+    assert.throws(
+        () =>
+            merge({
+                replacements: [
+                    [
+                        "expected_source_user_id uuid := NULL",
+                        `expected_source_user_id uuid := '${keepId}'`,
+                    ],
+                ],
+            }),
+        /do not match the configured IDs/,
+    );
+    assert.throws(
+        () =>
+            merge({
+                replacements: [
+                    [
+                        "expected_phone_last_two_digits integer := NULL",
+                        "expected_phone_last_two_digits integer := 24",
+                    ],
+                ],
+            }),
+        /no active phone matching/,
+    );
+    merge({
+        replacements: [
+            [
+                "expected_phone_calling_code text := NULL",
+                "expected_phone_calling_code text := '1'",
+            ],
+            [
+                "expected_phone_last_two_digits integer := NULL",
+                "expected_phone_last_two_digits integer := 23",
+            ],
+        ],
+    });
+});
+
+test("can require language preferences to be absent", () => {
+    assert.throws(
+        () =>
+            merge({
+                replacements: [
+                    [
+                        "'user_display_language', 'user_spoken_languages'\n    ]",
+                        "]::text[]",
+                    ],
+                ],
+            }),
+        /user_display_language.user_id: 1 row/,
+    );
+});
+
+test("dry run exercises composite email constraints and rolls back on failure", () => {
+    sql(`INSERT INTO email_delivery SELECT user_id, id FROM email`);
+    const original = snapshot();
+    assert.throws(() => merge(), /violates foreign key constraint/);
+    assert.equal(snapshot(), original);
+});
+
+test("a late failure rolls back email, device, OTP and soft-delete writes", () => {
+    sql(
+        "ALTER TABLE realtime_event_outbox ADD CHECK (event_type <> 'auth_state_changed')",
+    );
+    const original = snapshot();
+    assert.throws(() => merge({ apply: true }), /violates check constraint/);
+    assert.equal(snapshot(), original);
+});
+
+test("requires explicit maintenance confirmation in both modes", () => {
+    const original = snapshot();
+    assert.throws(
+        () => merge({ maintenanceConfirmed: false }),
+        /Maintenance required/,
+    );
+    assert.throws(
+        () => merge({ apply: true, maintenanceConfirmed: false }),
+        /Maintenance required/,
+    );
+    assert.throws(
+        () =>
+            merge({
+                replacements: [
+                    [
+                        "writers_paused_and_buffers_drained boolean := true",
+                        "writers_paused_and_buffers_drained boolean := NULL",
+                    ],
+                ],
+            }),
+        /Maintenance required/,
+    );
+    assert.equal(snapshot(), original);
+});
+
+test.each(["Asia/Tokyo", "America/Los_Angeles"])(
+    "expires sessions and OTPs in API UTC time from %s",
+    (timezone) => {
+        merge({
+            apply: true,
+            replacements: [
+                ["DO $merge$", `SET TIME ZONE '${timezone}'; DO $merge$`],
+            ],
+        });
+        const utcNow =
+            "date_trunc('second', clock_timestamp() AT TIME ZONE 'UTC')";
+        assert.equal(
+            sql(
+                `SELECT session_expiry <= ${utcNow} FROM device WHERE did_write = 'source-device'`,
+            ),
+            "t",
+        );
+        assert.equal(
+            sql(`SELECT code_expiry <= ${utcNow} FROM auth_attempt_email`),
+            "t",
+        );
+        assert.equal(
+            sql(`SELECT code_expiry <= ${utcNow} FROM auth_attempt_phone`),
+            "t",
+        );
+        assert.equal(
+            sql(`SELECT created_at <= ${utcNow} FROM realtime_event_outbox`),
+            "t",
+        );
+        assert.equal(
+            sql(
+                "SELECT session_expiry = date_trunc('second', session_expiry) FROM device WHERE did_write = 'source-device'",
+            ),
+            "t",
+        );
+    },
+);
+
+test("already-linked still checks configured IDs, phone and active status", () => {
+    merge({ apply: true });
+    const merged = snapshot();
+    assert.throws(
+        () =>
+            merge({
+                replacements: [
+                    [
+                        "expected_keep_user_id uuid := NULL",
+                        `expected_keep_user_id uuid := '${sourceId}'`,
+                    ],
+                ],
+            }),
+        /do not match the configured IDs/,
+    );
+    assert.throws(
+        () =>
+            merge({
+                replacements: [
+                    [
+                        "expected_source_user_id uuid := NULL",
+                        `expected_source_user_id uuid := '${sourceId}'`,
+                    ],
+                ],
+            }),
+        /do not match the configured IDs/,
+    );
+    assert.throws(
+        () =>
+            merge({
+                replacements: [
+                    [
+                        "expected_phone_last_two_digits integer := NULL",
+                        "expected_phone_last_two_digits integer := 24",
+                    ],
+                ],
+            }),
+        /no active phone matching/,
+    );
+    merge({
+        replacements: [
+            [
+                "expected_keep_user_id uuid := NULL",
+                `expected_keep_user_id uuid := '${keepId}'`,
+            ],
+            [
+                "expected_source_user_id uuid := NULL",
+                `expected_source_user_id uuid := '${keepId}'`,
+            ],
+        ],
+    });
+    assert.equal(snapshot(), merged);
+    sql(`UPDATE public."user" SET is_deleted = true WHERE id = '${keepId}'`);
+    assert.throws(() => merge(), /Both accounts must be active/);
+});
+
+test("already-linked still requires an active primary email", () => {
+    merge({ apply: true });
+    sql("UPDATE email SET type = 'backup'");
+    assert.throws(() => merge(), /active primary credential/);
+});
+
+test("checks deferred constraints before reporting dry-run success", () => {
+    sql(
+        "ALTER TABLE email_delivery ALTER CONSTRAINT email_delivery_recipient_id_email_id_fkey DEFERRABLE INITIALLY DEFERRED",
+    );
+    sql("INSERT INTO email_delivery SELECT user_id, id FROM email");
+    const original = snapshot();
+    assert.throws(() => merge(), /violates foreign key constraint/);
+    assert.throws(
+        () => merge({ apply: true }),
+        /violates foreign key constraint/,
+    );
+    assert.equal(snapshot(), original);
+});
+
+test("utility notices do not print account identifiers", () => {
+    const results = [merge(), merge({ apply: true }), merge()];
+    for (const result of results) {
+        for (const identifier of [
+            "kept-test-account",
+            "source-test-account",
+            "source@example.com",
+            keepId,
+            sourceId,
+            "test-phone-hash",
+        ]) {
+            assert.equal(result.messages.includes(identifier), false);
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- Add a reusable maintenance-only SQL utility to move an empty account's primary email into a retained account, expire source sessions and OTPs, and soft-delete the source atomically.
- Require an explicit operator assertion that writers are paused and buffers are drained; document the maintenance procedure and its limits.
- Check deployed foreign-key references, credential conflicts, configured identities, and phone conditions, including on already-linked runs.
- Use schema-derived SQL types and UTC whole-second timestamps, and validate deferred constraints before dry-run rollback.
- Keep configuration as placeholders and notices free of account identifiers. Examples and tests use synthetic identities only.
- Add TypeScript regression tests that reuse the API auth fixture and auth-state payload schema.

## Verification
- API TypeScript checking passed through the service test runner.
- pnpm exec vitest run tests/mergeEmptyEmailAccount.test.ts: 16 tests passed against isolated PostgreSQL 16.
- pnpm exec eslint --no-ignore tests/mergeEmptyEmailAccount.test.ts: passed.
- Prettier checks for the test and guide: passed.
- Git whitespace checks and review of all committed content and publication metadata: passed.

## Deployment
Deploy: none

The utility is run manually during a maintenance window. The maintenance flag is an operator assertion, not an automated check of in-memory or Valkey buffers.