### PR TITLE
fix(tooling): harden schema and sync scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,32 +74,42 @@ dev-sync-backend: dev-sync-ts-backend
 sync-python-artifacts: sync-python-models sync-python-shared-types sync-import-worker-contracts
 
 sync-python-models: sync-ts-backend
-	cd services/api && npx drizzle-kit export > /tmp/agora-schema.sql
-	cd services/api && npx tsx scripts/sync-schema-cli.ts \
+	set -eu; \
+	cd services/api; \
+	schema_sql=$$(mktemp "$${TMPDIR:-/tmp}/agora-schema.XXXXXX"); \
+	trap 'rm -f "$$schema_sql"' 0; \
+	trap 'exit 1' HUP INT TERM; \
+	npx drizzle-kit export > "$$schema_sql"; \
+	npx tsx scripts/sync-schema-cli.ts \
 		--service scoring-worker \
 		--schema-ts ../shared-backend/src/schema.ts \
-		--sql /tmp/agora-schema.sql \
-		--output ../scoring-worker/src/scoring_worker/generated_models.py
-	cd services/api && npx tsx scripts/sync-schema-cli.ts \
+		--sql "$$schema_sql" \
+		--output ../scoring-worker/src/scoring_worker/generated_models.py; \
+	npx tsx scripts/sync-schema-cli.ts \
 		--service shared-analysis-worker \
 		--schema-ts ../shared-backend/src/schema.ts \
-		--sql /tmp/agora-schema.sql \
-		--output ../shared-analysis-worker/src/agora_analysis_worker_shared/generated_models.py
-	cd services/api && npx tsx scripts/sync-schema-cli.ts \
+		--sql "$$schema_sql" \
+		--output ../shared-analysis-worker/src/agora_analysis_worker_shared/generated_models.py; \
+	npx tsx scripts/sync-schema-cli.ts \
 		--service import-worker \
 		--schema-ts ../shared-backend/src/schema.ts \
-		--sql /tmp/agora-schema.sql \
-		--output ../import-worker/src/import_worker/generated_models.py
-	cd services/api && npx tsx scripts/sync-schema-cli.ts \
+		--sql "$$schema_sql" \
+		--output ../import-worker/src/import_worker/generated_models.py; \
+	npx tsx scripts/sync-schema-cli.ts \
 		--service content-translation-worker \
 		--schema-ts ../shared-backend/src/schema.ts \
-		--sql /tmp/agora-schema.sql \
+		--sql "$$schema_sql" \
 		--output ../content-translation-worker/src/content_translation_worker/generated_models.py
 
-sync-api-test-db-fixtures:
-	cd services/api && npx drizzle-kit export > /tmp/agora-schema.sql
-	cd services/api && npx tsx scripts/sync-api-test-schema-fixtures-cli.ts \
-		--sql /tmp/agora-schema.sql \
+sync-api-test-db-fixtures: sync-ts-backend
+	set -eu; \
+	cd services/api; \
+	schema_sql=$$(mktemp "$${TMPDIR:-/tmp}/agora-schema.XXXXXX"); \
+	trap 'rm -f "$$schema_sql"' 0; \
+	trap 'exit 1' HUP INT TERM; \
+	npx drizzle-kit export > "$$schema_sql"; \
+	npx tsx scripts/sync-api-test-schema-fixtures-cli.ts \
+		--sql "$$schema_sql" \
 		--config tests/fixtures/db/schema-fixtures.json \
 		--output-dir tests/fixtures/db
 

--- a/scripts/rename-sql-migration.test.mjs
+++ b/scripts/rename-sql-migration.test.mjs
@@ -1,0 +1,458 @@
+// Run with node --test scripts/rename-sql-migration.test.mjs. No database tooling.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { resolve } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+
+const temporaryDirectory = resolve(tmpdir(), "opencode");
+const script = resolve(
+  import.meta.dirname,
+  "../services/api/scripts/rename_sql_migration_file.sh"
+);
+
+async function contents(directory) {
+  const result = {};
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = resolve(directory, entry.name);
+    result[entry.name] = entry.isDirectory()
+      ? await contents(path)
+      : await readFile(path, "utf8");
+  }
+  return result;
+}
+
+async function fixture(t) {
+  await mkdir(temporaryDirectory, { recursive: true });
+  const directory = await mkdtemp(
+    resolve(temporaryDirectory, "rename sql migration-")
+  );
+  t.after(async () => await rm(directory, { recursive: true, force: true }));
+  const service = resolve(directory, "fixture service");
+  const source = resolve(service, "drizzle");
+  const flyway = resolve(service, "database/flyway");
+  const bin = resolve(directory, "stub commands");
+  for (const path of [source, flyway, bin, resolve(service, "scripts")]) {
+    await mkdir(path, { recursive: true });
+  }
+  const copiedScript = resolve(service, "scripts/rename_sql_migration_file.sh");
+  await copyFile(script, copiedScript);
+
+  const stub = resolve(bin, "command.mjs");
+  await writeFile(
+    stub,
+    `
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, readdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+const [command, ...args] = process.argv.slice(2);
+if (process.env.FAIL_COMMAND === command) {
+    console.error(command + " failed synthetically");
+    process.exit(73);
+}
+if (command === "rsync") {
+    const source = args.at(-2);
+    const destination = args.at(-1);
+    const include = args[args.indexOf("--include") + 1];
+    assert.ok(args.includes('--exclude=*'));
+    assert.ok(["*.sql", "[0-9][0-9][0-9][0-9]_*.sql"].includes(include));
+    const pattern = include === "*.sql" ? /\\.sql$/ : /^[0-9]{4}_.*\\.sql$/;
+    // Deliberately reverse copy order: processing order must come from the script.
+    for (const entry of readdirSync(source, { withFileTypes: true }).reverse()) {
+        if (entry.isFile() && pattern.test(entry.name)) {
+            copyFileSync(resolve(source, entry.name), resolve(destination, entry.name));
+        }
+    }
+} else if (command === "mv") {
+    if (process.env.MV_COLLISION === "1") {
+        writeFileSync(args.at(-1), "-- concurrent Flyway migration\\n");
+    }
+    const result = spawnSync("/bin/mv", args, { stdio: "inherit" });
+    if (result.error) throw result.error;
+    process.exit(result.status ?? 1);
+} else {
+    throw new Error("Unexpected stub command: " + command);
+}
+`
+  );
+  for (const command of ["rsync", "mv"]) {
+    const path = resolve(bin, command);
+    await writeFile(
+      path,
+      `#!/bin/bash\nexec "$TEST_NODE" "$TEST_COMMAND_STUB" ${command} "$@"\n`
+    );
+    await chmod(path, 0o755);
+  }
+
+  async function seed({ drizzle = {}, migrations = {} }) {
+    for (const [root, files] of [
+      [source, drizzle],
+      [flyway, migrations],
+    ]) {
+      for (const [name, sql] of Object.entries(files)) {
+        const path = resolve(root, name);
+        await mkdir(resolve(path, ".."), { recursive: true });
+        await writeFile(path, sql);
+      }
+    }
+  }
+
+  async function run({ cwd = service, args = ["drizzle/"], env = {} } = {}) {
+    const sourceBefore = await contents(source);
+    const result = spawnSync("/bin/bash", [copiedScript, ...args], {
+      cwd,
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH}`,
+        TEST_NODE: process.execPath,
+        TEST_COMMAND_STUB: stub,
+        FAIL_COMMAND: "",
+        MV_COLLISION: "",
+        ...env,
+      },
+    });
+    assert.ifError(result.error);
+    assert.equal(result.signal, null);
+    assert.deepEqual(
+      await contents(source),
+      sourceBefore,
+      "Drizzle source changed"
+    );
+    return result;
+  }
+
+  return { directory, service, source, flyway, seed, run };
+}
+
+function succeeded(result) {
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+}
+
+test("allocates distinct increasing versions in stable order and is idempotent", async (t) => {
+  const f = await fixture(t);
+  const historical = {
+    "V0000__origin.sql": "-- original zero\n",
+    "V0086__historical.sql": "-- immutable deployed SQL\n",
+    "V0086.1__backfill.sql": "-- immutable backfill\n",
+  };
+  await f.seed({
+    drizzle: {
+      "0000_origin.sql": "-- historical source may differ\n",
+      "0002_historical.sql": "-- renumbered historical source\n",
+      "0005_zebra.sql": "SELECT 5;\n",
+      "0003_alpha.sql": "SELECT 3;\n",
+      "0004_beta.sql": "SELECT 4;\n",
+      "0095_jump.sql": "SELECT 95;\n",
+      "0096_after_jump.sql": "SELECT 96;\n",
+      "V0086__historical.sql": "-- must never be copied\n",
+      "meta/_journal.json": "{}\n",
+      "nested/0999_ignored.sql": "-- not a root migration\n",
+    },
+    migrations: historical,
+  });
+  const result = await f.run();
+  succeeded(result);
+  assert.equal(result.stdout.match(/Renamed /g)?.length, 5);
+  const expected = {
+    ...historical,
+    "V0087__alpha.sql": "SELECT 3;\n",
+    "V0088__beta.sql": "SELECT 4;\n",
+    "V0089__zebra.sql": "SELECT 5;\n",
+    "V0095__jump.sql": "SELECT 95;\n",
+    "V0096__after_jump.sql": "SELECT 96;\n",
+  };
+  assert.deepEqual(await contents(f.flyway), expected);
+  const repeated = await f.run();
+  succeeded(repeated);
+  assert.doesNotMatch(repeated.stdout, /Renamed /);
+  assert.deepEqual(await contents(f.flyway), expected);
+});
+
+test("matches literal complete descriptions only among actual Flyway names", async (t) => {
+  const f = await fixture(t);
+  const historical = {
+    "V0020__prefix_cat_suffix.sql": "-- unrelated substring\n",
+    "V0021__axb.sql": "-- unrelated regex match\n",
+    "V0022__literal[ab].sql": "-- exact literal historical match\n",
+    "notes__plain.sql": "-- unversioned SQL\n",
+    "V0023__directory.sql/keep.txt": "not a migration",
+  };
+  await f.seed({
+    drizzle: {
+      "0001_cat.sql": "SELECT 1;\n",
+      "0002_a.b.sql": "SELECT 2;\n",
+      "0003_literal[ab].sql": "-- source is retained\n",
+      "0004_plain.sql": "SELECT 4;\n",
+      "0005_directory.sql": "SELECT 5;\n",
+      "0006_cat_suffix.sql": "SELECT 6;\n",
+    },
+    migrations: historical,
+  });
+  succeeded(await f.run());
+  assert.deepEqual(await contents(f.flyway), {
+    "V0020__prefix_cat_suffix.sql": historical["V0020__prefix_cat_suffix.sql"],
+    "V0021__axb.sql": historical["V0021__axb.sql"],
+    "V0022__literal[ab].sql": historical["V0022__literal[ab].sql"],
+    "notes__plain.sql": historical["notes__plain.sql"],
+    "V0023__directory.sql": { "keep.txt": "not a migration" },
+    "V0023__cat.sql": "SELECT 1;\n",
+    "V0024__a.b.sql": "SELECT 2;\n",
+    "V0025__plain.sql": "SELECT 4;\n",
+    "V0026__directory.sql": "SELECT 5;\n",
+    "V0027__cat_suffix.sql": "SELECT 6;\n",
+  });
+});
+
+test("does not skip a newer index reusing an older random description", async (t) => {
+  const f = await fixture(t);
+  await f.seed({
+    drizzle: {
+      "0003_same_name.sql": "-- first pending\n",
+      "0004_same_name.sql": "-- second pending\n",
+    },
+    migrations: {
+      "V0002__same_name.sql": "-- old migration\n",
+      "V0086__latest.sql": "-- latest\n",
+    },
+  });
+  succeeded(await f.run());
+  const expected = {
+    "V0002__same_name.sql": "-- old migration\n",
+    "V0086__latest.sql": "-- latest\n",
+    "V0087__same_name.sql": "-- first pending\n",
+    "V0088__same_name.sql": "-- second pending\n",
+  };
+  assert.deepEqual(await contents(f.flyway), expected);
+  succeeded(await f.run());
+  assert.deepEqual(await contents(f.flyway), expected);
+});
+
+for (const scenario of [
+  {
+    name: "one renumbered historical file cannot hide a newer same-description source",
+    drizzle: {
+      "0088_same.sql": "-- new SQL\n",
+      "0087_same.sql": "-- historical source\n",
+    },
+    migrations: { "V0089__same.sql": "-- immutable historical copy\n" },
+    added: { "V0090__same.sql": "-- new SQL\n" },
+  },
+  {
+    name: "each duplicate historical description, including fractions, is consumed only once",
+    drizzle: {
+      "0089_same.sql": "-- new SQL\n",
+      "0088_same.sql": "-- third historical source\n",
+      "0087_same.sql": "-- second historical source\n",
+      "0086_same.sql": "-- first historical source\n",
+    },
+    migrations: {
+      "V0089__same.sql": "-- immutable main version\n",
+      "V0089.2__same.sql": "-- immutable fraction two\n",
+      "V0089.10__same.sql": "-- immutable fraction ten\n",
+    },
+    added: { "V0090__same.sql": "-- new SQL\n" },
+  },
+  {
+    name: "matching consumes lower major versions before higher fractional versions",
+    drizzle: {
+      "0091_same.sql": "-- new SQL\n",
+      "0090_same.sql": "-- later historical source\n",
+      "0087_same.sql": "-- earlier historical source\n",
+    },
+    migrations: {
+      "V0090.1__same.sql": "-- immutable later copy\n",
+      "V0089__same.sql": "-- immutable earlier copy\n",
+    },
+    added: { "V0091__same.sql": "-- new SQL\n" },
+  },
+]) {
+  test(`${scenario.name}; reruns are idempotent`, async (t) => {
+    const f = await fixture(t);
+    await f.seed(scenario);
+    const first = await f.run();
+    succeeded(first);
+    assert.equal(first.stdout.match(/Renamed /g)?.length, 1);
+    const expected = { ...scenario.migrations, ...scenario.added };
+    assert.deepEqual(await contents(f.flyway), expected);
+    for (let repeat = 0; repeat < 2; repeat++) {
+      const result = await f.run();
+      succeeded(result);
+      assert.doesNotMatch(result.stdout, /Renamed /);
+      assert.deepEqual(await contents(f.flyway), expected);
+    }
+  });
+}
+
+test("preserves the exact sturdy_serpent_society tool-upgrade exception", async (t) => {
+  const f = await fixture(t);
+  await f.seed({
+    drizzle: {
+      "0000_sturdy_serpent_society.sql": "-- tool-upgrade baseline\n",
+      "0001_sturdy_serpent_society_extra.sql": "SELECT 1;\n",
+    },
+  });
+  succeeded(await f.run());
+  assert.deepEqual(await contents(f.flyway), {
+    "V0001__sturdy_serpent_society_extra.sql": "SELECT 1;\n",
+  });
+  succeeded(await f.run());
+  assert.deepEqual(await contents(f.flyway), {
+    "V0001__sturdy_serpent_society_extra.sql": "SELECT 1;\n",
+  });
+});
+
+test("counts fractional major versions and ignores invalid prefixes and nested SQL", async (t) => {
+  const f = await fixture(t);
+  const ignored = {
+    "prefixV9999__ignored.sql": "-- anchored prefix required\n",
+    "V999__ignored.sql": "-- four digits required\n",
+    "V99999__ignored.sql": "-- only four digits\n",
+    "V9999x1__ignored.sql": "-- literal decimal point required\n",
+    "V9999.1.2__ignored.sql": "-- only one fraction\n",
+    "V9999_ignored.sql": "-- double underscore required\n",
+    "V9999__ignored.sql.bak": "-- SQL extension required\n",
+    "plain.sql": "-- no version\n",
+    archive: { "V9999__ignored.sql": "-- root files only\n" },
+  };
+  const { archive, ...rootFiles } = ignored;
+  await f.seed({
+    drizzle: {
+      "0007_fraction_match.sql": "-- historical fractional match\n",
+      "0008_pending.sql": "SELECT 8;\n",
+      "0087_fraction_match.sql": "SELECT 87;\n",
+      "008_fraction_match.sql": "-- invalid source index\n",
+      "00008_fraction_match.sql": "-- invalid source index\n",
+    },
+    migrations: {
+      ...rootFiles,
+      "archive/V9999__ignored.sql": archive["V9999__ignored.sql"],
+      "V0086.1__fraction_match.sql": "-- highest valid major\n",
+      "V0009__lower.sql": "-- lower version sorted later\n",
+    },
+  });
+  succeeded(await f.run());
+  assert.deepEqual(await contents(f.flyway), {
+    ...ignored,
+    "V0086.1__fraction_match.sql": "-- highest valid major\n",
+    "V0009__lower.sql": "-- lower version sorted later\n",
+    "V0087__pending.sql": "SELECT 8;\n",
+    "V0088__fraction_match.sql": "SELECT 87;\n",
+  });
+});
+
+test("supports empty Flyway directories and paths with spaces outside service cwd", async (t) => {
+  const f = await fixture(t);
+  succeeded(await f.run());
+  await f.seed({ drizzle: { "0008_two words.sql": "SELECT 8;\n" } });
+  succeeded(await f.run({ cwd: f.directory, args: [f.source] }));
+  assert.deepEqual(await contents(f.flyway), {
+    "V0008__two words.sql": "SELECT 8;\n",
+  });
+});
+
+test("falls back to a numeric maximum when only unversioned SQL exists", async (t) => {
+  const f = await fixture(t);
+  await f.seed({
+    drizzle: { "0008_pending.sql": "SELECT 8;\n" },
+    migrations: { "plain.sql": "-- not a version\n" },
+  });
+  succeeded(await f.run());
+  assert.deepEqual(await contents(f.flyway), {
+    "plain.sql": "-- not a version\n",
+    "V0008__pending.sql": "SELECT 8;\n",
+  });
+});
+
+for (const command of ["rsync", "mv"]) {
+  test(`${command} failure exits nonzero without claiming a rename; retry is safe`, async (t) => {
+    const f = await fixture(t);
+    await f.seed({
+      drizzle: { "0001_pending.sql": "SELECT 1;\n" },
+      migrations: { "V0086__existing.sql": "-- immutable\n" },
+    });
+    const result = await f.run({ env: { FAIL_COMMAND: command } });
+    assert.equal(result.status, 73);
+    assert.match(result.stderr, new RegExp(`${command} failed synthetically`));
+    assert.doesNotMatch(result.stdout, /Renamed /);
+    assert.deepEqual(await contents(f.flyway), {
+      "V0086__existing.sql": "-- immutable\n",
+      ...(command === "mv" ? { "0001_pending.sql": "SELECT 1;\n" } : {}),
+    });
+    succeeded(await f.run());
+    assert.deepEqual(await contents(f.flyway), {
+      "V0086__existing.sql": "-- immutable\n",
+      "V0087__pending.sql": "SELECT 1;\n",
+    });
+  });
+}
+
+test("never overwrites a destination appearing before mv, even when mv -n exits zero", async (t) => {
+  const f = await fixture(t);
+  await f.seed({ drizzle: { "0008_pending.sql": "SELECT 8;\n" } });
+  const result = await f.run({ env: { MV_COLLISION: "1" } });
+  assert.notEqual(result.status, 0);
+  assert.doesNotMatch(result.stdout, /Renamed /);
+  assert.deepEqual(await contents(f.flyway), {
+    "0008_pending.sql": "SELECT 8;\n",
+    "V0008__pending.sql": "-- concurrent Flyway migration\n",
+  });
+});
+
+test("refuses to allocate beyond the four-digit main-version contract", async (t) => {
+  const f = await fixture(t);
+  await f.seed({
+    drizzle: { "0001_pending.sql": "SELECT 1;\n" },
+    migrations: { "V9999.1__last.sql": "-- immutable\n" },
+  });
+  const result = await f.run();
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /No four-digit Flyway version/);
+  assert.doesNotMatch(result.stdout, /Renamed /);
+  assert.deepEqual(await contents(f.flyway), {
+    "0001_pending.sql": "SELECT 1;\n",
+    "V9999.1__last.sql": "-- immutable\n",
+  });
+});
+
+test("does not move pending SQL into a directory named like its destination", async (t) => {
+  const f = await fixture(t);
+  await f.seed({
+    drizzle: { "0008_pending.sql": "SELECT 8;\n" },
+    migrations: { "V0008__pending.sql/keep.txt": "untouched" },
+  });
+  const result = await f.run();
+  assert.notEqual(result.status, 0);
+  assert.doesNotMatch(result.stdout, /Renamed /);
+  assert.deepEqual(await contents(f.flyway), {
+    "0008_pending.sql": "SELECT 8;\n",
+    "V0008__pending.sql": { "keep.txt": "untouched" },
+  });
+});
+
+test("rejects missing sources and using Flyway itself as the source", async (t) => {
+  const f = await fixture(t);
+  await f.seed({
+    migrations: { "0001_pending.sql": "-- do not delete source\n" },
+  });
+  for (const args of [[], ["missing directory"], [f.flyway]]) {
+    const result = await f.run({ args });
+    assert.notEqual(result.status, 0);
+    assert.doesNotMatch(result.stdout, /Renamed /);
+  }
+  assert.deepEqual(await contents(f.flyway), {
+    "0001_pending.sql": "-- do not delete source\n",
+  });
+});

--- a/scripts/schema-export.test.mjs
+++ b/scripts/schema-export.test.mjs
@@ -1,0 +1,265 @@
+// Run with node --test scripts/schema-export.test.mjs. No real schema or DB tooling.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const targets = ["sync-python-models", "sync-api-test-db-fixtures"];
+const models = [
+  ["scoring-worker", "scoring_worker"],
+  ["shared-analysis-worker", "agora_analysis_worker_shared"],
+  ["import-worker", "import_worker"],
+  ["content-translation-worker", "content_translation_worker"],
+];
+
+async function fixture(t) {
+  const parent = resolve(tmpdir(), "opencode");
+  await mkdir(parent, { recursive: true });
+  const root = await realpath(
+    await mkdtemp(resolve(parent, "schema export test-"))
+  );
+  t.after(async () => await rm(root, { recursive: true, force: true }));
+  const bin = resolve(root, "stub commands");
+  const scratch = resolve(root, "scratch sql");
+  const events = resolve(root, "events.jsonl");
+  for (const path of [
+    bin,
+    scratch,
+    resolve(root, "barrier"),
+    resolve(root, "services/api"),
+    resolve(root, "services/shared-backend"),
+  ]) {
+    await mkdir(path, { recursive: true });
+  }
+  await copyFile(
+    resolve(import.meta.dirname, "../Makefile"),
+    resolve(root, "Makefile")
+  );
+  await writeFile(events, "");
+  const stub = resolve(bin, "command.mjs");
+  await writeFile(
+    stub,
+    `
+import assert from "node:assert/strict";
+import { appendFileSync, existsSync, fstatSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+const [command, ...args] = process.argv.slice(2);
+const root = process.env.TEST_ROOT;
+const record = (event) => appendFileSync(resolve(root, "events.jsonl"), JSON.stringify(event) + "\\n");
+const fail = (stage) => {
+    if (process.env.FAIL_STAGE === stage) {
+        console.error("Synthetic failure: " + stage);
+        process.exit(73);
+    }
+};
+if (command === "pnpm") {
+    assert.equal(process.cwd(), resolve(root, "services/shared-backend"));
+    assert.deepEqual(args, ["run", "sync"]);
+    fail("sync");
+    await delay(100);
+    writeFileSync(resolve(root, "backend-synced"), "synced");
+    record({ kind: "sync" });
+} else if (command === "npx") {
+    assert.equal(process.cwd(), resolve(root, "services/api"));
+    assert.ok(existsSync(resolve(root, "backend-synced")), "export requires completed backend sync");
+    if (args[0] === "drizzle-kit") {
+        assert.deepEqual(args, ["drizzle-kit", "export"]);
+        // Identify redirected stdout portably without Linux-only /proc or readlink.
+        const output = fstatSync(1);
+        const sql = readdirSync(process.env.TMPDIR).map(name => resolve(process.env.TMPDIR, name))
+            .find(path => {
+                const file = statSync(path);
+                return file.dev === output.dev && file.ino === output.ino;
+            });
+        assert.ok(sql, "export must use the fixture scratch directory");
+        const content = "synthetic export " + process.pid;
+        writeFileSync(1, content);
+        record({ kind: "export", sql, content });
+        fail("export");
+        writeFileSync(resolve(root, "barrier", String(process.pid)), "ready");
+        const deadline = Date.now() + 5000;
+        while (readdirSync(resolve(root, "barrier")).length < Number(process.env.EXPORT_COUNT)) {
+            assert.ok(Date.now() < deadline, "exports did not overlap");
+            await delay(10);
+        }
+    } else {
+        assert.equal(args[0], "tsx");
+        assert.ok(["scripts/sync-schema-cli.ts", "scripts/sync-api-test-schema-fixtures-cli.ts"].includes(args[1]));
+        const sql = args[args.indexOf("--sql") + 1];
+        const stage = args[1] === "scripts/sync-schema-cli.ts"
+            ? args[args.indexOf("--service") + 1] : "fixtures";
+        record({ kind: "consume", stage, args, sql, content: readFileSync(sql, "utf8") });
+        fail(stage);
+    }
+} else {
+    throw new Error("Unexpected command: " + command);
+}
+`
+  );
+  for (const command of ["pnpm", "npx"]) {
+    const path = resolve(bin, command);
+    await writeFile(
+      path,
+      `#!/bin/sh\nexec "$TEST_NODE" "$TEST_STUB" ${command} "$@"\n`
+    );
+    await chmod(path, 0o755);
+  }
+  async function run({
+    goals = targets,
+    failStage = "",
+    missingScratch = false,
+  } = {}) {
+    const result = spawnSync("make", ["-j2", ...goals], {
+      cwd: root,
+      encoding: "utf8",
+      timeout: 15_000,
+      env: {
+        ...process.env,
+        MAKEFLAGS: "",
+        MFLAGS: "",
+        MAKEOVERRIDES: "",
+        MAKEFILES: "",
+        PATH: `${bin}:${process.env.PATH}`,
+        TMPDIR: missingScratch ? resolve(scratch, "missing") : scratch,
+        TEST_ROOT: root,
+        TEST_NODE: process.execPath,
+        TEST_STUB: stub,
+        FAIL_STAGE: failStage,
+        EXPORT_COUNT: String(goals.length),
+      },
+    });
+    assert.ifError(result.error);
+    assert.equal(result.signal, null);
+    assert.deepEqual(
+      await readdir(scratch),
+      [],
+      "scratch SQL must be cleaned up"
+    );
+    const log = (await readFile(events, "utf8")).trim();
+    return {
+      ...result,
+      events: log ? log.split("\n").map((line) => JSON.parse(line)) : [],
+    };
+  }
+  return { run };
+}
+
+test("parallel targets use distinct exports after backend sync and preserve consumer arguments", async (t) => {
+  const f = await fixture(t);
+  const result = await f.run();
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(result.events[0].kind, "sync");
+  assert.equal(
+    result.events.filter((event) => event.kind === "sync").length,
+    1
+  );
+  const exports = result.events.filter((event) => event.kind === "export");
+  assert.equal(exports.length, 2);
+  assert.notEqual(exports[0].sql, exports[1].sql);
+  const consumers = result.events.filter((event) => event.kind === "consume");
+  assert.equal(consumers.length, 5);
+  // Both exporters must reach the barrier before either target consumes SQL.
+  assert.deepEqual(
+    result.events.slice(1, 3).map((event) => event.kind),
+    ["export", "export"]
+  );
+  for (const consumer of consumers) {
+    assert.equal(
+      consumer.content,
+      exports.find((event) => event.sql === consumer.sql)?.content
+    );
+  }
+  const python = consumers.filter((event) => event.stage !== "fixtures");
+  const fixtures = consumers.find((event) => event.stage === "fixtures");
+  assert.notEqual(fixtures.sql, python[0].sql);
+  assert.deepEqual(
+    python.map((event) => event.stage),
+    models.map(([service]) => service)
+  );
+  for (const [index, [service, module]] of models.entries()) {
+    assert.equal(python[index].sql, python[0].sql);
+    assert.deepEqual(python[index].args, [
+      "tsx",
+      "scripts/sync-schema-cli.ts",
+      "--service",
+      service,
+      "--schema-ts",
+      "../shared-backend/src/schema.ts",
+      "--sql",
+      python[0].sql,
+      "--output",
+      `../${service}/src/${module}/generated_models.py`,
+    ]);
+  }
+  assert.deepEqual(fixtures.args, [
+    "tsx",
+    "scripts/sync-api-test-schema-fixtures-cli.ts",
+    "--sql",
+    fixtures.sql,
+    "--config",
+    "tests/fixtures/db/schema-fixtures.json",
+    "--output-dir",
+    "tests/fixtures/db",
+  ]);
+});
+
+for (const target of targets) {
+  const stages =
+    target === "sync-python-models"
+      ? models.map(([service]) => service)
+      : ["fixtures"];
+  for (const failStage of ["sync", "export", ...stages]) {
+    test(`${target}: ${failStage} failure stops the recipe and cleans scratch SQL`, async (t) => {
+      const f = await fixture(t);
+      const result = await f.run({ goals: [target], failStage });
+      assert.notEqual(result.status, 0);
+      assert.match(
+        result.stderr,
+        new RegExp(`Synthetic failure: ${failStage}`)
+      );
+      const consumers = result.events.filter(
+        (event) => event.kind === "consume"
+      );
+      assert.deepEqual(
+        consumers.map((event) => event.stage),
+        stages.slice(0, stages.indexOf(failStage) + 1)
+      );
+      assert.equal(
+        result.events.filter((event) => event.kind === "export").length,
+        failStage === "sync" ? 0 : 1
+      );
+    });
+  }
+  test(`${target}: mktemp failure prevents export`, async (t) => {
+    const f = await fixture(t);
+    const result = await f.run({ goals: [target], missingScratch: true });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /mktemp/);
+    assert.deepEqual(result.events, [{ kind: "sync" }]);
+  });
+  test(`${target}: standalone invocation syncs backend and cleans scratch SQL`, async (t) => {
+    const f = await fixture(t);
+    const result = await f.run({ goals: [target] });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(result.events[0].kind, "sync");
+    assert.deepEqual(
+      result.events
+        .filter((event) => event.kind === "consume")
+        .map((event) => event.stage),
+      stages
+    );
+  });
+}

--- a/scripts/shared-script.test.mjs
+++ b/scripts/shared-script.test.mjs
@@ -163,22 +163,24 @@ test("source sync is repeatable, warns correctly, deletes stale copies and keeps
   );
 });
 
-test("shared-backend stops on an rsync failure instead of reporting success", async (t) => {
-  const root = await syncFixture(t);
-  const bin = resolve(root, "bin");
-  await put({
-    path: resolve(bin, "rsync"),
-    content: "#!/bin/sh\nexit 23\n",
-    executable: true,
+for (const service of ["shared", "shared-backend", "shared-app-api"]) {
+  test(`${service} stops on an rsync failure instead of reporting success`, async (t) => {
+    const root = await syncFixture(t);
+    const bin = resolve(root, "bin");
+    await put({
+      path: resolve(bin, "rsync"),
+      content: "#!/bin/sh\nexit 23\n",
+      executable: true,
+    });
+    const result = runSync({
+      root,
+      service,
+      env: { PATH: `${bin}:${process.env.PATH}` },
+    });
+    assert.equal(result.status, 23, result.stderr);
+    assert.doesNotMatch(result.stdout, /sync complete|Universal sync complete/);
   });
-  const result = runSync({
-    root,
-    service: "shared-backend",
-    env: { PATH: `${bin}:${process.env.PATH}` },
-  });
-  assert.equal(result.status, 23, result.stderr);
-  assert.doesNotMatch(result.stdout, /sync complete|Universal sync complete/);
-});
+}
 
 function shellQuote(value) {
   return `'${value.replaceAll("'", "'\\''")}'`;

--- a/services/api/scripts/rename_sql_migration_file.sh
+++ b/services/api/scripts/rename_sql_migration_file.sh
@@ -1,65 +1,91 @@
 #!/bin/bash
 
-# Provide the directory path as an argument to the script
-directory="$1"
+set -euo pipefail
+export LC_ALL=C
+shopt -s nullglob
 
-# Check if the directory exists
+directory="${1:-}"
 if [ ! -d "$directory" ]; then
-    echo "Directory does not exist."
+    echo "Directory does not exist: $directory" >&2
     exit 1
 fi
 
-rsync -av --include "*.sql" --exclude="*" "$directory" ./database/flyway/
+directory=$(cd -- "$directory" && pwd -P)
+service_directory=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+FLYWAY_DIRECTORY=$(cd -- "$service_directory/database/flyway" && pwd -P)
+if [ "$directory" = "$FLYWAY_DIRECTORY" ]; then
+    echo "Source and Flyway directories must differ." >&2
+    exit 1
+fi
 
+# Never copy versioned SQL over existing Flyway migrations.
+rsync -av --include "[0-9][0-9][0-9][0-9]_*.sql" --exclude="*" "$directory/" "$FLYWAY_DIRECTORY/"
+
+# Bash globs give stable bytewise order, without a pipeline subshell losing state.
+existing_files=("$FLYWAY_DIRECTORY"/*.sql)
+flyway_pattern='^V([0-9]{4})(\.[0-9]+)?__(.+)\.sql$'
+drizzle_pattern='^([0-9]{4})_(.+)\.sql$'
 max_version=0
-
-# Find the largest migrate script number (e.g: 5 from V0001, V0002 V0003... V0005)
-max_version=$(find "./database/flyway" -type f -name "*.sql" -print0 | while IFS= read -r -d '' filename; do
-    basename=$(basename "$filename" .sql)
-
-    # Check if the basename matches the desired format (4 digits followed by an underscore)
-    if [[ $basename =~ ^V[0-9]{4}__ ]]; then
-        # Extract the first 4 digits and the rest of the basename
-        first_four_digits=${basename:1:4}
-        rest_of_basename=${basename:5}
-        version_number=$(expr "$first_four_digits" + 0)
-        
+# Bash 3 treats empty arrays as unset under nounset.
+for filename in "${existing_files[@]:-}"; do
+    basename=${filename##*/}
+    if [ -f "$filename" ] && [[ $basename =~ $flyway_pattern ]]; then
+        version_number=$((10#${BASH_REMATCH[1]}))
         if [ "$version_number" -gt "$max_version" ]; then
-          max_version="$version_number"
-          echo "$max_version"
+            max_version=$version_number
         fi
     fi
-  done)
+done
 
-# https://stackoverflow.com/a/39615292/11046178
-max_version=$(echo "${max_version##*$'\n'}")
+for filename in "$FLYWAY_DIRECTORY"/*.sql; do
+    basename=${filename##*/}
+    if [ -f "$filename" ] && [[ $basename =~ $drizzle_pattern ]]; then
+        version_number=$((10#${BASH_REMATCH[1]}))
+        rest_of_basename=${BASH_REMATCH[2]}
+        already_migrated=false
+        existing_index=0
+        for existing_filename in "${existing_files[@]:-}"; do
+            existing_basename=${existing_filename##*/}
+            if [ -f "$existing_filename" ] && [[ $existing_basename =~ $flyway_pattern ]]; then
+                # Historical renumbering only increases the Drizzle index. A newer
+                # index reusing an older random description is a new migration.
+                if [ "${BASH_REMATCH[3]}" = "$rest_of_basename" ] &&
+                    [ "$((10#${BASH_REMATCH[1]}))" -ge "$version_number" ]; then
+                    already_migrated=true
+                    # Consume each historical copy once, in ascending source order.
+                    existing_files[existing_index]=""
+                    break
+                fi
+            fi
+            existing_index=$((existing_index + 1))
+        done
 
-FLYWAY_DIRECTORY="./database/flyway"
-# Use find to search for files with ".sql" extension in the given directory
-# Then, use a for loop to go through each filename and extract only the filenames without extensions
-find $FLYWAY_DIRECTORY -type f -name "*.sql" -print0 | while IFS= read -r -d '' filename; do
-    basename=$(basename "$filename" .sql)
-
-    # Check if the basename matches the desired format (4 digits followed by an underscore)
-    if [[ $basename =~ ^[0-9]{4}_ ]]; then
-        # Extract the first 4 digits and the rest of the basename
-        first_four_digits=${basename:0:4}
-        rest_of_basename=${basename:5}
-        number_of_existing_files_with_that_name=$(ls database/flyway | grep "$rest_of_basename" | wc -l)
-        # Special case - when upgrading the tool
-        if ([ "$rest_of_basename" = "sturdy_serpent_society" ] || [ "$number_of_existing_files_with_that_name" -gt 1 ]); then
-          rm "$filename"
-        else
-          # Rename the file using the desired format (V<4_digits>__<some_name>.sql)
-          version_number=$(expr "$first_four_digits" + 0)
-          if [ $version_number -le $max_version ]; then
-            version_number=$(expr "$max_version" + 1)
-            first_four_digits=$(printf '%04d' $version_number) # pad 4 zeros at the beginning
-          fi
-          new_basename="V${first_four_digits}__${rest_of_basename}"
-          new_filename="$FLYWAY_DIRECTORY/$new_basename.sql"
-          mv "$filename" "$new_filename"
-          echo "Renamed $filename to $new_basename.sql"
+        # Special case retained from the Drizzle tool upgrade.
+        if [ "$rest_of_basename" = "sturdy_serpent_society" ] || [ "$already_migrated" = true ]; then
+            rm -- "$filename"
+            continue
         fi
+
+        if [ "$version_number" -le "$max_version" ]; then
+            version_number=$((max_version + 1))
+        fi
+        if [ "$version_number" -gt 9999 ]; then
+            echo "No four-digit Flyway version available for $filename" >&2
+            exit 1
+        fi
+        new_basename=$(printf 'V%04d__%s.sql' "$version_number" "$rest_of_basename")
+        new_filename="$FLYWAY_DIRECTORY/$new_basename"
+        if [ -e "$new_filename" ] || [ -L "$new_filename" ]; then
+            echo "Refusing to overwrite $new_filename" >&2
+            exit 1
+        fi
+        mv -n -- "$filename" "$new_filename"
+        # mv -n can report success without moving when the destination exists.
+        if [ -e "$filename" ] || [ -L "$filename" ]; then
+            echo "Refusing to overwrite $new_filename" >&2
+            exit 1
+        fi
+        max_version=$version_number
+        echo "Renamed $filename to $new_basename"
     fi
 done

--- a/services/shared-app-api/scripts/rsync_and_sed.sh
+++ b/services/shared-app-api/scripts/rsync_and_sed.sh
@@ -3,6 +3,8 @@
 # Sync shared-app-api code to frontend (agora) and API only
 #
 
+set -euo pipefail
+
 # Step 1: Use rsync to copy from source to api
 rsync -av --delete ./src/ ../api/src/shared-app-api/
 
@@ -13,7 +15,7 @@ rsync -av --delete ./src/ ../agora/src/shared-app-api/
 # See https://github.com/validatorjs/validator.js
 # Step 4: add "generated" comment if it does not already exist
 comment="/** **** WARNING: GENERATED FROM SHARED-APP-API DIRECTORY, DO NOT MODIFY THIS FILE DIRECTLY! **** **/"
-find ../agora/src/shared-app-api/ -name "*.ts" -print0 | while read -d $'\0' file
+find ../agora/src/shared-app-api/ -name "*.ts" -print0 | while read -r -d $'\0' file
 do
   # cross-platform sed (macOS and Linux)
   if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -33,7 +35,7 @@ do
   fi
 done
 
-find ../api/src/shared-app-api/ -name "*.ts" -print0 | while read -d $'\0' file
+find ../api/src/shared-app-api/ -name "*.ts" -print0 | while read -r -d $'\0' file
 do
   # Check if the comment already exists in the file
   if ! grep -qF "$comment" "$file"; then

--- a/services/shared/scripts/rsync_and_sed.sh
+++ b/services/shared/scripts/rsync_and_sed.sh
@@ -3,6 +3,8 @@
 # Sync universal shared code to ALL services (frontend + backend)
 #
 
+set -euo pipefail
+
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SHARED_DIR="$(dirname "$SCRIPT_DIR")"
@@ -33,7 +35,7 @@ for service in "${ALL_SERVICES[@]}"; do
     rsync -av --delete "$SHARED_DIR/src/" "$TARGET_DIR/"
 
     # Add warning comment to all TypeScript files
-    find "$TARGET_DIR" -name "*.ts" -print0 | while read -d $'\0' file; do
+    find "$TARGET_DIR" -name "*.ts" -print0 | while read -r -d $'\0' file; do
         # Check if the comment already exists in the file
         if ! grep -qF "$COMMENT" "$file"; then
             # Add comment at the beginning of the file


### PR DESCRIPTION
## Summary

- Publish the seven-file tooling changes explicitly excluded from #1244 in a dedicated PR.
- Allocate Flyway migration versions deterministically, recognize renumbered and fractional historical migrations, consume historical description matches once, preserve existing versioned SQL, and reject overwrite collisions or exhausted version ranges.
- Give Python-model and API-test-fixture schema exports isolated temporary SQL files, cleanup and failure propagation, and a backend-sync prerequisite so parallel exports cannot consume each other’s output.
- Make shared and shared-app-api synchronization stop on shell/pipeline errors and preserve backslashes when reading filenames.

## Background

PR #1244 introduced schema/migration tooling fixes in 9c8a30d9 and removed them, together with generic sync-script hardening, in 3e4be229 to keep the email-update PR focused. These changes remained in the local working tree. The five tracked-file patches match the inverse of that removal, and the two restored test files match the removed versions byte for byte.

## Validation

- `node --test scripts/rename-sql-migration.test.mjs scripts/schema-export.test.mjs scripts/shared-script.test.mjs` — **39 tests passed** on macOS, with TMPDIR directed to an isolated scratch parent.
- `bash -n services/api/scripts/rename_sql_migration_file.sh services/shared/scripts/rsync_and_sed.sh services/shared-app-api/scripts/rsync_and_sed.sh` — passed.
- `git diff --check upstream/main...HEAD` — passed.

Tests cover deterministic ordering, repeatability, historical migration matching, paths with spaces, destination collisions, copy/rename failures, concurrent exports, temporary-file cleanup, prerequisite ordering, and shared-sync failure propagation. Migration/export tests use temporary fixtures and stub database tooling.

Deploy: none